### PR TITLE
Add multilingual engine tests

### DIFF
--- a/Sources/CreatorCoreForge/MultilingualEngine.swift
+++ b/Sources/CreatorCoreForge/MultilingualEngine.swift
@@ -6,6 +6,8 @@ public final class MultilingualEngine {
         case english = "en"
         case spanish = "es"
         case french  = "fr"
+        case german  = "de"
+        case italian = "it"
         case unknown = "unknown"
     }
 
@@ -15,6 +17,8 @@ public final class MultilingualEngine {
     public func detectLanguage(of text: String) -> Language {
         if text.range(of: "[áéíóúñ]", options: .regularExpression) != nil { return .spanish }
         if text.range(of: "[àâçéèêëïîôùûü]", options: .regularExpression) != nil { return .french }
+        if text.range(of: "[äöüß]", options: .regularExpression) != nil { return .german }
+        if text.range(of: "[àèìòù]", options: .regularExpression) != nil { return .italian }
         if text.range(of: "[a-zA-Z]", options: .regularExpression) != nil { return .english }
         return .unknown
     }
@@ -25,6 +29,8 @@ public final class MultilingualEngine {
         case .english: return "LocalVoiceAI-En"
         case .spanish: return "LocalVoiceAI-Es"
         case .french:  return "LocalVoiceAI-Fr"
+        case .german:  return "LocalVoiceAI-De"
+        case .italian: return "LocalVoiceAI-It"
         case .unknown: return "LocalVoiceAI-Default"
         }
     }

--- a/Tests/CreatorCoreForgeTests/LanguageTranslationManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/LanguageTranslationManagerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class LanguageTranslationManagerTests: XCTestCase {
+    func testTranslateSingle() {
+        let manager = LanguageTranslationManager(translations: [
+            "it": ["hello": "ciao"],
+            "de": ["hello": "hallo"]
+        ])
+        XCTAssertEqual(manager.translate("hello", to: "it"), "ciao")
+        XCTAssertEqual(manager.translate("hello", to: "de"), "hallo")
+        XCTAssertEqual(manager.translate("hello", to: "fr"), "hello")
+    }
+
+    func testTranslateMultiple() {
+        let manager = LanguageTranslationManager(translations: [
+            "it": ["yes": "sì", "no": "no"],
+            "de": ["yes": "ja", "no": "nein"]
+        ])
+        let resultsIt = manager.translate(contents: ["yes", "no"], to: "it")
+        XCTAssertEqual(resultsIt, ["sì", "no"])
+        let resultsDe = manager.translate(contents: ["yes", "no"], to: "de")
+        XCTAssertEqual(resultsDe, ["ja", "nein"])
+    }
+}

--- a/Tests/CreatorCoreForgeTests/MultilingualEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/MultilingualEngineTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class MultilingualEngineTests: XCTestCase {
+    func testDetection() {
+        let engine = MultilingualEngine()
+        XCTAssertEqual(engine.detectLanguage(of: "Hola amigo"), .spanish)
+        XCTAssertEqual(engine.detectLanguage(of: "Bonjour"), .french)
+        XCTAssertEqual(engine.detectLanguage(of: "Guten Morgen"), .german)
+        XCTAssertEqual(engine.detectLanguage(of: "Ciao"), .italian)
+        XCTAssertEqual(engine.detectLanguage(of: "Hello"), .english)
+    }
+
+    func testModelForText() {
+        let engine = MultilingualEngine()
+        XCTAssertEqual(engine.modelForText("¿Cómo estás?"), "LocalVoiceAI-Es")
+        XCTAssertEqual(engine.modelForText("Bonjour"), "LocalVoiceAI-Fr")
+        XCTAssertEqual(engine.modelForText("Guten Tag"), "LocalVoiceAI-De")
+        XCTAssertEqual(engine.modelForText("Ciao"), "LocalVoiceAI-It")
+        XCTAssertEqual(engine.modelForText("Hi"), "LocalVoiceAI-En")
+    }
+}


### PR DESCRIPTION
## Summary
- extend `MultilingualEngine` with German and Italian support
- add tests for `MultilingualEngine` and `LanguageTranslationManager`

## Testing
- `swift test --disable-sandbox` *(fails: 7 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6855ed191fe88321a500c046bddd890b