### PR TITLE
Add compileAudiobook with metadata support

### DIFF
--- a/Sources/CreatorCoreForge/AudiobookCompiler.swift
+++ b/Sources/CreatorCoreForge/AudiobookCompiler.swift
@@ -14,3 +14,41 @@ public final class AudiobookCompiler {
         return exporter.compressToZip(filePaths: chapterFiles, zipName: name)
     }
 }
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+extension AudiobookCompiler {
+#if canImport(UIKit)
+    /// Compiles chapters into a zipped audiobook package including metadata and optional cover art.
+    public func compileAudiobook(chapters: [URL], metadata: Metadata, cover: UIImage?) -> URL {
+        return compileAudiobook(chapters: chapters, metadata: metadata, coverData: cover?.pngData())
+    }
+#else
+    /// Compiles chapters into a zipped audiobook package including metadata. Cover art is ignored on this platform.
+    public func compileAudiobook(chapters: [URL], metadata: Metadata, cover: Any?) -> URL {
+        return compileAudiobook(chapters: chapters, metadata: metadata, coverData: nil)
+    }
+#endif
+
+    private func compileAudiobook(chapters: [URL], metadata: Metadata, coverData: Data?) -> URL {
+        let workDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        for url in chapters {
+            let dest = workDir.appendingPathComponent(url.lastPathComponent)
+            try? FileManager.default.copyItem(at: url, to: dest)
+        }
+        let metaURL = workDir.appendingPathComponent("metadata.json")
+        if let data = try? JSONEncoder().encode(metadata) {
+            try? data.write(to: metaURL)
+        }
+        if let cData = coverData {
+            let coverURL = workDir.appendingPathComponent("cover.png")
+            try? cData.write(to: coverURL)
+        }
+        let files = (try? FileManager.default.contentsOfDirectory(atPath: workDir.path).map { workDir.appendingPathComponent($0).path }) ?? []
+        let zipPath = exporter.compressToZip(filePaths: files, zipName: metadata.title.replacingOccurrences(of: " ", with: "_"))
+        return URL(fileURLWithPath: zipPath)
+    }
+}

--- a/Sources/CreatorCoreForge/AudiobookMetadata.swift
+++ b/Sources/CreatorCoreForge/AudiobookMetadata.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Basic metadata for audiobook exports.
+public struct Metadata: Codable {
+    public var title: String
+    public var author: String
+    public var narrator: String?
+
+    public init(title: String, author: String, narrator: String? = nil) {
+        self.title = title
+        self.author = author
+        self.narrator = narrator
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AudiobookCompilerTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudiobookCompilerTests.swift
@@ -11,4 +11,15 @@ final class AudiobookCompilerTests: XCTestCase {
         let zipPath = compiler.compile(chapterFiles: [tmp1.path, tmp2.path], name: "book")
         XCTAssertTrue(zipPath.hasSuffix("book.zip"))
     }
+
+    func testCompileAudiobookPackage() {
+        let tmp1 = FileManager.default.temporaryDirectory.appendingPathComponent("c1.wav")
+        let tmp2 = FileManager.default.temporaryDirectory.appendingPathComponent("c2.wav")
+        try? "ch1".data(using: .utf8)?.write(to: tmp1)
+        try? "ch2".data(using: .utf8)?.write(to: tmp2)
+        let metadata = Metadata(title: "Test", author: "Author")
+        let compiler = AudiobookCompiler(exporter: AudioExporter())
+        let url = compiler.compileAudiobook(chapters: [tmp1, tmp2], metadata: metadata, cover: nil)
+        XCTAssertTrue(url.path.hasSuffix("Test.zip"))
+    }
 }


### PR DESCRIPTION
## Summary
- extend `AudiobookCompiler` with `compileAudiobook` to bundle chapters, metadata and cover art
- add `Metadata` struct for audiobook info
- test new compilation method

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685595ccd46c8321b4998905e6a826e2