### PR TITLE
Implement NSFW clip search and clear

### DIFF
--- a/Sources/CreatorCoreForge/NSFWVoiceClipManager.swift
+++ b/Sources/CreatorCoreForge/NSFWVoiceClipManager.swift
@@ -32,6 +32,20 @@ public final class NSFWManager {
         return nsfwVault
     }
 
+    /// Search vault clips by matching character name or text.
+    public func searchClips(keyword: String) -> [VoiceClip] {
+        let lower = keyword.lowercased()
+        return nsfwVault.filter { clip in
+            clip.character.lowercased().contains(lower) ||
+                clip.text.lowercased().contains(lower)
+        }
+    }
+
+    /// Remove all stored NSFW clips.
+    public func clearVault() {
+        nsfwVault.removeAll()
+    }
+
     /// Enable exporting of NSFW clips when the correct password is provided.
     @discardableResult
     public func enableStealthExport(password: String) -> Bool {

--- a/Tests/CreatorCoreForgeTests/NSFWManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWManagerTests.swift
@@ -17,4 +17,15 @@ final class NSFWManagerTests: XCTestCase {
         let files = manager.exportNSFWClips()
         XCTAssertTrue(files.isEmpty)
     }
+
+    func testSearchAndClearVault() {
+        let manager = NSFWManager()
+        manager.clearVault()
+        _ = manager.tagVoiceClip(character: "Hero", text: "moan softly", file: "/tmp/moan.wav")
+        _ = manager.tagVoiceClip(character: "Villain", text: "touch gently", file: "/tmp/touch.wav")
+        let results = manager.searchClips(keyword: "touch")
+        XCTAssertEqual(results.count, 1)
+        manager.clearVault()
+        XCTAssertTrue(manager.listNSFWClips().isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- add searchClips and clearVault utilities to `NSFWManager`
- test new functionality in `NSFWManagerTests`

## Testing
- `swift test --filter NSFWManagerTests`
- `swift test --parallel` *(fails: MultilingualEngineTests)*

------
https://chatgpt.com/codex/tasks/task_e_6855eed2ab48832181b894d7203657ce