### PR TITLE
Add stub modules for visual and audio features

### DIFF
--- a/Sources/CreatorCoreForge/FaceTrackerService.swift
+++ b/Sources/CreatorCoreForge/FaceTrackerService.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Represents a detected face position.
+public struct FacePosition: Equatable {
+    public let x: Double
+    public let y: Double
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+/// Basic stub face tracker returning no faces by default.
+public final class FaceTrackerService {
+    public init() {}
+
+    /// Track faces in the given frame. Returns an array of positions.
+    public func track(frame: Any) -> [FacePosition] {
+        []
+    }
+}

--- a/Sources/CreatorCoreForge/RenderAnalyticsDashboard.swift
+++ b/Sources/CreatorCoreForge/RenderAnalyticsDashboard.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Simple struct representing a render metric.
+public struct RenderMetric: Equatable {
+    public let name: String
+    public let value: Double
+    public init(name: String, value: Double) {
+        self.name = name
+        self.value = value
+    }
+}
+
+/// Minimal analytics dashboard that formats metrics for display.
+public struct RenderAnalyticsDashboard {
+    public init() {}
+    public func display(metrics: [RenderMetric]) -> String {
+        metrics.map { "\($0.name): \($0.value)" }.joined(separator: "\n")
+    }
+}

--- a/Sources/CreatorCoreForge/SubtitleGenerator.swift
+++ b/Sources/CreatorCoreForge/SubtitleGenerator.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Represents a generated subtitle at a point in the timeline.
+public struct Subtitle: Equatable {
+    public let time: Int
+    public let text: String
+    public init(time: Int, text: String) {
+        self.time = time
+        self.text = text
+    }
+}
+
+/// Generates simple subtitles by splitting lines of a script.
+public func generateSubtitles(from script: String) -> [Subtitle] {
+    script.split(whereSeparator: { $0.isNewline }).enumerated().map { index, line in
+        Subtitle(time: index, text: String(line))
+    }
+}

--- a/Sources/CreatorCoreForge/VoiceBookmarkService.swift
+++ b/Sources/CreatorCoreForge/VoiceBookmarkService.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Stores bookmarks and notes for audio playback.
+public final class VoiceBookmarkService {
+    private var notes: [URL: [Bookmark]] = [:]
+    public init() {}
+
+    /// Represents a note at a time offset in seconds.
+    public struct Bookmark: Equatable {
+        public let time: TimeInterval
+        public let note: String
+        public init(time: TimeInterval, note: String) {
+            self.time = time
+            self.note = note
+        }
+    }
+
+    /// Add a bookmark for the given file URL.
+    public func addBookmark(for url: URL, time: TimeInterval, note: String) {
+        let bookmark = Bookmark(time: time, note: note)
+        notes[url, default: []].append(bookmark)
+    }
+
+    /// Retrieve bookmarks for the given file URL.
+    public func bookmarks(for url: URL) -> [Bookmark] {
+        notes[url] ?? []
+    }
+
+    /// Remove all bookmarks for the given file URL.
+    public func clearBookmarks(for url: URL) {
+        notes[url] = nil
+    }
+}

--- a/Sources/CreatorCoreForge/WatermarkService.swift
+++ b/Sources/CreatorCoreForge/WatermarkService.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Adds simple watermarks to video frame identifiers.
+public struct WatermarkService {
+    public init() {}
+
+    /// Appends the watermark string to the frame identifier.
+    public func applyWatermark(frame: String, watermark: String) -> String {
+        "\(frame)-wm(\(watermark))"
+    }
+}

--- a/Tests/CreatorCoreForgeTests/VisualFeatureStubsTests.swift
+++ b/Tests/CreatorCoreForgeTests/VisualFeatureStubsTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class VisualFeatureStubsTests: XCTestCase {
+    func testWatermarkService() {
+        let svc = WatermarkService()
+        XCTAssertEqual(svc.applyWatermark(frame: "frame1", watermark: "wm"), "frame1-wm(wm)")
+    }
+
+    func testFaceTrackerService() {
+        let tracker = FaceTrackerService()
+        XCTAssertTrue(tracker.track(frame: Data()).isEmpty)
+    }
+
+    func testSubtitleGenerator() {
+        let subs = generateSubtitles(from: "Hello\nWorld")
+        XCTAssertEqual(subs.count, 2)
+        XCTAssertEqual(subs.first?.text, "Hello")
+    }
+
+    func testRenderAnalyticsDashboard() {
+        let dash = RenderAnalyticsDashboard()
+        let output = dash.display(metrics: [RenderMetric(name: "fps", value: 60)])
+        XCTAssertTrue(output.contains("fps"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/VoiceBookmarkServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceBookmarkServiceTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class VoiceBookmarkServiceTests: XCTestCase {
+    func testAddAndRetrieveBookmarks() {
+        let svc = VoiceBookmarkService()
+        let url = URL(fileURLWithPath: "/tmp/test.wav")
+        svc.addBookmark(for: url, time: 1.5, note: "Intro")
+        svc.addBookmark(for: url, time: 3.0, note: "Verse")
+        let bookmarks = svc.bookmarks(for: url)
+        XCTAssertEqual(bookmarks.count, 2)
+        XCTAssertEqual(bookmarks[0].note, "Intro")
+    }
+
+    func testClearBookmarks() {
+        let svc = VoiceBookmarkService()
+        let url = URL(fileURLWithPath: "/tmp/test.wav")
+        svc.addBookmark(for: url, time: 1.0, note: "A")
+        svc.clearBookmarks(for: url)
+        XCTAssertTrue(svc.bookmarks(for: url).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- implement VoiceBookmarkService for audio notes
- add minimal visual feature stubs (WatermarkService, FaceTrackerService, SubtitleGenerator, RenderAnalyticsDashboard)
- add tests for new modules

## Testing
- `npm test --silent` in VoiceLab
- `npm install --silent && npm test --silent` in VisualLab
- `swift test --disable-sandbox`

------
https://chatgpt.com/codex/tasks/task_e_68568867ebf88321ad91be8a1b1c790f