### PR TITLE
Implement admin quota and reporting services

### DIFF
--- a/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/AdminService.swift
+++ b/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/AdminService.swift
@@ -1,0 +1,52 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct Quota: Codable, Equatable {
+    public let userId: String
+    public let limit: Int
+}
+
+public final class AdminService {
+    private let baseURL: URL
+    private let session: URLSession
+
+    public init(baseURL: URL = URL(string: "https://api.coreforgemarket.com")!,
+                session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func getQuotas(completion: @escaping (Result<[Quota], Error>) -> Void) {
+        let url = baseURL.appendingPathComponent("quotas")
+        session.dataTask(with: url) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data,
+                  let quotas = try? JSONDecoder().decode([Quota].self, from: data) else {
+                completion(.success([]))
+                return
+            }
+            completion(.success(quotas))
+        }.resume()
+    }
+
+    public func updateQuota(userId: String,
+                            newQuota: Quota,
+                            completion: @escaping (Result<Void, Error>) -> Void) {
+        var request = URLRequest(url: baseURL.appendingPathComponent("quotas/\(userId)"))
+        request.httpMethod = "PUT"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(newQuota)
+        session.dataTask(with: request) { _, _, error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }.resume()
+    }
+}

--- a/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/ReportingService.swift
+++ b/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/ReportingService.swift
@@ -1,0 +1,44 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct DateRange: Codable, Equatable {
+    public let start: Date
+    public let end: Date
+}
+
+public struct Report: Codable, Equatable {
+    public let summary: String
+}
+
+public final class ReportingService {
+    private let baseURL: URL
+    private let session: URLSession
+
+    public init(baseURL: URL = URL(string: "https://api.coreforgemarket.com")!,
+                session: URLSession = .shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func generateUsageReport(period: DateRange,
+                                    completion: @escaping (Result<Report, Error>) -> Void) {
+        var request = URLRequest(url: baseURL.appendingPathComponent("usageReport"))
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(period)
+        session.dataTask(with: request) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            guard let data = data,
+                  let report = try? JSONDecoder().decode(Report.self, from: data) else {
+                completion(.failure(NSError(domain: "ReportingService", code: -1)))
+                return
+            }
+            completion(.success(report))
+        }.resume()
+    }
+}

--- a/apps/CoreForgeMarket/TradeMindAIFull/Tests/TradeMindAITests/AdminServiceTests.swift
+++ b/apps/CoreForgeMarket/TradeMindAIFull/Tests/TradeMindAITests/AdminServiceTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import TradeMindAI
+
+final class AdminServiceTests: XCTestCase {
+    private class MockProtocol: URLProtocol {
+        static var requestHandler: ((URLRequest) -> (HTTPURLResponse, Data))?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            guard let handler = MockProtocol.requestHandler else { return }
+            let (response, data) = handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    func makeService(json: String) -> AdminService {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockProtocol.self]
+        let session = URLSession(configuration: config)
+        MockProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, json.data(using: .utf8)!)
+        }
+        return AdminService(baseURL: URL(string: "https://example.com")!, session: session)
+    }
+
+    func testGetQuotasReturnsDecodedData() {
+        let json = "[{\"userId\":\"u1\",\"limit\":1}]"
+        let service = makeService(json: json)
+        let exp = expectation(description: "quotas")
+        service.getQuotas { result in
+            switch result {
+            case .success(let quotas):
+                XCTAssertEqual(quotas, [Quota(userId: "u1", limit: 1)])
+            case .failure(let err):
+                XCTFail("Unexpected error: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testUpdateQuotaSendsPut() {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockProtocol.self]
+        let session = URLSession(configuration: config)
+        var receivedMethod: String?
+        var receivedBody: Data?
+        MockProtocol.requestHandler = { request in
+            receivedMethod = request.httpMethod
+            receivedBody = request.httpBody
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+        let service = AdminService(baseURL: URL(string: "https://example.com")!, session: session)
+        let quota = Quota(userId: "u1", limit: 5)
+        let exp = expectation(description: "update")
+        service.updateQuota(userId: "u1", newQuota: quota) { result in
+            if case .failure(let err) = result { XCTFail("Unexpected: \(err)") }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+        XCTAssertEqual(receivedMethod, "PUT")
+        let decoded = try? JSONDecoder().decode(Quota.self, from: receivedBody ?? Data())
+        XCTAssertEqual(decoded, quota)
+    }
+}

--- a/apps/CoreForgeMarket/TradeMindAIFull/Tests/TradeMindAITests/ReportingServiceTests.swift
+++ b/apps/CoreForgeMarket/TradeMindAIFull/Tests/TradeMindAITests/ReportingServiceTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import TradeMindAI
+
+final class ReportingServiceTests: XCTestCase {
+    private class MockProtocol: URLProtocol {
+        static var requestHandler: ((URLRequest) -> (HTTPURLResponse, Data))?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            guard let handler = MockProtocol.requestHandler else { return }
+            let (response, data) = handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    func testGenerateUsageReportParsesResponse() {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockProtocol.self]
+        let session = URLSession(configuration: config)
+        let json = "{\"summary\":\"ok\"}"
+        MockProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, json.data(using: .utf8)!)
+        }
+        let service = ReportingService(baseURL: URL(string: "https://example.com")!, session: session)
+        let range = DateRange(start: Date(), end: Date())
+        let exp = expectation(description: "report")
+        service.generateUsageReport(period: range) { result in
+            switch result {
+            case .success(let report):
+                XCTAssertEqual(report, Report(summary: "ok"))
+            case .failure(let err):
+                XCTFail("Unexpected: \(err)")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add `AdminService` with `getQuotas` and `updateQuota`
- add `ReportingService` with `generateUsageReport`
- test admin and reporting service network calls

## Testing
- `swift test`
- `swift test` in TradeMindAIFull
- `npm test --prefix VoiceLab`
- `npm test --prefix VisualLab`


------
https://chatgpt.com/codex/tasks/task_e_68561070a18483218148642da6dff9fe