### PR TITLE
Add instructions and CI step for Node tests

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,3 @@
+# GitHub Workflows
+
+This folder contains CI configurations for building, testing and deploying CreatorCoreForge apps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,17 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
-      - run: |
+      - name: Test VoiceLab
+        run: |
           cd VoiceLab
           npm ci
           npm run lint
           npm run build
+          npm test
+      - name: Test VisualLab
+        run: |
+          cd VisualLab
+          npm ci
           npm test
       - uses: swift-actions/setup-swift@v1
         with:

--- a/README.md
+++ b/README.md
@@ -320,3 +320,15 @@ Cross-platform builds can be generated using `electron-builder`. Run
 Each app includes a `Desktop` folder with a starter Electron configuration for
 building installers.
 
+## Running Tests
+
+Install Node dependencies for the labs before running the test suites:
+
+```bash
+cd VoiceLab && npm install && npm test
+cd ../VisualLab && npm install && npm test
+cd .. && swift test
+```
+
+This ensures `jest`, `ts-node`, and other dev tools are available.
+

--- a/Sources/README.md
+++ b/Sources/README.md
@@ -1,0 +1,3 @@
+# Sources
+
+Swift source code for the shared CreatorCoreForge library resides in `CreatorCoreForge/`. Targets are defined in `Package.swift`.

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+Unit tests for the Swift package and apps. Run `swift test` to execute the suite.

--- a/VisualLab/README.md
+++ b/VisualLab/README.md
@@ -1,0 +1,3 @@
+# VisualLab
+
+VisualLab contains experimental TypeScript tools for advanced video rendering and scene editing. Install dependencies with `npm install` and run the tests with `npm test`.

--- a/VoiceLab/README.md
+++ b/VoiceLab/README.md
@@ -1,0 +1,3 @@
+# VoiceLab
+
+VoiceLab provides TypeScript utilities and components for voice analysis and transcription used by the CreatorCoreForge ecosystem. Run `npm install` then `npm test` to build and test the package.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,3 @@
+# Apps Directory
+
+This folder groups each major CreatorCoreForge application. Every app contains its own `README.md` and setup guides.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Additional guides and phase planning documents for the CreatorCoreForge ecosystem live here.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,3 @@
+# Fastlane
+
+Configuration files for iOS TestFlight distribution. `Fastfile` defines lanes for building and uploading builds.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Scripts
+
+Utility shell and Python scripts used for building projects and auditing features. See each script for details.


### PR DESCRIPTION
## Summary
- add `Running Tests` instructions to README
- ensure GitHub CI installs and tests both labs

## Testing
- `swift test`
- `npm test` in VoiceLab
- `npm test` in VisualLab

------
https://chatgpt.com/codex/tasks/task_e_68562612abb08321b6650d96669710a3