### PR TITLE
Add transcript utilities and UI sync highlighting

### DIFF
--- a/VoiceLab/package.json
+++ b/VoiceLab/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "node --loader ts-node/esm test/index.test.ts && node --loader ts-node/esm test/performance.test.ts"
+    "test": "node --loader ts-node/esm test/index.test.ts && node --loader ts-node/esm test/performance.test.ts && node --loader ts-node/esm test/transcript.test.ts && node --loader ts-node/esm test/syncHighlight.test.tsx"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/VoiceLab/src/index.ts
+++ b/VoiceLab/src/index.ts
@@ -2,3 +2,5 @@ export { LocalVoiceAI, VoiceModel } from './voiceModels';
 export { VoiceAnalyticsService, VoiceMetrics } from './VoiceAnalyticsService';
 export { VoiceLabUI } from './VoiceLabUI';
 export { PerformanceMonitor } from './PerformanceMonitor';
+export { TranscriptGenerator } from './transcriptGenerator';
+export { SyncHighlight, TranscriptSegment } from './syncHighlight';

--- a/VoiceLab/src/syncHighlight.tsx
+++ b/VoiceLab/src/syncHighlight.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export interface TranscriptSegment {
+  text: string;
+  start: number; // seconds
+  end: number; // seconds
+}
+
+export interface SyncHighlightProps {
+  transcript: TranscriptSegment[];
+  currentTime: number;
+}
+
+export const SyncHighlight: React.FC<SyncHighlightProps> = ({ transcript, currentTime }) => {
+  return (
+    <p>
+      {transcript.map((seg, i) => {
+        const active = currentTime >= seg.start && currentTime <= seg.end;
+        const style = active ? { backgroundColor: 'yellow' } : undefined;
+        return (
+          <span key={i} style={style}>
+            {seg.text + ' '}
+          </span>
+        );
+      })}
+    </p>
+  );
+};

--- a/VoiceLab/src/transcriptGenerator.ts
+++ b/VoiceLab/src/transcriptGenerator.ts
@@ -1,0 +1,43 @@
+export interface TranscriptGeneratorOptions {
+  apiKey?: string;
+  model?: string;
+  language?: string;
+}
+
+export class TranscriptGenerator {
+  private apiKey: string;
+  private model: string;
+  private language?: string;
+
+  constructor(options: TranscriptGeneratorOptions = {}) {
+    this.apiKey = options.apiKey || process.env.OPENAI_API_KEY || '';
+    this.model = options.model || 'whisper-1';
+    this.language = options.language;
+  }
+
+  async generateTranscript(audio: Blob | File): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error('OpenAI API key missing');
+    }
+    const form = new FormData();
+    form.append('file', audio);
+    form.append('model', this.model);
+    if (this.language) form.append('language', this.language);
+
+    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      body: form
+    });
+
+    if (!response.ok) {
+      const txt = await response.text();
+      throw new Error(`Transcription failed: ${response.status} ${txt}`);
+    }
+
+    const data = await response.json();
+    return data.text as string;
+  }
+}

--- a/VoiceLab/test/syncHighlight.test.tsx
+++ b/VoiceLab/test/syncHighlight.test.tsx
@@ -1,0 +1,8 @@
+import assert from 'node:assert';
+import React from 'react';
+import { SyncHighlight } from '../src/syncHighlight.tsx';
+
+const transcript = [{ text: 'Hello', start: 0, end: 1 }];
+const element = SyncHighlight({ transcript, currentTime: 0 });
+assert.ok(React.isValidElement(element));
+console.log('SyncHighlight test passed');

--- a/VoiceLab/test/transcript.test.ts
+++ b/VoiceLab/test/transcript.test.ts
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { TranscriptGenerator } from '../src/transcriptGenerator.ts';
+
+const generator = new TranscriptGenerator({ apiKey: 'test-key' });
+assert.ok(typeof generator.generateTranscript === 'function');
+console.log('TranscriptGenerator basic test passed');

--- a/VoiceLab/tsconfig.json
+++ b/VoiceLab/tsconfig.json
@@ -10,5 +10,5 @@
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- add a TranscriptGenerator service for Whisper API usage
- highlight transcript segments during playback in React
- expose new exports in VoiceLab index
- extend tests and config for new files

## Testing
- `npm test` within `VoiceLab`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855ffbaaf9883219b28e7a918a85527