### PR TITLE
Implement region gating and consent tracker

### DIFF
--- a/Sources/CreatorCoreForge/CommunityFilter.swift
+++ b/Sources/CreatorCoreForge/CommunityFilter.swift
@@ -7,18 +7,27 @@ public final class CommunityFilter {
     private let defaults: UserDefaults
     private let pinKey = "CF_PIN"
     private let flagKey = "CF_NSFW"
+    private let regionKey = "CF_REGION"
     private var pin: String
     private var nsfwEnabled: Bool
+    private var region: String
+    private var blockedRegions: Set<String>
 
-    public init(userDefaults: UserDefaults = .standard) {
+    public init(userDefaults: UserDefaults = .standard,
+                region: String? = nil,
+                blockedRegions: Set<String> = []) {
         self.defaults = userDefaults
         self.pin = userDefaults.string(forKey: pinKey) ?? ""
         self.nsfwEnabled = userDefaults.bool(forKey: flagKey)
+        self.region = userDefaults.string(forKey: regionKey) ?? region ?? Locale.current.regionCode ?? "US"
+        self.blockedRegions = blockedRegions
     }
 
     /// Attempt to enable NSFW content. If a PIN is already set, it must match.
+    /// Returns false when the user's region is blocked.
     @discardableResult
     public func enableNSFW(pin: String) -> Bool {
+        guard isRegionAllowed() else { return false }
         if self.pin.isEmpty {
             self.pin = pin
             nsfwEnabled = true
@@ -42,8 +51,20 @@ public final class CommunityFilter {
         nsfwEnabled ? text : ContentPolicyManager.sanitize(text)
     }
 
+    /// Change the current region code.
+    public func setRegion(_ code: String) {
+        region = code
+        persist()
+    }
+
+    /// Returns true if the user's region allows NSFW content.
+    public func isRegionAllowed() -> Bool {
+        return !blockedRegions.contains(region)
+    }
+
     private func persist() {
         defaults.set(pin, forKey: pinKey)
         defaults.set(nsfwEnabled, forKey: flagKey)
+        defaults.set(region, forKey: regionKey)
     }
 }

--- a/Sources/CreatorCoreForge/ConsentTracker.swift
+++ b/Sources/CreatorCoreForge/ConsentTracker.swift
@@ -1,0 +1,67 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+
+/// Tracks user consent events and monitors for safe-word triggers.
+public final class ConsentTracker: ObservableObject {
+    public static let shared = ConsentTracker()
+    public init() {}
+
+    public struct ConsentEvent: Identifiable, Codable {
+        public var id: UUID = UUID()
+        public var userID: String
+        public var consentGiven: Bool
+        public var date: Date
+    }
+
+    @Published public private(set) var events: [ConsentEvent] = []
+    @Published public var safeWord: String = "red"
+
+    public func logConsent(userID: String, consent: Bool) {
+        let event = ConsentEvent(userID: userID, consentGiven: consent, date: Date())
+        events.append(event)
+    }
+
+    /// Returns true when the supplied text contains the configured safe word.
+    public func containsSafeWord(_ text: String) -> Bool {
+        text.lowercased().contains(safeWord.lowercased())
+    }
+
+    public func lastConsent(for userID: String) -> ConsentEvent? {
+        events.last { $0.userID == userID }
+    }
+}
+#else
+
+public final class ConsentTracker {
+    public static let shared = ConsentTracker()
+    public init() {}
+
+    public struct ConsentEvent: Identifiable, Codable {
+        public var id: UUID = UUID()
+        public var userID: String
+        public var consentGiven: Bool
+        public var date: Date
+    }
+
+    public private(set) var events: [ConsentEvent] = []
+    public var safeWord: String = "red"
+
+    public func logConsent(userID: String, consent: Bool) {
+        let event = ConsentEvent(userID: userID, consentGiven: consent, date: Date())
+        events.append(event)
+    }
+
+    public func containsSafeWord(_ text: String) -> Bool {
+        text.lowercased().contains(safeWord.lowercased())
+    }
+
+    public func lastConsent(for userID: String) -> ConsentEvent? {
+        events.last { $0.userID == userID }
+    }
+}
+#endif
+
+// Example usage:
+// ConsentTracker.shared.logConsent(userID: "user1", consent: true)
+// if ConsentTracker.shared.containsSafeWord("stop now") { pausePlayback() }

--- a/Tests/CreatorCoreForgeTests/CommunityFilterTests.swift
+++ b/Tests/CreatorCoreForgeTests/CommunityFilterTests.swift
@@ -14,4 +14,16 @@ final class CommunityFilterTests: XCTestCase {
         XCTAssertTrue(filter.enableNSFW(pin: "1234"))
         suite.removePersistentDomain(forName: "CFTest")
     }
+
+    func testRegionGating() {
+        let suite = UserDefaults(suiteName: "CFRegionTest")!
+        var filter = CommunityFilter(userDefaults: suite,
+                                     region: "US",
+                                     blockedRegions: ["US"]) 
+        XCTAssertFalse(filter.enableNSFW(pin: "1111"))
+        filter.setRegion("CA")
+        XCTAssertTrue(filter.enableNSFW(pin: "1111"))
+        XCTAssertTrue(filter.isRegionAllowed())
+        suite.removePersistentDomain(forName: "CFRegionTest")
+    }
 }

--- a/Tests/CreatorCoreForgeTests/ConsentTrackerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ConsentTrackerTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ConsentTrackerTests: XCTestCase {
+    func testConsentLogging() {
+        let tracker = ConsentTracker()
+        tracker.logConsent(userID: "user", consent: true)
+        XCTAssertEqual(tracker.events.count, 1)
+        XCTAssertTrue(tracker.events.first?.consentGiven ?? false)
+    }
+
+    func testSafeWordDetection() {
+        let tracker = ConsentTracker()
+        tracker.safeWord = "pineapple"
+        XCTAssertTrue(tracker.containsSafeWord("PINEAPPLE please"))
+        XCTAssertFalse(tracker.containsSafeWord("nothing here"))
+    }
+}


### PR DESCRIPTION
## Summary
- add region-based NSFW gating to `CommunityFilter`
- create `ConsentTracker` to log consent events and detect safe words
- test region gating logic
- add consent tracking tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855c5d5851c83218ca1ad6462fefd53