### PR TITLE
Implement initial book importer updates

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
+++ b/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
@@ -2,10 +2,16 @@ import Foundation
 
 /// Manages chapter-based audio playback with simple bookmarking support.
 public struct Chapter {
+    /// Title of the chapter if known.
     public let title: String
-    public let audioURL: String
-    public init(title: String, audioURL: String) {
+    /// Raw text contents for narration or analysis.
+    public let text: String
+    /// Optional URL to pre-rendered audio for playback.
+    public var audioURL: String?
+
+    public init(title: String, text: String, audioURL: String? = nil) {
         self.title = title
+        self.text = text
         self.audioURL = audioURL
     }
 }
@@ -35,7 +41,11 @@ public final class PlaybackManager {
         }
         isPlaying = true
         let chapter = chapters[currentIndex]
-        print("▶️ Playing Chapter \(currentIndex + 1): \(chapter.title) at \(chapter.audioURL)")
+        if let url = chapter.audioURL {
+            print("▶️ Playing Chapter \(currentIndex + 1): \(chapter.title) at \(url)")
+        } else {
+            print("▶️ Playing Chapter \(currentIndex + 1): \(chapter.title)")
+        }
         return true
     }
 

--- a/Tests/CreatorCoreForgeTests/BookProcessingTests.swift
+++ b/Tests/CreatorCoreForgeTests/BookProcessingTests.swift
@@ -7,6 +7,7 @@ final class BookProcessingTests: XCTestCase {
         try? "Chapter 1\nHello\n\nChapter 2\nWorld".write(to: tmp, atomically: true, encoding: .utf8)
         let chapters = BookProcessing.importBook(filePath: tmp.path)
         XCTAssertEqual(chapters.count, 2)
+        XCTAssertTrue(chapters[0].text.contains("Chapter 1"))
     }
 
     func testAssignVoices() {

--- a/Tests/CreatorCoreForgeTests/PlaybackBookmarkingTests.swift
+++ b/Tests/CreatorCoreForgeTests/PlaybackBookmarkingTests.swift
@@ -5,8 +5,8 @@ final class PlaybackBookmarkingTests: XCTestCase {
     func testBookmarkAndResume() {
         let manager = PlaybackManager()
         let chapters = [
-            Chapter(title: "One", audioURL: "1.mp3"),
-            Chapter(title: "Two", audioURL: "2.mp3")
+            Chapter(title: "One", text: "A", audioURL: "1.mp3"),
+            Chapter(title: "Two", text: "B", audioURL: "2.mp3")
         ]
         manager.loadChapters(chapters)
         XCTAssertTrue(manager.playCurrentChapter())
@@ -19,7 +19,7 @@ final class PlaybackBookmarkingTests: XCTestCase {
 
     func testPreviousChapterBounds() {
         let manager = PlaybackManager()
-        manager.loadChapters([Chapter(title: "A", audioURL: "a.mp3")])
+        manager.loadChapters([Chapter(title: "A", text: "", audioURL: "a.mp3")])
         XCTAssertFalse(manager.previousChapter())
     }
 }


### PR DESCRIPTION
## Summary
- add chapter `text` to keep metadata on parsed book chapters
- import book data with text and return `Chapter` objects
- update playback logic to handle missing audio URLs
- adjust tests for updated `Chapter` structure

## Testing
- `swift test`
- `npm test` in `VisualLab`
- `npm test` in `VoiceLab`


------
https://chatgpt.com/codex/tasks/task_e_68568d4e54688321b008bc7a49d8bcef