### PR TITLE
Implement consent tracking and aftercare helpers

### DIFF
--- a/Sources/CreatorCoreForge/NSFWContentManager.swift
+++ b/Sources/CreatorCoreForge/NSFWContentManager.swift
@@ -9,6 +9,14 @@ import Combine
 public final class NSFWContentManager: ObservableObject {
     public static let shared = NSFWContentManager()
 
+    private let consentTracker = ConsentTracker.shared
+    private var aftercareIndex = 0
+    public var aftercarePrompts: [String] = [
+        "Take a moment to breathe and hydrate.",
+        "Remember to respect boundaries and communicate.",
+        "Consider a gentle cool-down or aftercare routine."
+    ]
+
     @Published public var unlocked: Bool = false
     @Published public var nsfwSceneLog: [NSFWScene] = []
     @Published public var contentIntensity: NSFWIntensity = .softcore
@@ -33,7 +41,23 @@ public final class NSFWContentManager: ObservableObject {
     public func unlock(with promoCode: String) {
         if promoCode.lowercased() == "creatoraccess" {
             unlocked = true
+            consentTracker.logConsent(userID: "local", consent: true)
         }
+    }
+
+    public func logConsent(userID: String, consent: Bool) {
+        consentTracker.logConsent(userID: userID, consent: consent)
+    }
+
+    public func shouldPause(for text: String) -> Bool {
+        consentTracker.containsSafeWord(text)
+    }
+
+    public func nextAftercarePrompt() -> String {
+        guard !aftercarePrompts.isEmpty else { return "" }
+        let prompt = aftercarePrompts[aftercareIndex % aftercarePrompts.count]
+        aftercareIndex += 1
+        return prompt
     }
 
     public func logScene(chapter: String, label: String, intensity: NSFWIntensity) {
@@ -76,6 +100,14 @@ public final class NSFWContentManager: ObservableObject {
 public final class NSFWContentManager {
     public static let shared = NSFWContentManager()
 
+    private let consentTracker = ConsentTracker.shared
+    private var aftercareIndex = 0
+    public var aftercarePrompts: [String] = [
+        "Take a moment to breathe and hydrate.",
+        "Remember to respect boundaries and communicate.",
+        "Consider a gentle cool-down or aftercare routine."
+    ]
+
     public var unlocked: Bool = false
     public var nsfwSceneLog: [NSFWScene] = []
     public var contentIntensity: NSFWIntensity = .softcore
@@ -100,7 +132,23 @@ public final class NSFWContentManager {
     public func unlock(with promoCode: String) {
         if promoCode.lowercased() == "creatoraccess" {
             unlocked = true
+            consentTracker.logConsent(userID: "local", consent: true)
         }
+    }
+
+    public func logConsent(userID: String, consent: Bool) {
+        consentTracker.logConsent(userID: userID, consent: consent)
+    }
+
+    public func shouldPause(for text: String) -> Bool {
+        consentTracker.containsSafeWord(text)
+    }
+
+    public func nextAftercarePrompt() -> String {
+        guard !aftercarePrompts.isEmpty else { return "" }
+        let prompt = aftercarePrompts[aftercareIndex % aftercarePrompts.count]
+        aftercareIndex += 1
+        return prompt
     }
 
     public func logScene(chapter: String, label: String, intensity: NSFWIntensity) {

--- a/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
@@ -32,4 +32,20 @@ final class NSFWContentManagerTests: XCTestCase {
         manager.setMode(.medium)
         XCTAssertEqual(manager.contentMode, .medium)
     }
+
+    func testConsentAndPause() {
+        let manager = NSFWContentManager.shared
+        manager.logConsent(userID: "u1", consent: true)
+        XCTAssertNotNil(ConsentTracker.shared.lastConsent(for: "u1"))
+        ConsentTracker.shared.safeWord = "pause"
+        XCTAssertTrue(manager.shouldPause(for: "please PAUSE now"))
+    }
+
+    func testAftercarePrompt() {
+        let manager = NSFWContentManager.shared
+        let first = manager.nextAftercarePrompt()
+        let second = manager.nextAftercarePrompt()
+        XCTAssertNotEqual(first, "")
+        XCTAssertNotEqual(second, "")
+    }
 }

--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -152,7 +152,7 @@ This file is a full checklist of every feature required for code completion and 
 - [ ] Age/ID verification for all explicit content
 - [ ] NSFW content toggle and region filtering
 - [ ] NSFW content auto-tagging, search, and privacy vaults
-- [ ] Consent tracking, safe word pause, aftercare prompts
+- [x] Consent tracking, safe word pause, aftercare prompts
 - [ ] Private/anonymous user modes and secret fan club invites
 - [ ] Sensual and explicit SFX packs, moan/breath/ASMR generators
 - [ ] Haptic/wearable feedback integration for erotic audio


### PR DESCRIPTION
## Summary
- extend `NSFWContentManager` with consent tracking and aftercare prompts
- add related unit tests
- mark consent tracking task complete in CoreForge Audio AGENTS

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6855ce8f280c8321848e73022e6181c8