### PR TITLE
Add NSFW utility managers

### DIFF
--- a/Sources/CreatorCoreForge/DecoyScreenManager.swift
+++ b/Sources/CreatorCoreForge/DecoyScreenManager.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Handles activation of a decoy screen for secret mode sessions.
+public final class DecoyScreenManager {
+    public static let shared = DecoyScreenManager()
+    private(set) var active = false
+
+    private init() {}
+
+    /// Enable the decoy screen.
+    public func enable() {
+        active = true
+    }
+
+    /// Disable the decoy screen.
+    public func disable() {
+        active = false
+    }
+
+    /// Query decoy screen state.
+    public func isActive() -> Bool { active }
+}
+

--- a/Sources/CreatorCoreForge/MultiPOVSceneBuilder.swift
+++ b/Sources/CreatorCoreForge/MultiPOVSceneBuilder.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Represents a short segment of narration from a specific character's POV.
+public struct POVSegment: Codable, Equatable {
+    public let character: String
+    public let text: String
+    public init(character: String, text: String) {
+        self.character = character
+        self.text = text
+    }
+}
+
+/// Builds a scene by combining multiple POV segments in sequence.
+public final class MultiPOVSceneBuilder {
+    private var segments: [POVSegment] = []
+
+    public init() {}
+
+    /// Add a segment from a character's point of view.
+    public func addSegment(character: String, text: String) {
+        let segment = POVSegment(character: character, text: text)
+        segments.append(segment)
+    }
+
+    /// Compose the final scene string with "Character: line" formatting.
+    public func buildScene() -> String {
+        segments.map { "\($0.character): \($0.text)" }.joined(separator: "\n")
+    }
+
+    public func reset() {
+        segments.removeAll()
+    }
+}
+

--- a/Sources/CreatorCoreForge/NSFWPaywallManager.swift
+++ b/Sources/CreatorCoreForge/NSFWPaywallManager.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Handles premium unlocks, paywall checks, and tip jar tracking for NSFW content.
+public final class NSFWPaywallManager {
+    public static let shared = NSFWPaywallManager()
+
+    private var premiumUnlocked = false
+    private(set) var tips: [Decimal] = []
+
+    private init() {}
+
+    /// Unlock premium NSFW features with a provided code.
+    @discardableResult
+    public func unlockPremium(code: String) -> Bool {
+        guard code == "UNLOCK-NSFW" else { return false }
+        premiumUnlocked = true
+        return true
+    }
+
+    /// Returns whether premium features are unlocked.
+    public func isPremiumUnlocked() -> Bool { premiumUnlocked }
+
+    /// Record a tip amount from a user.
+    public func addTip(_ amount: Decimal) {
+        tips.append(amount)
+    }
+
+    /// Total amount of tips received.
+    public var totalTips: Decimal {
+        tips.reduce(0, +)
+    }
+}
+

--- a/Sources/CreatorCoreForge/NSFWSFXPackManager.swift
+++ b/Sources/CreatorCoreForge/NSFWSFXPackManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Represents a collection of NSFW sound effects such as moans or ASMR breaths.
+public struct NSFWSFXPack: Codable, Equatable {
+    public let name: String
+    public let files: [String]
+    public init(name: String, files: [String]) {
+        self.name = name
+        self.files = files
+    }
+}
+
+/// Manages available NSFW sound effect packs for playback.
+public final class NSFWSFXPackManager {
+    public static let shared = NSFWSFXPackManager()
+    private var packs: [NSFWSFXPack] = []
+
+    private init() {}
+
+    /// Register a new SFX pack.
+    public func register(_ pack: NSFWSFXPack) {
+        if !packs.contains(pack) {
+            packs.append(pack)
+        }
+    }
+
+    /// List all registered packs.
+    public func listPacks() -> [NSFWSFXPack] {
+        packs
+    }
+
+    /// Get file names for a pack by name.
+    public func files(for name: String) -> [String] {
+        packs.first { $0.name == name }?.files ?? []
+    }
+}
+

--- a/Sources/CreatorCoreForge/ParentReportManager.swift
+++ b/Sources/CreatorCoreForge/ParentReportManager.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Collects session logs that can be exported for parental or creator review.
+public final class ParentReportManager {
+    public static let shared = ParentReportManager()
+
+    private var log: [String] = []
+
+    private init() {}
+
+    /// Record a single event line.
+    public func record(_ event: String) {
+        log.append(event)
+    }
+
+    /// Export the log as a newline separated string.
+    public func exportReport() -> String {
+        log.joined(separator: "\n")
+    }
+
+    public func clear() {
+        log.removeAll()
+    }
+}

--- a/Tests/CreatorCoreForgeTests/DecoyScreenManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/DecoyScreenManagerTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class DecoyScreenManagerTests: XCTestCase {
+    func testEnableDisable() {
+        let manager = DecoyScreenManager.shared
+        manager.disable()
+        XCTAssertFalse(manager.isActive())
+        manager.enable()
+        XCTAssertTrue(manager.isActive())
+        manager.disable()
+        XCTAssertFalse(manager.isActive())
+    }
+}

--- a/Tests/CreatorCoreForgeTests/MultiPOVSceneBuilderTests.swift
+++ b/Tests/CreatorCoreForgeTests/MultiPOVSceneBuilderTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class MultiPOVSceneBuilderTests: XCTestCase {
+    func testBuildScene() {
+        let builder = MultiPOVSceneBuilder()
+        builder.addSegment(character: "Alice", text: "Hello")
+        builder.addSegment(character: "Bob", text: "Hi")
+        let scene = builder.buildScene()
+        XCTAssertTrue(scene.contains("Alice: Hello"))
+        XCTAssertTrue(scene.contains("Bob: Hi"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWPaywallManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWPaywallManagerTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWPaywallManagerTests: XCTestCase {
+    func testUnlockAndTip() {
+        let manager = NSFWPaywallManager.shared
+        XCTAssertFalse(manager.isPremiumUnlocked())
+        XCTAssertFalse(manager.unlockPremium(code: "wrong"))
+        XCTAssertFalse(manager.isPremiumUnlocked())
+        XCTAssertTrue(manager.unlockPremium(code: "UNLOCK-NSFW"))
+        XCTAssertTrue(manager.isPremiumUnlocked())
+        manager.addTip(1.5)
+        manager.addTip(2.0)
+        XCTAssertEqual(manager.totalTips, 3.5)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWSFXPackManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWSFXPackManagerTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWSFXPackManagerTests: XCTestCase {
+    func testRegisterAndList() {
+        let manager = NSFWSFXPackManager.shared
+        manager.register(NSFWSFXPack(name: "Pack1", files: ["a", "b"]))
+        XCTAssertEqual(manager.listPacks().count, 1)
+        XCTAssertEqual(manager.files(for: "Pack1"), ["a", "b"])
+    }
+}

--- a/Tests/CreatorCoreForgeTests/ParentReportManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ParentReportManagerTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ParentReportManagerTests: XCTestCase {
+    func testRecordAndExport() {
+        let manager = ParentReportManager.shared
+        manager.clear()
+        manager.record("Event1")
+        manager.record("Event2")
+        let report = manager.exportReport()
+        XCTAssertTrue(report.contains("Event1"))
+        XCTAssertTrue(report.contains("Event2"))
+    }
+}


### PR DESCRIPTION
## Summary
- add managers for SFX packs, paywall/tipping, multi-POV scenes, reporting, and decoy mode
- include unit tests for new managers

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685611bb79888321a9996238eb75388f