### PR TITLE
Implement emotion intensity analysis

### DIFF
--- a/Sources/CreatorCoreForge/EmotionAnalyzer.swift
+++ b/Sources/CreatorCoreForge/EmotionAnalyzer.swift
@@ -4,6 +4,17 @@ import Foundation
 public final class EmotionAnalyzer {
     public init() {}
 
+    /// Represents a detected emotion and its intensity.
+    public struct EmotionProfile {
+        public let emotion: String
+        public let intensity: Float
+
+        public init(emotion: String, intensity: Float) {
+            self.emotion = emotion
+            self.intensity = intensity
+        }
+    }
+
     /// Analyze text and suggest a narration tone.
     public func recommendTone(for text: String) -> String {
         let lowered = text.lowercased()
@@ -15,5 +26,30 @@ public final class EmotionAnalyzer {
             return "angry"
         }
         return "calm"
+    }
+
+    /// Analyze text and return an emotion with a naive intensity score.
+    public func analyzeEmotion(from text: String) -> EmotionProfile {
+        let lowered = text.lowercased()
+        var emotion = "neutral"
+        var intensity: Float = 0.0
+
+        if lowered.contains("excited") || lowered.contains("amazing") {
+            emotion = "excited"
+            intensity = 0.5
+        } else if lowered.contains("sad") || lowered.contains("lost") {
+            emotion = "sad"
+            intensity = 0.5
+        } else if lowered.contains("angry") || lowered.contains("furious") {
+            emotion = "angry"
+            intensity = 0.5
+        }
+
+        let exclamationCount = text.filter { $0 == "!" }.count
+        if exclamationCount > 0 {
+            intensity = min(1.0, intensity + Float(exclamationCount) * 0.1)
+        }
+
+        return EmotionProfile(emotion: emotion, intensity: intensity)
     }
 }

--- a/Tests/CreatorCoreForgeTests/EmotionAnalyzerTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionAnalyzerTests.swift
@@ -9,4 +9,11 @@ final class EmotionAnalyzerTests: XCTestCase {
         XCTAssertEqual(analyzer.recommendTone(for: "He was furious"), "angry")
         XCTAssertEqual(analyzer.recommendTone(for: "Just reading"), "calm")
     }
+
+    func testAnalyzeEmotion() {
+        let analyzer = EmotionAnalyzer()
+        let profile = analyzer.analyzeEmotion(from: "I am furious!!")
+        XCTAssertEqual(profile.emotion, "angry")
+        XCTAssertTrue(profile.intensity > 0.5)
+    }
 }


### PR DESCRIPTION
## Summary
- expand `EmotionAnalyzer` with an `EmotionProfile` struct
- add `analyzeEmotion(from:)` which returns detected emotion and a naive intensity
- extend tests to verify emotion analysis works

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_685595a45b588321a19a5ca41ebb89a2