### PR TITLE
Add missing AGENTS files

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Repository Automation
+
+## Directory: .github
+Purpose: CI workflows and GitHub settings
+
+### Tasks
+- [ ] Update workflow scripts for new platforms
+- [ ] Maintain issue templates and PR checks
+- [ ] Document CI usage in README
+
+---
+
+## Codex/AI Agent Note
+Repository automation must stay functional across phases.

--- a/Sources/AGENTS.md
+++ b/Sources/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Core Library Integration
+
+## Directory: Sources
+Purpose: Shared Swift libraries powering CreatorCoreForge apps
+
+### Tasks
+- [ ] Keep Package.swift targets up to date
+- [ ] Maintain cross-app modules in CreatorCoreForge
+- [ ] Add unit tests for new engines
+
+---
+
+## Codex/AI Agent Note
+Central Swift code belongs here; keep interfaces stable.

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Test Suite Oversight
+
+## Directory: Tests
+Purpose: Swift and TypeScript tests for all modules
+
+### Tasks
+- [ ] Expand coverage for AI engines
+- [ ] Ensure continuous integration runs pass
+- [ ] Add regression tests for bug fixes
+
+---
+
+## Codex/AI Agent Note
+Testing is required before merging new features.

--- a/VisualLab/AGENTS.md
+++ b/VisualLab/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent: Feature Pipeline – VisualLab
+
+## Module: VisualLab
+Language: TypeScript
+Purpose: Experimental video rendering utilities and testbed
+
+### Tasks
+- [ ] Maintain CI workflow for `npm test`
+- [ ] Update dependencies and tsconfig
+- [ ] Sync features with CoreForge Visual
+- [ ] Document advanced usage in README
+
+---
+
+## Codex/AI Agent Note
+Keep this file updated as VisualLab evolves.

--- a/VoiceLab/AGENTS.md
+++ b/VoiceLab/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent: Feature Pipeline – VoiceLab
+
+## Module: VoiceLab
+Language: TypeScript
+Purpose: Voice analysis and transcription components
+
+### Tasks
+- [ ] Ensure voice training scripts run via CI
+- [ ] Keep React components typed and tested
+- [ ] Integrate with OpenAI service
+- [ ] Document new APIs
+
+---
+
+## Codex/AI Agent Note
+Use this checklist to track VoiceLab improvements.

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Apps Directory Tracking
+
+## Directory: apps
+Purpose: Consolidate all CreatorCoreForge application packages
+
+### Tasks
+- [ ] Keep each subfolder in sync with master roadmap
+- [ ] Maintain per-app AGENTS.md files
+- [ ] Coordinate shared assets and templates
+
+---
+
+## Codex/AI Agent Note
+Use this checklist when auditing app-level progress.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Documentation Curation
+
+## Directory: docs
+Purpose: Guides and phase roadmaps for CreatorCoreForge
+
+### Tasks
+- [ ] Keep PHASE_EIGHT.md synced with features-phase8.json
+- [ ] Update migration guides for new modules
+- [ ] Review diagrams and images for accuracy
+
+---
+
+## Codex/AI Agent Note
+Documentation should mirror the latest build features.

--- a/fastlane/AGENTS.md
+++ b/fastlane/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Fastlane Automation
+
+## Directory: fastlane
+Purpose: Manage build and distribution pipelines for iOS/macOS
+
+### Tasks
+- [ ] Maintain Fastfile lanes for all apps
+- [ ] Update ExportOptions.plist for new entitlements
+- [ ] Document usage in README
+
+---
+
+## Codex/AI Agent Note
+Automated deployments rely on this folder staying updated.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent: Build Script Maintenance
+
+## Directory: scripts
+Purpose: Utility scripts for building and auditing CreatorCoreForge
+
+### Tasks
+- [ ] Keep bash and Python scripts cross-platform
+- [ ] Ensure templates generate valid pbxproj files
+- [ ] Expand feature audit logic
+
+---
+
+## Codex/AI Agent Note
+Scripts should be tested regularly on all platforms.


### PR DESCRIPTION
## Summary
- create AGENTS.md for documentation, fastlane and script folders
- add agents for VisualLab and VoiceLab packages
- include AGENTS for sources, tests, apps directory and GitHub workflows

## Testing
- `npm test --prefix VoiceLab`
- `npm test --prefix VisualLab`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68562a65e09c83218333bb24a20d5eb0