### PR TITLE
Add placeholder modules for PRACTICAL_PLAN tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## [Unreleased]
 - Added `HeatmapAnalytics` and `VersionedExports` features to `CoreForgeAudio` in `features-phase8.json`.
 - Added audio personalization and immersive feature placeholders (`ReplayAnalyticsService`, `SleepReadMode`, `EmotionShiftTracker`, `VoiceReviewSystem`, `AutoCastingEngine`, `PronunciationEditor`, `NarrationScheduler`, `SpatialAudioSupport`, `EmotionPacingEditor`, `SmartAmbientMixer`, `AutoRemixMode`, `AccessibilityOutput`, `WatchSyncService`, `VoicePolls`, `HeartRateAdaptiveAudio`, `UnlockableVoiceSkins`, `PersonalizedGreetingService`, `AdvancedTimelineEditor`, `BrailleOutputService`, `PronunciationDictionary`) to `CoreForgeAudio` in `features-phase8.json`.
+- Added placeholder implementations for Visual and Writer features (`StoryboardImporter`, `SceneSegmenter`, `StyleEngine`, `FrameRenderer`, `OutlineGenerator`, `WorldMemoryService`, `BranchService`, `ExportService`).
+- Added Studio feature stubs (`MultiTrackEditor`, `LiveEnsembleRoom`, `MacroWorkflowEngine`, `ExportProduction`) with unit tests.

--- a/Sources/CreatorCoreForge/BranchService.swift
+++ b/Sources/CreatorCoreForge/BranchService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Tracks alternate story branches.
+public final class BranchService {
+    private var branches: [String: String] = [:]
+    public init() {}
+
+    public func addBranch(id: String, text: String) {
+        branches[id] = text
+    }
+
+    public func branch(for id: String) -> String? {
+        branches[id]
+    }
+}

--- a/Sources/CreatorCoreForge/ExportProduction.swift
+++ b/Sources/CreatorCoreForge/ExportProduction.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Generates production exports with an optional watermark.
+public final class ExportProduction {
+    public init() {}
+
+    public func export(frames: [String], watermark: String? = nil) -> [String] {
+        if let mark = watermark {
+            return frames.map { "\($0)-wm(\(mark))" }
+        }
+        return frames
+    }
+}

--- a/Sources/CreatorCoreForge/ExportService.swift
+++ b/Sources/CreatorCoreForge/ExportService.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Writes text to simple ePub/Docx-like files.
+public final class ExportService {
+    public init() {}
+
+    public func export(text: String, to url: URL) throws {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/CreatorCoreForge/FrameRenderer.swift
+++ b/Sources/CreatorCoreForge/FrameRenderer.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Assembles frames into a simple clip structure.
+public struct RenderedClip {
+    public let frames: [String]
+    public init(frames: [String]) { self.frames = frames }
+}
+
+public final class FrameRenderer {
+    public init() {}
+
+    /// Combine frames with optional transitions (ignored in stub).
+    public func render(frames: [String]) -> RenderedClip {
+        RenderedClip(frames: frames)
+    }
+}

--- a/Sources/CreatorCoreForge/LiveEnsembleRoom.swift
+++ b/Sources/CreatorCoreForge/LiveEnsembleRoom.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Simulates a live ensemble chat room.
+public final class LiveEnsembleRoom {
+    private(set) var messages: [String] = []
+    public init() {}
+
+    public func post(_ message: String) {
+        messages.append(message)
+    }
+}

--- a/Sources/CreatorCoreForge/MacroWorkflowEngine.swift
+++ b/Sources/CreatorCoreForge/MacroWorkflowEngine.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Records and replays simple UI action macros.
+public final class MacroWorkflowEngine {
+    private var actions: [String] = []
+    public init() {}
+
+    public func record(_ action: String) {
+        actions.append(action)
+    }
+
+    public func replay() -> [String] {
+        actions
+    }
+}

--- a/Sources/CreatorCoreForge/MultiTrackEditor.swift
+++ b/Sources/CreatorCoreForge/MultiTrackEditor.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Edits multiple audio tracks and performs a simple mixdown.
+public final class MultiTrackEditor {
+    public init() {}
+
+    public func mix(tracks: [[Int]]) -> [Int] {
+        guard let longest = tracks.map({ $0.count }).max() else { return [] }
+        var result = Array(repeating: 0, count: longest)
+        for track in tracks {
+            for (i, sample) in track.enumerated() {
+                result[i] += sample
+            }
+        }
+        return result
+    }
+}

--- a/Sources/CreatorCoreForge/OutlineGenerator.swift
+++ b/Sources/CreatorCoreForge/OutlineGenerator.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Generates simple outlines for stories.
+public final class OutlineGenerator {
+    public init() {}
+
+    /// Create an outline splitting text by blank lines.
+    public func generate(from text: String) -> [String] {
+        text.components(separatedBy: "\n\n").filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+}

--- a/Sources/CreatorCoreForge/SceneSegmenter.swift
+++ b/Sources/CreatorCoreForge/SceneSegmenter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Splits a scene description into basic shot segments.
+public final class SceneSegmenter {
+    public init() {}
+
+    /// Segment the scene string using simple period separation.
+    public func segments(from scene: String) -> [String] {
+        scene.split(separator: ".").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+    }
+}

--- a/Sources/CreatorCoreForge/StoryboardImporter.swift
+++ b/Sources/CreatorCoreForge/StoryboardImporter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Parses storyboard files into simple scene identifiers.
+public final class StoryboardImporter {
+    public init() {}
+
+    /// Import a storyboard text and return scene identifiers.
+    public func importStoryboard(_ text: String) -> [String] {
+        text.split(separator: "\n").map { String($0) }.filter { !$0.isEmpty }
+    }
+}

--- a/Sources/CreatorCoreForge/StyleEngine.swift
+++ b/Sources/CreatorCoreForge/StyleEngine.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Simple rendering style enum for visual scenes.
+public enum VisualStyle: Equatable {
+    case anime, liveAction, fantasy
+    case custom(String)
+}
+
+/// Applies visual styles to frame identifiers.
+public final class StyleEngine {
+    public init() {}
+
+    public func apply(style: VisualStyle, to frame: String) -> String {
+        switch style {
+        case .anime: return "\(frame)-anime"
+        case .liveAction: return "\(frame)-live"
+        case .fantasy: return "\(frame)-fantasy"
+        case .custom(let name): return "\(frame)-\(name)"
+        }
+    }
+}

--- a/Sources/CreatorCoreForge/WorldMemoryService.swift
+++ b/Sources/CreatorCoreForge/WorldMemoryService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Stores and retrieves simple world lore key-values.
+public final class WorldMemoryService {
+    private var store: [String: String] = [:]
+    public init() {}
+
+    public func remember(key: String, value: String) {
+        store[key] = value
+    }
+
+    public func recall(key: String) -> String? {
+        store[key]
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class PracticalPlanFeatureTests: XCTestCase {
+    func testStoryboardImporter() {
+        let importer = StoryboardImporter()
+        let scenes = importer.importStoryboard("A\nB")
+        XCTAssertEqual(scenes, ["A", "B"])
+    }
+
+    func testSceneSegmenter() {
+        let seg = SceneSegmenter()
+        let shots = seg.segments(from: "a. b.")
+        XCTAssertEqual(shots, ["a", "b"])
+    }
+
+    func testStyleEngine() {
+        let engine = StyleEngine()
+        XCTAssertEqual(engine.apply(style: .anime, to: "f"), "f-anime")
+    }
+
+    func testFrameRenderer() {
+        let renderer = FrameRenderer()
+        let clip = renderer.render(frames: ["f1", "f2"])
+        XCTAssertEqual(clip.frames.count, 2)
+    }
+
+    func testOutlineGenerator() {
+        let gen = OutlineGenerator()
+        let outline = gen.generate(from: "A\n\nB")
+        XCTAssertEqual(outline, ["A", "B"])
+    }
+
+    func testWorldMemoryService() {
+        let svc = WorldMemoryService()
+        svc.remember(key: "city", value: "Neo")
+        XCTAssertEqual(svc.recall(key: "city"), "Neo")
+    }
+
+    func testBranchService() {
+        let svc = BranchService()
+        svc.addBranch(id: "1", text: "A")
+        XCTAssertEqual(svc.branch(for: "1"), "A")
+    }
+
+    func testExportService() throws {
+        let svc = ExportService()
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("t.txt")
+        try? FileManager.default.removeItem(at: url)
+        try svc.export(text: "hi", to: url)
+        let out = try String(contentsOf: url)
+        XCTAssertEqual(out, "hi")
+    }
+
+    func testMultiTrackEditor() {
+        let editor = MultiTrackEditor()
+        let mix = editor.mix(tracks: [[1,2],[3]])
+        XCTAssertEqual(mix[0], 4)
+    }
+
+    func testLiveEnsembleRoom() {
+        let room = LiveEnsembleRoom()
+        room.post("hello")
+        XCTAssertEqual(room.messages.count, 1)
+    }
+
+    func testMacroWorkflowEngine() {
+        let engine = MacroWorkflowEngine()
+        engine.record("tap")
+        XCTAssertEqual(engine.replay(), ["tap"])
+    }
+
+    func testExportProduction() {
+        let export = ExportProduction()
+        let frames = export.export(frames: ["f"], watermark: "wm")
+        XCTAssertEqual(frames.first, "f-wm(wm)")
+    }
+}


### PR DESCRIPTION
## Summary
- implement placeholder services from docs/PRACTICAL_PLAN
- cover new modules with simple unit tests
- document additions in CHANGELOG

## Testing
- `swift test`
- `npm test` in VoiceLab
- `npm test` in VisualLab

------
https://chatgpt.com/codex/tasks/task_e_68568c87c0648321a3478fcfe23dcf0d