### PR TITLE
Implement simple encryption utilities

### DIFF
--- a/Sources/CreatorCoreForge/DataEncryptionManager.swift
+++ b/Sources/CreatorCoreForge/DataEncryptionManager.swift
@@ -1,0 +1,63 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Provides simple data encryption and decryption utilities.
+public struct DataEncryptionManager {
+    public init() {}
+
+    #if canImport(CryptoKit)
+    /// Encrypts the given data with the provided symmetric key.
+    public func encrypt(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let sealed = try AES.GCM.seal(data, using: key)
+        return sealed.combined!
+    }
+
+    /// Decrypts the given data with the provided symmetric key.
+    public func decrypt(_ data: Data, using key: SymmetricKey) throws -> Data {
+        let box = try AES.GCM.SealedBox(combined: data)
+        return try AES.GCM.open(box, using: key)
+    }
+
+    /// Encrypts a file to the provided output URL.
+    @discardableResult
+    public func encryptFile(at input: URL, output: URL, key: SymmetricKey) throws -> URL {
+        let data = try Data(contentsOf: input)
+        let encrypted = try encrypt(data, using: key)
+        try encrypted.write(to: output)
+        return output
+    }
+
+    /// Decrypts a file from the provided URL.
+    @discardableResult
+    public func decryptFile(at input: URL, output: URL, key: SymmetricKey) throws -> URL {
+        let data = try Data(contentsOf: input)
+        let decrypted = try decrypt(data, using: key)
+        try decrypted.write(to: output)
+        return output
+    }
+    #else
+    /// Fallback encryption using simple byte reversal.
+    public func encrypt(_ data: Data) -> Data { Data(data.reversed()) }
+
+    /// Fallback decryption using simple byte reversal.
+    public func decrypt(_ data: Data) -> Data { Data(data.reversed()) }
+
+    @discardableResult
+    public func encryptFile(at input: URL, output: URL) throws -> URL {
+        let data = try Data(contentsOf: input)
+        let encrypted = encrypt(data)
+        try encrypted.write(to: output)
+        return output
+    }
+
+    @discardableResult
+    public func decryptFile(at input: URL, output: URL) throws -> URL {
+        let data = try Data(contentsOf: input)
+        let decrypted = decrypt(data)
+        try decrypted.write(to: output)
+        return output
+    }
+    #endif
+}

--- a/Tests/CreatorCoreForgeTests/DataEncryptionManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/DataEncryptionManagerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import CreatorCoreForge
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+final class DataEncryptionManagerTests: XCTestCase {
+    func testEncryptDecryptRoundTrip() throws {
+        let manager = DataEncryptionManager()
+        #if canImport(CryptoKit)
+        let key = SymmetricKey(size: .bits256)
+        let data = "Hello".data(using: .utf8)!
+        let encrypted = try manager.encrypt(data, using: key)
+        let decrypted = try manager.decrypt(encrypted, using: key)
+        XCTAssertEqual(decrypted, data)
+        #else
+        let data = "Hello".data(using: .utf8)!
+        let encrypted = manager.encrypt(data)
+        let decrypted = manager.decrypt(encrypted)
+        XCTAssertEqual(decrypted, data)
+        #endif
+    }
+
+    func testEncryptDecryptFile() throws {
+        let manager = DataEncryptionManager()
+        let tmp = FileManager.default.temporaryDirectory
+        let input = tmp.appendingPathComponent("input.txt")
+        let encryptedURL = tmp.appendingPathComponent("enc.bin")
+        let output = tmp.appendingPathComponent("output.txt")
+        try "secret".data(using: .utf8)?.write(to: input)
+        #if canImport(CryptoKit)
+        let key = SymmetricKey(size: .bits256)
+        try manager.encryptFile(at: input, output: encryptedURL, key: key)
+        try manager.decryptFile(at: encryptedURL, output: output, key: key)
+        #else
+        try manager.encryptFile(at: input, output: encryptedURL)
+        try manager.decryptFile(at: encryptedURL, output: output)
+        #endif
+        let decrypted = try String(contentsOf: output)
+        XCTAssertEqual(decrypted, "secret")
+    }
+}


### PR DESCRIPTION
## Summary
- add `DataEncryptionManager` with CryptoKit-based encryption and fallbacks
- test encryption round trip and file operations

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855e99e9bd4832185e00e8649ce5223