### PR TITLE
Add FusionEngine logging plugin

### DIFF
--- a/Sources/CreatorCoreForge/LoggingPlugin.swift
+++ b/Sources/CreatorCoreForge/LoggingPlugin.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// FusionEngine plugin that logs prompts and responses for debugging.
+public struct LoggingPlugin: FusionEnginePlugin {
+    private let logger: AnalyticsLogger
+
+    public init(logger: AnalyticsLogger = AnalyticsLogger()) {
+        self.logger = logger
+    }
+
+    public func processPrompt(_ prompt: String) -> String {
+        logger.log(event: "Prompt: \(prompt)")
+        return prompt
+    }
+
+    public func processResponse(_ response: String) -> String {
+        logger.log(event: "Response: \(response)")
+        return response
+    }
+}

--- a/Tests/CreatorCoreForgeTests/LoggingPluginTests.swift
+++ b/Tests/CreatorCoreForgeTests/LoggingPluginTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class LoggingPluginTests: XCTestCase {
+    func testLogsPromptAndResponse() {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let logger = AnalyticsLogger(directory: tempDir)
+        let plugin = LoggingPlugin(logger: logger)
+        let engine = FusionEngine(engine: DummyEngine(), plugins: [plugin])
+        let exp = expectation(description: "prompt")
+        engine.sendPrompt("Ping") { result in
+            if case .success = result {
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 1)
+        // Allow async logging to flush
+        Thread.sleep(forTimeInterval: 0.1)
+        let logPath = tempDir.appendingPathComponent("analytics.log").path
+        let log = try? String(contentsOfFile: logPath)
+        XCTAssertNotNil(log)
+        XCTAssertTrue(log?.contains("Prompt: Ping") ?? false)
+        XCTAssertTrue(log?.contains("Response:") ?? false)
+    }
+
+    private struct DummyEngine: AIEngine {
+        func sendPrompt(_ prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+            completion(.success("Pong"))
+        }
+        func sendEmbeddingRequest(text: String, completion: @escaping (Result<[Double], Error>) -> Void) {
+            completion(.success([]))
+        }
+        func summarize(_ text: String, completion: @escaping (Result<String, Error>) -> Void) {
+            completion(.success("sum"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `LoggingPlugin` for FusionEngine
- test LoggingPlugin behavior

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6855ce2dbc0883219bb9d35e634e5291