### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/CreatorCoreForge/AudioExporter.swift
+++ b/Sources/CreatorCoreForge/AudioExporter.swift
@@ -61,10 +61,10 @@ public final class AudioExporter {
             try FileManager.default.zipItem(at: tempDir, to: zipPath)
             #else
             let process = Process()
-            process.launchPath = "/usr/bin/zip"
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
             process.currentDirectoryURL = tempDir
             process.arguments = ["-r", zipPath.path, "."]
-            process.launch()
+            try process.run()
             process.waitUntilExit()
             #endif
             try FileManager.default.removeItem(at: tempDir)

--- a/Sources/CreatorCoreForge/SceneAtmosphereBuilder.swift
+++ b/Sources/CreatorCoreForge/SceneAtmosphereBuilder.swift
@@ -63,7 +63,7 @@ public final class SceneAtmosphereBuilder {
         let tempDir = FileManager.default.temporaryDirectory
         let fileURL = tempDir.appendingPathComponent("atmo_\(mood.rawValue)").appendingPathExtension("caf")
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: Data(), attributes: nil)
+            _ = FileManager.default.createFile(atPath: fileURL.path, contents: Data(), attributes: nil)
         }
 
         print("Atmosphere generation skipped for \(mood.rawValue) — AVFoundation unavailable")

--- a/Tests/CreatorCoreForgeTests/EbookImporterTests.swift
+++ b/Tests/CreatorCoreForgeTests/EbookImporterTests.swift
@@ -23,7 +23,7 @@ final class EbookImporterTests: XCTestCase {
 
     func testImportMobi() {
         let path = "/tmp/test.mobi"
-        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+        _ = FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
         let importer = EbookImporter()
         let chapters = importer.importEbook(from: path)
         XCTAssertEqual(chapters.count, 2)
@@ -31,7 +31,7 @@ final class EbookImporterTests: XCTestCase {
 
     func testImportAzw() {
         let path = "/tmp/test.azw"
-        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+        _ = FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
         let importer = EbookImporter()
         let chapters = importer.importEbook(from: path)
         XCTAssertEqual(chapters.count, 2)

--- a/Tests/CreatorCoreForgeTests/NSFWBlurToggleTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWBlurToggleTests.swift
@@ -5,7 +5,7 @@ final class NSFWBlurToggleTests: XCTestCase {
     func testBlurToggleAgeGated() {
         let suite = UserDefaults(suiteName: "BlurToggleTests")!
         suite.removePersistentDomain(forName: "BlurToggleTests")
-        var blur = NSFWBlurToggle(store: suite)
+        let blur = NSFWBlurToggle(store: suite)
         var comps = DateComponents(); comps.year = Calendar.current.component(.year, from: Date()) - 10; comps.month = 1; comps.day = 1
         let underage = Calendar.current.date(from: comps)!
         XCTAssertFalse(blur.toggle(birthdate: underage))


### PR DESCRIPTION
## Summary
- address deprecated APIs in `AudioExporter`
- avoid unused result warnings in `SceneAtmosphereBuilder`
- clean up unit tests

## Testing
- `swift test`
- `npm test` in `VisualLab`

------
https://chatgpt.com/codex/tasks/task_e_6856215f03f0832190dfe7f05d30a2a5