### PR TITLE
Add missing app setup docs

### DIFF
--- a/apps/CoreForgeBuild/APISetup.md
+++ b/apps/CoreForgeBuild/APISetup.md
@@ -1,0 +1,5 @@
+# API Setup
+
+1. Register for API keys required by the AI code generator and cloud build services.
+2. Add keys to your environment variables or Xcode scheme as needed.
+3. Place any service configuration files (e.g. Firebase) inside the project directory.

--- a/apps/CoreForgeBuild/DeveloperSetup.md
+++ b/apps/CoreForgeBuild/DeveloperSetup.md
@@ -1,0 +1,5 @@
+# Developer Setup
+
+- Install Xcode 15 and Node.js 18 for desktop builds.
+- Run `swift package resolve` within `Desktop` if using Swift packages.
+- Open the Xcode project under `Desktop` and build for your platform.

--- a/apps/CoreForgeBuild/PromptTemplates.md
+++ b/apps/CoreForgeBuild/PromptTemplates.md
@@ -1,0 +1,10 @@
+# Prompt Templates
+
+Use these templates with `PromptTemplateLoader` to generate UI code and assets.
+
+```json
+{
+  "ui": "Build a SwiftUI view for a screen that shows: {{description}}",
+  "logic": "Write pseudocode to handle: {{feature}}"
+}
+```

--- a/apps/CoreForgeLeads/APISetup.md
+++ b/apps/CoreForgeLeads/APISetup.md
@@ -1,0 +1,5 @@
+# API Setup
+
+1. Obtain API keys for DataForge and CRM integrations.
+2. Set the keys as environment variables before running.
+3. Download any required config files to the project directory.

--- a/apps/CoreForgeLeads/DeveloperSetup.md
+++ b/apps/CoreForgeLeads/DeveloperSetup.md
@@ -1,0 +1,5 @@
+# Developer Setup
+
+- Install Xcode 15 and run `swift package resolve` inside `DataForgeAIFull`.
+- Open the Xcode project and build.
+- Export `OPENAI_API_KEY` to enable AI scoring tests.

--- a/apps/CoreForgeLeads/PromptTemplates.md
+++ b/apps/CoreForgeLeads/PromptTemplates.md
@@ -1,0 +1,10 @@
+# Prompt Templates
+
+Use these templates with the lead scoring engine.
+
+```json
+{
+  "score": "Score this lead based on role {{role}} and market {{market}}",
+  "email": "Generate a short outreach email for {{name}} about {{product}}"
+}
+```

--- a/apps/CoreForgeMusic/APISetup.md
+++ b/apps/CoreForgeMusic/APISetup.md
@@ -1,0 +1,5 @@
+# API Setup
+
+1. Obtain API keys for voice synthesis and beat marketplace services.
+2. Set them as environment variables or in your build configuration.
+3. Include any vendor config files (e.g. Firebase) in the project.

--- a/apps/CoreForgeMusic/DeveloperSetup.md
+++ b/apps/CoreForgeMusic/DeveloperSetup.md
@@ -1,0 +1,5 @@
+# Developer Setup
+
+- Install Node.js 18 and Xcode if building for macOS.
+- Run `npm install` inside `Desktop` then `npm start` for the Electron version.
+- Provide any API keys in a `.env` file or scheme variables.

--- a/apps/CoreForgeMusic/PromptTemplates.md
+++ b/apps/CoreForgeMusic/PromptTemplates.md
@@ -1,0 +1,10 @@
+# Prompt Templates
+
+These templates help the AI craft hooks and lyrics.
+
+```json
+{
+  "hook": "Write a catchy hook about {{topic}} in the style of {{artist}}",
+  "lyrics": "Generate a {{genre}} verse about {{theme}}"
+}
+```

--- a/apps/CoreForgeStudio/APISetup.md
+++ b/apps/CoreForgeStudio/APISetup.md
@@ -1,0 +1,5 @@
+# API Setup
+
+1. Acquire API keys for rendering services and asset storage.
+2. Add them to your environment variables or Xcode scheme.
+3. Include any platform configuration files in the project.

--- a/apps/CoreForgeStudio/DeveloperSetup.md
+++ b/apps/CoreForgeStudio/DeveloperSetup.md
@@ -1,0 +1,5 @@
+# Developer Setup
+
+- Install Xcode 15 and Node.js for the Electron wrapper.
+- Run `swift package resolve` inside `VocalVisionFull`.
+- Build the Xcode project and ensure `OPENAI_API_KEY` is set for tests.

--- a/apps/CoreForgeStudio/PromptTemplates.md
+++ b/apps/CoreForgeStudio/PromptTemplates.md
@@ -1,0 +1,10 @@
+# Prompt Templates
+
+These prompts help drive the cinematic engine.
+
+```json
+{
+  "storyboard": "Create a shot list for: {{scene}}",
+  "caption": "Generate a short caption for this clip: {{description}}"
+}
+```

--- a/apps/CoreForgeWriter/APISetup.md
+++ b/apps/CoreForgeWriter/APISetup.md
@@ -1,0 +1,5 @@
+# API Setup
+
+1. Generate an OpenAI API key for text and embedding calls.
+2. Add the key to your environment or Xcode scheme (`OPENAI_API_KEY`).
+3. Include any additional service configuration files in the project.

--- a/apps/CoreForgeWriter/DeveloperSetup.md
+++ b/apps/CoreForgeWriter/DeveloperSetup.md
@@ -1,0 +1,5 @@
+# Developer Setup
+
+- Install the latest Xcode and run `swift package resolve` inside `InkwellAIFull`.
+- Open `InkwellAIFull` in Xcode and build or run tests with `swift test`.
+- Set `OPENAI_API_KEY` when running integration tests.

--- a/apps/CoreForgeWriter/PromptTemplates.md
+++ b/apps/CoreForgeWriter/PromptTemplates.md
@@ -1,0 +1,10 @@
+# Prompt Templates
+
+Use these prompts with `PromptTemplateLoader` when generating prose.
+
+```json
+{
+  "chapter": "Write the next chapter in {{style}} style about {{topic}}",
+  "summary": "Summarize this section in two sentences: {{text}}"
+}
+```


### PR DESCRIPTION
## Summary
- add API setup, developer setup and prompt template docs across app modules

## Testing
- `swift test`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685621f6f6e483219e88dc415122fdf9