### PR TITLE
Add voice linking helper and profile retrieval

### DIFF
--- a/Sources/CreatorCoreForge/VoiceDNAForge.swift
+++ b/Sources/CreatorCoreForge/VoiceDNAForge.swift
@@ -57,6 +57,11 @@ public final class VoiceDNAForge {
         dnaRegistry[characterID]
     }
 
+    /// Returns the voice profile for a given character if available.
+    public func getVoiceProfile(for characterID: String) -> VoiceDNA? {
+        getDNA(for: characterID)
+    }
+
     public func linkCharacters(primaryID: String, linkedID: String) {
         guard var primaryDNA = dnaRegistry[primaryID] else { return }
         if !primaryDNA.linkedCharacters.contains(linkedID) {

--- a/Sources/CreatorCoreForge/VoiceMultiverseLinker.swift
+++ b/Sources/CreatorCoreForge/VoiceMultiverseLinker.swift
@@ -30,6 +30,11 @@ public final class VoiceMultiverseLinker: ObservableObject {
         links.append(link)
     }
 
+    /// Convenience helper to link voices using default context.
+    public func linkVoices(primaryID: String, secondaryID: String) {
+        linkVoices(source: primaryID, linked: secondaryID, project: "global", reason: "direct link")
+    }
+
     /// Return all links associated with the given voice ID as source or target.
     public func getLinks(for voiceID: String) -> [VoiceLink] {
         links.filter { $0.sourceVoiceID == voiceID || $0.linkedVoiceID == voiceID }
@@ -70,6 +75,11 @@ public final class VoiceMultiverseLinker {
     public func linkVoices(source: String, linked: String, project: String, reason: String) {
         let link = VoiceLink(sourceVoiceID: source, linkedVoiceID: linked, projectContext: project, reason: reason)
         links.append(link)
+    }
+
+    /// Convenience helper to link voices using default context.
+    public func linkVoices(primaryID: String, secondaryID: String) {
+        linkVoices(source: primaryID, linked: secondaryID, project: "global", reason: "direct link")
     }
 
     public func getLinks(for voiceID: String) -> [VoiceLink] {

--- a/Tests/CreatorCoreForgeTests/VoiceDNAForgeTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceDNAForgeTests.swift
@@ -21,4 +21,12 @@ final class VoiceDNAForgeTests: XCTestCase {
         XCTAssertTrue(dna?.linkedCharacters.contains("villain") ?? false)
         XCTAssertEqual(dna?.emotionRange["anger"], 0.5)
     }
+
+    func testGetVoiceProfile() {
+        let forge = VoiceDNAForge.shared
+        forge.resetAllDNA()
+        forge.createDNA(for: "testChar", basePitch: 1.0, cadence: 1.0, toneProfile: "calm", emotionRange: [:], styleTags: [])
+        let dna = forge.getVoiceProfile(for: "testChar")
+        XCTAssertEqual(dna?.toneProfile, "calm")
+    }
 }

--- a/Tests/CreatorCoreForgeTests/VoiceMultiverseLinkerTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceMultiverseLinkerTests.swift
@@ -21,4 +21,11 @@ final class VoiceMultiverseLinkerTests: XCTestCase {
         linker.removeLink(firstID)
         XCTAssertTrue(linker.links.isEmpty)
     }
+
+    func testSimpleLink() {
+        let linker = VoiceMultiverseLinker()
+        linker.clearAll()
+        linker.linkVoices(primaryID: "a", secondaryID: "b")
+        XCTAssertEqual(linker.getLinks(for: "a").count, 1)
+    }
 }


### PR DESCRIPTION
## Summary
- add `linkVoices(primaryID:secondaryID:)` to `VoiceMultiverseLinker`
- add `getVoiceProfile(for:)` to `VoiceDNAForge`
- update unit tests for new helper methods

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685595c7528483218b1b0cbdd2379afc