### PR TITLE
Add improviser memory support

### DIFF
--- a/Tests/CreatorCoreForgeTests/RealTimeImproviserServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/RealTimeImproviserServiceTests.swift
@@ -10,6 +10,16 @@ final class RealTimeImproviserServiceTests: XCTestCase {
         func summarize(_ text: String, completion: @escaping (Result<String, Error>) -> Void) { completion(.success("sum")) }
     }
 
+    private class RecordingEngine: AIEngine {
+        var prompts: [String] = []
+        func sendPrompt(_ prompt: String, completion: @escaping (Result<String, Error>) -> Void) {
+            prompts.append(prompt)
+            completion(.success("ok"))
+        }
+        func sendEmbeddingRequest(text: String, completion: @escaping (Result<[Double], Error>) -> Void) { completion(.success([])) }
+        func summarize(_ text: String, completion: @escaping (Result<String, Error>) -> Void) { completion(.success("sum")) }
+    }
+
     func testImproviseReturnsLine() {
         let service = RealTimeImproviserService(engine: FusionEngine(engine: MockEngine()), context: "Scene")
         let exp = expectation(description: "reply")
@@ -25,6 +35,33 @@ final class RealTimeImproviserServiceTests: XCTestCase {
         let exp = expectation(description: "session")
         service.runSession(with: ["A","B"]) { replies in
             XCTAssertEqual(replies.count, 2)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testMemoryContextIncludedInPrompts() {
+        let rec = RecordingEngine()
+        let service = RealTimeImproviserService(engine: FusionEngine(engine: rec), context: "Scene")
+        let exp = expectation(description: "two")
+        service.improvise(userInput: "Hello") { _ in
+            service.improvise(userInput: "Bye") { _ in
+                XCTAssertTrue(rec.prompts[1].contains("Q: Hello"))
+                exp.fulfill()
+            }
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testClearHistoryResetsContext() {
+        let rec = RecordingEngine()
+        let service = RealTimeImproviserService(engine: FusionEngine(engine: rec))
+        service.improvise(userInput: "Hello") { _ in }
+        service.clearHistory()
+        let exp = expectation(description: "reply")
+        rec.prompts.removeAll()
+        service.improvise(userInput: "Next") { _ in
+            XCTAssertFalse(rec.prompts[0].contains("Hello"))
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)

--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -33,7 +33,7 @@ This file is a full checklist of every feature required for code completion and 
 - [x] FusionEngine: modular AI plugin support, macro builder, personal agent scripting
 - [x] Creator/Admin dashboard with credits, usage, quota, permissions, reporting
 - [x] Universal project/character/voice memory linking (across all CreatorCoreForge apps)
-- [ ] Real-time AI “improviser” for interactive or roleplay narration
+- [x] Real-time AI “improviser” for interactive or roleplay narration
 
 ### UX/UI Components
 - [x] Audiobook player with seek, skip, speed, loop, and bookmark features


### PR DESCRIPTION
## Summary
- expand `RealTimeImproviserService` with contextual memory and clearing
- verify new behaviour with additional unit tests
- mark improviser feature as complete in CoreForge Audio

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68561662f6088321827f755c9fec7d10