### PR TITLE
Implement NSFW age + ID verification

### DIFF
--- a/Sources/CreatorCoreForge/AgeIDVerifier.swift
+++ b/Sources/CreatorCoreForge/AgeIDVerifier.swift
@@ -1,0 +1,44 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Verifies user age and simple ID validation for unlocking NSFW content.
+public struct AgeIDVerifier {
+    private let idKey = "AgeIDVerifierIDHash"
+    private let store: UserDefaults
+
+    public init(store: UserDefaults = .standard) {
+        self.store = store
+    }
+
+    /// Returns true if the birthdate meets the minimum age requirement and
+    /// the provided ID number passes basic validation rules.
+    public func verify(birthdate: Date, idNumber: String, minimumAge: Int = 18) -> Bool {
+        guard DOBCheck.isOfAge(birthdate: birthdate, minimumAge: minimumAge) else { return false }
+        guard Self.isValid(idNumber: idNumber) else { return false }
+        store.set(Self.hash(idNumber), forKey: idKey)
+        return true
+    }
+
+    /// Returns true if an ID was previously verified.
+    public var isVerified: Bool {
+        store.string(forKey: idKey) != nil
+    }
+
+    private static func isValid(idNumber: String) -> Bool {
+        let trimmed = idNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = trimmed.filter("0123456789".contains)
+        return digits.count >= 6
+    }
+
+    private static func hash(_ id: String) -> String {
+        #if canImport(CryptoKit)
+        let data = Data(id.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+        #else
+        return String(id.reversed())
+        #endif
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeVisual_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeVisual_MissingFeatures.swift
@@ -4,10 +4,19 @@ import Foundation
 public struct CoreForgeVisualFeatures {
     public init() {}
 
-    /// Verify age and enable NSFW access using a PIN. Returns true on success.
+    /// Verify age and optional ID then enable NSFW access using a PIN.
+    /// Returns true on success.
     @discardableResult
     public func verifyAgeAndEnableNSFW(birthdate: Date, pin: String) -> Bool {
         guard DOBCheck.isOfAge(birthdate: birthdate) else { return false }
+        return CommunityFilter.shared.enableNSFW(pin: pin)
+    }
+
+    /// Verify age and ID then enable NSFW access using a PIN.
+    @discardableResult
+    public func verifyAgeIDAndEnableNSFW(birthdate: Date, idNumber: String, pin: String) -> Bool {
+        let verifier = AgeIDVerifier()
+        guard verifier.verify(birthdate: birthdate, idNumber: idNumber) else { return false }
         return CommunityFilter.shared.enableNSFW(pin: pin)
     }
 

--- a/Tests/CreatorCoreForgeTests/AgeIDVerifierTests.swift
+++ b/Tests/CreatorCoreForgeTests/AgeIDVerifierTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AgeIDVerifierTests: XCTestCase {
+    func testVerifyAndPersist() {
+        let suite = UserDefaults(suiteName: "AgeIDTest")!
+        suite.removePersistentDomain(forName: "AgeIDTest")
+        var comps = DateComponents(); comps.year = 1990; comps.month = 1; comps.day = 1
+        let birth = Calendar.current.date(from: comps)!
+        let verifier = AgeIDVerifier(store: suite)
+        XCTAssertTrue(verifier.verify(birthdate: birth, idNumber: "123456"))
+        XCTAssertTrue(verifier.isVerified)
+        suite.removePersistentDomain(forName: "AgeIDTest")
+    }
+
+    func testInvalidID() {
+        var comps = DateComponents(); comps.year = 1990; comps.month = 1; comps.day = 1
+        let birth = Calendar.current.date(from: comps)!
+        let verifier = AgeIDVerifier(store: UserDefaults(suiteName: "AgeIDTest2")!)
+        XCTAssertFalse(verifier.verify(birthdate: birth, idNumber: "12"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/MissingFeaturesTests.swift
+++ b/Tests/CreatorCoreForgeTests/MissingFeaturesTests.swift
@@ -49,6 +49,20 @@ final class MissingFeaturesTests: XCTestCase {
         suite.removePersistentDomain(forName: "VisualTest")
     }
 
+    func testVerifyAgeIDAndEnableNSFW() {
+        let suite = UserDefaults(suiteName: "VisualTest2")!
+        CommunityFilter.shared.disableNSFW()
+        UserDefaults.standard.removeObject(forKey: "CF_PIN")
+        UserDefaults.standard.removeObject(forKey: "CF_REGION")
+        CommunityFilter.shared.setRegion("US")
+        var comps = DateComponents(); comps.year = 1990; comps.month = 1; comps.day = 1
+        let birth = Calendar.current.date(from: comps)!
+        let verifier = AgeIDVerifier()
+        XCTAssertTrue(verifier.verify(birthdate: birth, idNumber: "987654"))
+        XCTAssertTrue(CommunityFilter.shared.enableNSFW(pin: "1234"))
+        suite.removePersistentDomain(forName: "VisualTest2")
+    }
+
     func testGenerateSceneVideo() {
         let features = CoreForgeVisualFeatures()
         let url = features.generateSceneVideo(from: "A hero rises.")


### PR DESCRIPTION
## Summary
- add `AgeIDVerifier` utility for age and ID validation
- extend `CoreForgeVisualFeatures` with `verifyAgeIDAndEnableNSFW`
- test verification logic in new `AgeIDVerifierTests`
- update missing features tests for age/ID unlock

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855d37b816c83219d0ced6c7c96ad29