### PR TITLE
Add core audio helper references

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
   - GPT-based chapter segmentation and ElevenLabs voice streaming
   - Downloadable audiobooks with bookmarkable playback
   - Audiobook export engine (MP3/WAV with zip packaging via `AudiobookCompiler`)
+  - Extra helpers in `Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift`
+    provide offline download and eBook conversion utilities for the app.
 - **Build Status:** Electron PC build in testing
 
 ---

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -22,6 +22,14 @@ vault system. It is written in SwiftUI and will expand to additional platforms.
 When Stealth Vault is enabled in the Settings screen, downloaded audio is
 stored in a hidden directory so it won't appear in the Files app.
 
+## Core Library Integration
+
+CoreForge Audio reuses modules from the shared `CreatorCoreForge` package. If
+you notice missing playback or export features, ensure the package is linked in
+Xcode and reference `Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift`
+for additional helper functions. These utilities provide an offline download
+queue and an eBook–to–audio converter that complement the app's own classes.
+
 ## Building (iOS)
 1. Open `VocalVerseFull/VocalVerse.xcodeproj` in Xcode.
 2. If the **VocalVerse** scheme is missing, create a new scheme that targets the


### PR DESCRIPTION
## Summary
- mention the `CoreForgeAudio_MissingFeatures.swift` helpers in the main README
- add section in CoreForge Audio README on integrating the shared library

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685582dcb6488321919c6953cd23d14c