### PR TITLE
Add basic Desktop project structure for apps

### DIFF
--- a/apps/CoreForgeAudio/Desktop/index.html
+++ b/apps/CoreForgeAudio/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeAudio/Desktop/main.js
+++ b/apps/CoreForgeAudio/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeAudio/Desktop/package.json
+++ b/apps/CoreForgeAudio/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeAudio-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgeaudio",
+    "productName": "CoreForgeAudio",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeBuild/Desktop/index.html
+++ b/apps/CoreForgeBuild/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeBuild/Desktop/main.js
+++ b/apps/CoreForgeBuild/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeBuild/Desktop/package.json
+++ b/apps/CoreForgeBuild/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeBuild-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgebuild",
+    "productName": "CoreForgeBuild",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeLeads/Desktop/index.html
+++ b/apps/CoreForgeLeads/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeLeads/Desktop/main.js
+++ b/apps/CoreForgeLeads/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeLeads/Desktop/package.json
+++ b/apps/CoreForgeLeads/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeLeads-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgeleads",
+    "productName": "CoreForgeLeads",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeMusic/Desktop/index.html
+++ b/apps/CoreForgeMusic/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeMusic/Desktop/main.js
+++ b/apps/CoreForgeMusic/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeMusic/Desktop/package.json
+++ b/apps/CoreForgeMusic/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeMusic-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgemusic",
+    "productName": "CoreForgeMusic",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeStudio/Desktop/index.html
+++ b/apps/CoreForgeStudio/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeStudio/Desktop/main.js
+++ b/apps/CoreForgeStudio/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeStudio/Desktop/package.json
+++ b/apps/CoreForgeStudio/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeStudio-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgestudio",
+    "productName": "CoreForgeStudio",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeVisual/Desktop/index.html
+++ b/apps/CoreForgeVisual/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeVisual/Desktop/main.js
+++ b/apps/CoreForgeVisual/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeVisual/Desktop/package.json
+++ b/apps/CoreForgeVisual/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeVisual-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgevisual",
+    "productName": "CoreForgeVisual",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}

--- a/apps/CoreForgeWriter/Desktop/index.html
+++ b/apps/CoreForgeWriter/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeWriter/Desktop/main.js
+++ b/apps/CoreForgeWriter/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeWriter/Desktop/package.json
+++ b/apps/CoreForgeWriter/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeWriter-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgewriter",
+    "productName": "CoreForgeWriter",
+    "files": ["**/*"],
+    "mac": {"target": "dmg"},
+    "win": {"target": "nsis"}
+  }
+}


### PR DESCRIPTION
## Summary
- add placeholder Electron 'Desktop' project to each app
- each project includes a minimal `package.json`, `main.js` and `index.html`

## Testing
- `swift test` *(fails: fatalError during build)*

------
https://chatgpt.com/codex/tasks/task_e_685617efd1508321a0c2ad040bc27e7b