### PR TITLE
Implement emotion heatmap

### DIFF
--- a/Sources/CreatorCoreForge/EmotionHeatmap.swift
+++ b/Sources/CreatorCoreForge/EmotionHeatmap.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Generates a real-time emotion heatmap from logged intensities.
+public final class EmotionHeatmap {
+    private var intensities: [Double] = []
+    private var labels: [String] = []
+
+    public init() {}
+
+    /// Log an emotion with the given intensity.
+    public func log(emotion: String, intensity: Double) {
+        labels.append(emotion)
+        intensities.append(intensity)
+    }
+
+    /// Normalize recent intensities in the 0-1 range.
+    /// - Parameter window: The number of latest entries to include.
+    public func generateHeatmap(window: Int = 10) -> [Double] {
+        let slice = intensities.suffix(window)
+        guard let min = slice.min(), let max = slice.max(), max > min else {
+            return Array(slice)
+        }
+        return slice.map { ($0 - min) / (max - min) }
+    }
+}

--- a/Tests/CreatorCoreForgeTests/EmotionHeatmapTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionHeatmapTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class EmotionHeatmapTests: XCTestCase {
+    func testHeatmapNormalization() {
+        let heatmap = EmotionHeatmap()
+        heatmap.log(emotion: "sad", intensity: 0.1)
+        heatmap.log(emotion: "neutral", intensity: 0.5)
+        heatmap.log(emotion: "happy", intensity: 0.9)
+        let result = heatmap.generateHeatmap(window: 3)
+        XCTAssertEqual(result.first ?? -1.0, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(result.last ?? -1.0, 1.0, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmotionHeatmap` utility to compute intensity heatmaps
- test heatmap normalization

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d3380f04832183938d40eb174933