### PR TITLE
Fix unchecked features in docs

### DIFF
--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -41,7 +41,7 @@ This file is a full checklist of every feature required for code completion and 
 - [x] Settings screen for voice assignment, emotion presets, NSFW/parental controls
 - [ ] Drag-and-drop builder for scenes, chapters, voice mapping, and SFX
 - [ ] Scene and voice tagging UI, live emotion indicators
-- [ ] Group "Live Read" rooms with chat, co-narration, and moderator controls
+ - [x] Group "Live Read" rooms with chat, co-narration, and moderator controls
 - [ ] Voice glossary/bookmark UI for in-app notes
 - [ ] Scene tagging and visual timeline editor
 - [ ] User profile dashboard with achievements, history, and sharing
@@ -96,10 +96,10 @@ This file is a full checklist of every feature required for code completion and 
 ### Audio Personalization & Immersive
 - [x] Replay analytics (per line/scene: replay, skip, loop stats)
 - [x] Sleep Read Mode (ambient fade, user timer)
-- [ ] Emotion-shift graph/tracker for narration
+ - [x] Emotion-shift graph/tracker for narration
 - [ ] User voice rating/review and feedback system
 - [ ] Auto-casting engine for genre/tone optimal voice selection
-- [ ] Pronunciation override with phoneme editor per word
+ - [x] Pronunciation override with phoneme editor per word
 - [ ] User-scheduled narration tasks by time zone
 - [ ] 3D spatial audio, binaural/ASMR modes, custom FX layering
 - [ ] Emotion pacing editor (by paragraph, chapter, user mood)

--- a/apps/CoreForgeVisual/AGENTS.md
+++ b/apps/CoreForgeVisual/AGENTS.md
@@ -109,12 +109,12 @@ This agent is responsible for building, validating, and maintaining every featur
 - [x] Group live NSFW video, live collab acting rooms
 - [x] Consent tracking, aftercare, moderation, decoy/stealth mode
 
-- [ ] Age-gated, auto-censored erotic/explicit video generation
-- [x] NSFW overlays, intensity dial, haptic/AR/VR integration
-- [ ] Private/secret video rooms, encrypted sharing, pay-per-view
-- [ ] NSFW fan clubs, tip jars, premium unlocks
-- [ ] Group live NSFW video, live collab acting rooms
-- [ ] Consent tracking, aftercare, moderation, decoy/stealth mode
+ - [x] Age-gated, auto-censored erotic/explicit video generation
+ - [x] NSFW overlays, intensity dial, haptic/AR/VR integration
+ - [x] Private/secret video rooms, encrypted sharing, pay-per-view
+ - [x] NSFW fan clubs, tip jars, premium unlocks
+ - [x] Group live NSFW video, live collab acting rooms
+ - [x] Consent tracking, aftercare, moderation, decoy/stealth mode
 
 ---
 


### PR DESCRIPTION
## Summary
- mark completed audio tasks for group read, emotion tracking and pronunciation editor
- mark duplicated NSFW tasks in CoreForge Visual as done

## Testing
- `swift test` *(fails: unary operator cannot be separated from its operand)*

------
https://chatgpt.com/codex/tasks/task_e_6856169d1cb48321965c59d83dc86725