### PR TITLE
Implement NSFW mood heatmap analytics

### DIFF
--- a/NSFWExpansion.md
+++ b/NSFWExpansion.md
@@ -14,6 +14,7 @@ The CreatorCoreForge ecosystem offers optional NSFW capabilities across apps. Ph
 - Live NSFW collaboration rooms with invite-only access
 - Haptic device integration for immersive experiences
 - NSFW analytics including mood heatmaps
+- `NSFWMoodHeatmap` module logs scene intensity levels and normalizes them for analytics
 - Premium unlocks, tipping, and pay-per-minute billing
 - Decoy or stealth modes for privacy
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
 - **Creator Dashboard:** Toggle Voice Memory, Emotion Graphs, Plugin Builder, AI Studio, Genesis, Global Unlock, and Sandbox tools across apps
 - **EmotionGraph:** Cross-app tracker for character emotion intensity
 - **EmotionalArcTracker:** Records emotion intensity for characters over time
+- **NSFWMoodHeatmap:** Normalizes logged NSFW intensity levels for analytics
 - **SceneGenerator:** Converts text into basic storyboard scenes
 - **VoiceMemoryManager:** Shares voice assignments across apps
 - **VoiceTrainer:** Uploads and trains custom voice models locally for offline voice synthesis.

--- a/Sources/CreatorCoreForge/NSFWMoodHeatmap.swift
+++ b/Sources/CreatorCoreForge/NSFWMoodHeatmap.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Generates a normalized heatmap from logged NSFW intensity levels.
+public final class NSFWMoodHeatmap {
+    private var log: [NSFWContentManager.NSFWIntensity] = []
+
+    public init() {}
+
+    /// Log an intensity level for later analysis.
+    public func log(intensity: NSFWContentManager.NSFWIntensity) {
+        log.append(intensity)
+    }
+
+    /// Normalize the most recent intensity levels in the range 0-1.
+    /// - Parameter window: Number of latest entries to include.
+    public func generateHeatmap(window: Int = 10) -> [Double] {
+        let slice = log.suffix(window)
+        let values = slice.map { level -> Double in
+            let index = NSFWContentManager.NSFWIntensity.allCases.firstIndex(of: level) ?? 0
+            return Double(index) / Double(NSFWContentManager.NSFWIntensity.allCases.count - 1)
+        }
+        guard let min = values.min(), let max = values.max(), max > min else {
+            return Array(values)
+        }
+        return values.map { ($0 - min) / (max - min) }
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWMoodHeatmapTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWMoodHeatmapTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWMoodHeatmapTests: XCTestCase {
+    func testHeatmapNormalization() {
+        let heatmap = NSFWMoodHeatmap()
+        heatmap.log(intensity: .softcore)
+        heatmap.log(intensity: .rough)
+        heatmap.log(intensity: .hardcore)
+        let result = heatmap.generateHeatmap(window: 3)
+        XCTAssertEqual(result.first ?? -1.0, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(result.last ?? -1.0, 1.0, accuracy: 0.0001)
+    }
+}

--- a/features-phase8.json
+++ b/features-phase8.json
@@ -25,7 +25,8 @@
     "CoreForgeAudio": [
       "Real-time emotion adaptation",
       "Voice DNA visualization",
-      "Quantum AI mode"
+      "Quantum AI mode",
+      "NSFW mood heatmap analytics"
     ],
     "CoreForgeVisual": [
       "Adaptive scene completion",


### PR DESCRIPTION
## Summary
- implement `NSFWMoodHeatmap` to track NSFW intensity levels
- create unit tests for the new heatmap
- document NSFW heatmap analytics in `NSFWExpansion.md`
- mention `NSFWMoodHeatmap` in shared modules section of README
- list NSFW heatmap analytics under CoreForge Audio Phase 8 features

## Testing
- `swift test` *(fails: 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6855f2031bcc8321878c34ef50341b3a