### PR TITLE
Add NSFW mode dial support

### DIFF
--- a/Sources/CreatorCoreForge/NSFWContentManager.swift
+++ b/Sources/CreatorCoreForge/NSFWContentManager.swift
@@ -12,9 +12,14 @@ public final class NSFWContentManager: ObservableObject {
     @Published public var unlocked: Bool = false
     @Published public var nsfwSceneLog: [NSFWScene] = []
     @Published public var contentIntensity: NSFWIntensity = .softcore
+    @Published public var contentMode: NSFWContentMode = .slow
 
     public enum NSFWIntensity: String, Codable, CaseIterable {
         case off, softcore, sensual, rough, hardcore
+    }
+
+    public enum NSFWContentMode: String, Codable, CaseIterable {
+        case slow, medium, extreme
     }
 
     public struct NSFWScene: Identifiable, Codable {
@@ -50,6 +55,10 @@ public final class NSFWContentManager: ObservableObject {
 
     public func setIntensity(level: NSFWIntensity) {
         self.contentIntensity = level
+    }
+
+    public func setMode(_ mode: NSFWContentMode) {
+        self.contentMode = mode
     }
 
     public func isSceneAllowed(_ intensity: NSFWIntensity) -> Bool {
@@ -70,9 +79,14 @@ public final class NSFWContentManager {
     public var unlocked: Bool = false
     public var nsfwSceneLog: [NSFWScene] = []
     public var contentIntensity: NSFWIntensity = .softcore
+    public var contentMode: NSFWContentMode = .slow
 
     public enum NSFWIntensity: String, Codable, CaseIterable {
         case off, softcore, sensual, rough, hardcore
+    }
+
+    public enum NSFWContentMode: String, Codable, CaseIterable {
+        case slow, medium, extreme
     }
 
     public struct NSFWScene: Identifiable, Codable {
@@ -110,6 +124,10 @@ public final class NSFWContentManager {
         self.contentIntensity = level
     }
 
+    public func setMode(_ mode: NSFWContentMode) {
+        self.contentMode = mode
+    }
+
     public func isSceneAllowed(_ intensity: NSFWIntensity) -> Bool {
         guard unlocked else { return false }
         let levels = NSFWIntensity.allCases
@@ -122,4 +140,7 @@ public final class NSFWContentManager {
 }
 #endif
 
-// Usage: unlock(with: "creatoraccess"), setIntensity(level: .hardcore), isSceneAllowed(.rough)
+// Usage: unlock(with: "creatoraccess"),
+//        setIntensity(level: .hardcore),
+//        setMode(.extreme),
+//        isSceneAllowed(.rough)

--- a/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
@@ -26,4 +26,10 @@ final class NSFWContentManagerTests: XCTestCase {
         XCTAssertTrue(manager.isSceneAllowed(.softcore))
         XCTAssertFalse(manager.isSceneAllowed(.hardcore))
     }
+
+    func testModeSetting() {
+        let manager = NSFWContentManager.shared
+        manager.setMode(.medium)
+        XCTAssertEqual(manager.contentMode, .medium)
+    }
 }

--- a/apps/CoreForgeWriter/AGENTS.md
+++ b/apps/CoreForgeWriter/AGENTS.md
@@ -73,5 +73,5 @@ Advanced AI writing assistant for creating books, series, and self-help guides w
 - [ ] Embed Booktok Trailer Generator + auto-caption tool
 - [ ] Integrate reader relatability + pacing metrics
 - [ ] Enable Book-to-Pitch feature (TV/Film pitch toolkit)
-- [ ] Add NSFW content mode dial (slow, medium, extreme)
+ - [x] Add NSFW content mode dial (slow, medium, extreme)
 - [ ] Export script to CoreForge Studio with assigned voices

--- a/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/SettingsView.swift
+++ b/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/SettingsView.swift
@@ -1,12 +1,19 @@
 #if canImport(SwiftUI)
 import SwiftUI
+import CreatorCoreForge
 
 struct SettingsView: View {
     @AppStorage("nsfwEnabled") private var nsfwEnabled = false
     @AppStorage("parentalPIN") private var parentalPIN = ""
+    @AppStorage("nsfwMode") private var nsfwModeRaw = NSFWContentMode.slow.rawValue
     @State private var showPinPrompt = false
     @State private var inputPIN = ""
     @State private var showIncorrectAlert = false
+
+    private var nsfwMode: NSFWContentMode {
+        get { NSFWContentMode(rawValue: nsfwModeRaw) ?? .slow }
+        set { nsfwModeRaw = newValue.rawValue }
+    }
 
     var body: some View {
         NavigationView {
@@ -21,6 +28,15 @@ struct SettingsView: View {
                                 nsfwEnabled = false
                             }
                         }))
+                    if nsfwEnabled {
+                        Picker("NSFW Mode", selection: Binding(
+                            get: { nsfwMode },
+                            set: { nsfwMode = $0 })) {
+                            ForEach(NSFWContentMode.allCases, id: \.self) { mode in
+                                Text(mode.rawValue.capitalized).tag(mode)
+                            }
+                        }
+                    }
                 }
                 Section(header: Text("Security")) {
                     Button("Change PIN") { showPinPrompt = true }

--- a/apps/CoreForgeWriter/README.md
+++ b/apps/CoreForgeWriter/README.md
@@ -91,6 +91,7 @@ This agent is responsible for building, validating, and maintaining every featur
 - [ ] Paywall, tip jar, premium NSFW stories
 - [ ] Community moderation, age/ID controls
 - [ ] NSFW sandbox, decoy/stealth mode
+- [x] NSFW content mode dial (slow, medium, extreme)
 
 ---
 


### PR DESCRIPTION
## Summary
- add `NSFWContentMode` enum and mode tracking in `NSFWContentManager`
- expose helper `setMode` API
- update writer settings view with a picker for NSFW mode
- mark corresponding tasks complete in documentation
- test new behaviour in `NSFWContentManagerTests`

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855c3b8c4748321a574d32e4dd2700c