### PR TITLE
Implement NSFWToneStyler utility

### DIFF
--- a/Sources/CreatorCoreForge/NSFWToneStyler.swift
+++ b/Sources/CreatorCoreForge/NSFWToneStyler.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Styles a line of dialogue with NSFW tone hints.
+public enum NSFWStyle: String, Codable, CaseIterable {
+    case soft
+    case sensual
+    case dominant
+    case whisper
+}
+
+/// Output of an NSFW tone styling request.
+public struct StyledVoiceOutput: Codable, Equatable {
+    public let styledText: String
+    public let style: NSFWStyle
+    public init(text: String, style: NSFWStyle) {
+        self.styledText = text
+        self.style = style
+    }
+}
+
+/// Apply a tone style to the provided sentence.
+/// The function prepends a short tag matching the style.
+public func applyNSFWTone(to sentence: String, context: NSFWStyle) -> StyledVoiceOutput {
+    let prefix: String
+    switch context {
+    case .soft:
+        prefix = "[Soft]"
+    case .sensual:
+        prefix = "[Sensual]"
+    case .dominant:
+        prefix = "[Dominant]"
+    case .whisper:
+        prefix = "[Whisper]"
+    }
+    return StyledVoiceOutput(text: "\(prefix) \(sentence)", style: context)
+}

--- a/Tests/CreatorCoreForgeTests/NSFWToneStylerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWToneStylerTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWToneStylerTests: XCTestCase {
+    func testApplySoftStyle() {
+        let output = applyNSFWTone(to: "Hello there", context: .soft)
+        XCTAssertEqual(output.styledText, "[Soft] Hello there")
+        XCTAssertEqual(output.style, .soft)
+    }
+
+    func testApplyWhisperStyle() {
+        let output = applyNSFWTone(to: "Be quiet", context: .whisper)
+        XCTAssertTrue(output.styledText.contains("[Whisper]"))
+        XCTAssertEqual(output.style, .whisper)
+    }
+}


### PR DESCRIPTION
## Summary
- add `NSFWToneStyler` with `applyNSFWTone` function
- provide `NSFWStyle` enum and `StyledVoiceOutput` struct
- test style application for soft and whisper modes

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685595bff1588321885361e303a202ec