### PR TITLE
Add EmotionShiftTracker feature

### DIFF
--- a/Sources/CreatorCoreForge/EmotionShiftTracker.swift
+++ b/Sources/CreatorCoreForge/EmotionShiftTracker.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Tracks transitions between detected emotions during narration.
+public final class EmotionShiftTracker {
+    /// Represents a change from one emotion to another.
+    public struct Shift: Codable, Equatable {
+        public let from: String
+        public let to: String
+        public let delta: Float
+    }
+
+    private(set) var shifts: [Shift] = []
+    private var lastEmotion: String?
+    private var lastIntensity: Float = 0.0
+
+    public init() {}
+
+    /// Log a new emotion observation. If a previous emotion exists, a shift is recorded.
+    public func log(emotion: String, intensity: Float) {
+        if let previous = lastEmotion {
+            let shift = Shift(from: previous, to: emotion, delta: intensity - lastIntensity)
+            shifts.append(shift)
+        }
+        lastEmotion = emotion
+        lastIntensity = intensity
+    }
+
+    /// Reset the tracker and remove all recorded shifts.
+    public func reset() {
+        shifts.removeAll()
+        lastEmotion = nil
+        lastIntensity = 0.0
+    }
+}

--- a/Tests/CreatorCoreForgeTests/EmotionShiftTrackerTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionShiftTrackerTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class EmotionShiftTrackerTests: XCTestCase {
+    func testShiftLogging() {
+        let tracker = EmotionShiftTracker()
+        tracker.log(emotion: "happy", intensity: 0.5)
+        tracker.log(emotion: "sad", intensity: 0.8)
+        XCTAssertEqual(tracker.shifts.count, 1)
+        if let first = tracker.shifts.first {
+            XCTAssertEqual(first.from, "happy")
+            XCTAssertEqual(first.to, "sad")
+            XCTAssertEqual(first.delta, 0.3, accuracy: 0.0001)
+        }
+    }
+
+    func testReset() {
+        let tracker = EmotionShiftTracker()
+        tracker.log(emotion: "happy", intensity: 0.5)
+        tracker.log(emotion: "neutral", intensity: 0.2)
+        tracker.reset()
+        XCTAssertTrue(tracker.shifts.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `EmotionShiftTracker` to log emotion transitions
- add unit tests for tracker

## Testing
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_6856136b8aac8321a4eac9ea02c0ee1c