### PR TITLE
Add desktop build for CoreForgeMarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,6 @@ Cross-platform builds can be generated using `electron-builder`. Run
 `.exe` installers for apps that include a `Desktop` project. See
 `docs/CrossPlatformBuild.md` for details.
 
-An initial Electron setup lives under `apps/CoreForgeAudio/Desktop` to help you
-get started.
+Each app includes a `Desktop` folder with a starter Electron configuration for
+building installers.
 

--- a/apps/CoreForgeMarket/Desktop/index.html
+++ b/apps/CoreForgeMarket/Desktop/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CreatorCoreForge Desktop</title>
+</head>
+<body>
+  <h1>CreatorCoreForge Desktop</h1>
+  <p>This is a placeholder desktop application.</p>
+</body>
+</html>

--- a/apps/CoreForgeMarket/Desktop/main.js
+++ b/apps/CoreForgeMarket/Desktop/main.js
@@ -1,0 +1,6 @@
+const { app, BrowserWindow } = require('electron');
+function createWindow() {
+  const win = new BrowserWindow({ width: 800, height: 600 });
+  win.loadFile('index.html');
+}
+app.whenReady().then(createWindow);

--- a/apps/CoreForgeMarket/Desktop/package.json
+++ b/apps/CoreForgeMarket/Desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "CoreForgeMarket-desktop",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-builder --mac --win"
+  },
+  "devDependencies": {
+    "electron": "^28.2.0",
+    "electron-builder": "^24.6.0"
+  },
+  "build": {
+    "appId": "com.creatorcoreforge.coreforgemarket",
+    "productName": "CoreForgeMarket",
+    "files": ["**/*"],
+    "mac": { "target": "dmg" },
+    "win": { "target": "nsis" }
+  }
+}

--- a/docs/CrossPlatformBuild.md
+++ b/docs/CrossPlatformBuild.md
@@ -16,7 +16,7 @@ Run the helper script from the repository root:
 
 The script searches each app folder for a `Desktop` project containing a `package.json` file. If found, it installs dependencies and invokes `electron-builder` to create installers for both macOS and Windows.
 
-An example desktop package is provided under `apps/CoreForgeAudio/Desktop`. Use it as a template when adding desktop builds for other apps.
+Each app now includes a `Desktop` folder with a minimal Electron setup. Use these as templates when customizing the builds for your project.
 
 Artifacts are generated under each app's `Desktop/dist` directory. Upload these installers to your distribution channel or attach them to a release.
 

--- a/scripts/build_desktop.sh
+++ b/scripts/build_desktop.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APPS=(CoreForgeAudio CoreForgeVisual CoreForgeWriter CoreForgeStudio CoreForgeLeads CoreForgeMusic CoreForgeBuild)
+APPS=(CoreForgeAudio CoreForgeVisual CoreForgeWriter CoreForgeStudio CoreForgeLeads CoreForgeMusic CoreForgeBuild CoreForgeMarket)
 
 for APP in "${APPS[@]}"; do
   APP_DIR="apps/${APP}/Desktop"


### PR DESCRIPTION
## Summary
- support electron builder for CoreForgeMarket
- include CoreForgeMarket in desktop build script
- document per-app Electron setup

## Testing
- `swift test` *(fails: fatalError)*

------
https://chatgpt.com/codex/tasks/task_e_68561bbcea188321b0e08970df15bf80