### PR TITLE
Add Kindle support to EbookImporter

### DIFF
--- a/Sources/CreatorCoreForge/EbookImporter.swift
+++ b/Sources/CreatorCoreForge/EbookImporter.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - eBook Import Pipeline
 
 public enum EbookFormat {
-    case txt, pdf, epub, unsupported
+    case txt, pdf, epub, mobi, azw, unsupported
 }
 
 public class EbookImporter {
@@ -15,6 +15,10 @@ public class EbookImporter {
             return .pdf
         } else if filename.hasSuffix(".epub") {
             return .epub
+        } else if filename.hasSuffix(".mobi") {
+            return .mobi
+        } else if filename.hasSuffix(".azw") {
+            return .azw
         }
         return .unsupported
     }
@@ -28,6 +32,10 @@ public class EbookImporter {
                 return importPdf(filePath)
             case .epub:
                 return importEpub(filePath)
+            case .mobi:
+                return importMobi(filePath)
+            case .azw:
+                return importAzw(filePath)
             default:
                 print("Unsupported format.")
                 return []
@@ -53,6 +61,20 @@ public class EbookImporter {
         // Simulated EPUB import
         print("Importing EPUB (simulated): \(filePath)")
         let simulatedText = "Chapter 1\nA new world begins...\n\nChapter 2\nTwists and turns await..."
+        return splitIntoChapters(simulatedText)
+    }
+
+    private func importMobi(_ filePath: String) -> [String] {
+        // Simulated MOBI import
+        print("Importing MOBI (simulated): \(filePath)")
+        let simulatedText = "Chapter 1\nKindle journey...\n\nChapter 2\nMore pages..."
+        return splitIntoChapters(simulatedText)
+    }
+
+    private func importAzw(_ filePath: String) -> [String] {
+        // Simulated AZW import
+        print("Importing AZW (simulated): \(filePath)")
+        let simulatedText = "Chapter 1\nAmazon format...\n\nChapter 2\nContinued..."
         return splitIntoChapters(simulatedText)
     }
 

--- a/Tests/CreatorCoreForgeTests/EbookImporterTests.swift
+++ b/Tests/CreatorCoreForgeTests/EbookImporterTests.swift
@@ -7,6 +7,8 @@ final class EbookImporterTests: XCTestCase {
         XCTAssertEqual(importer.detectFormat(filename: "story.txt"), .txt)
         XCTAssertEqual(importer.detectFormat(filename: "doc.pdf"), .pdf)
         XCTAssertEqual(importer.detectFormat(filename: "novel.epub"), .epub)
+        XCTAssertEqual(importer.detectFormat(filename: "book.mobi"), .mobi)
+        XCTAssertEqual(importer.detectFormat(filename: "story.azw"), .azw)
         XCTAssertEqual(importer.detectFormat(filename: "unknown.doc"), .unsupported)
     }
 
@@ -14,6 +16,22 @@ final class EbookImporterTests: XCTestCase {
         let tmp = "Chapter 1\nHello\n\nChapter 2\nWorld"
         let path = "/tmp/test.txt"
         try? tmp.write(toFile: path, atomically: true, encoding: .utf8)
+        let importer = EbookImporter()
+        let chapters = importer.importEbook(from: path)
+        XCTAssertEqual(chapters.count, 2)
+    }
+
+    func testImportMobi() {
+        let path = "/tmp/test.mobi"
+        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+        let importer = EbookImporter()
+        let chapters = importer.importEbook(from: path)
+        XCTAssertEqual(chapters.count, 2)
+    }
+
+    func testImportAzw() {
+        let path = "/tmp/test.azw"
+        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
         let importer = EbookImporter()
         let chapters = importer.importEbook(from: path)
         XCTAssertEqual(chapters.count, 2)


### PR DESCRIPTION
## Summary
- expand `EbookImporter` to detect MOBI and AZW files
- simulate import of Kindle formats
- cover new cases in unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855f3c87300832182e4dbc426852238