### PR TITLE
Implement missing phase 8 feature stubs

### DIFF
--- a/Sources/CreatorCoreForge/AIVocalProductionEngine.swift
+++ b/Sources/CreatorCoreForge/AIVocalProductionEngine.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Simple AI-driven vocal processor.
+public final class AIVocalProductionEngine {
+    public init() {}
+
+    /// Normalize a track so the maximum amplitude is 1.0.
+    public func process(track: [Float]) -> [Float] {
+        guard let maxVal = track.max(), maxVal != 0 else { return track }
+        return track.map { $0 / maxVal }
+    }
+}

--- a/Sources/CreatorCoreForge/FigmaUIBuilder.swift
+++ b/Sources/CreatorCoreForge/FigmaUIBuilder.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Parses simple Figma JSON exports to generate view names.
+public struct FigmaUIBuilder {
+    public init() {}
+
+    /// Return an array of node names found in the provided JSON string.
+    public func generateViews(from json: String) -> [String] {
+        guard let data = json.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let nodes = obj["nodes"] as? [[String: Any]] else {
+            return []
+        }
+        return nodes.compactMap { $0["name"] as? String }
+    }
+}

--- a/Sources/CreatorCoreForge/HybridQuantumTradingEngine.swift
+++ b/Sources/CreatorCoreForge/HybridQuantumTradingEngine.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Demonstrates a hybrid trading engine combining classical and quantum signals.
+public struct HybridQuantumTradingEngine {
+    public init() {}
+
+    /// Evaluate market prices and return a basic trading action.
+    public func evaluateSignals(_ prices: [Double]) -> String {
+        guard let first = prices.first, let last = prices.last else { return "HOLD" }
+        return last > first ? "BUY" : "SELL"
+    }
+}

--- a/Sources/CreatorCoreForge/QuantumRealitySwitcher.swift
+++ b/Sources/CreatorCoreForge/QuantumRealitySwitcher.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Switches between alternate video realities.
+public final class QuantumRealitySwitcher {
+    public private(set) var currentReality: String
+    public init(initialReality: String = "Base") {
+        self.currentReality = initialReality
+    }
+
+    /// Switch to a different reality and return the active name.
+    @discardableResult
+    public func switchReality(to reality: String) -> String {
+        currentReality = reality
+        return currentReality
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AIVocalProductionEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/AIVocalProductionEngineTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AIVocalProductionEngineTests: XCTestCase {
+    func testProcess() {
+        let engine = AIVocalProductionEngine()
+        let processed = engine.process(track: [0.5, 1.0, 0.25])
+        XCTAssertEqual(processed.max(), 1.0)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FigmaUIBuilderTests.swift
+++ b/Tests/CreatorCoreForgeTests/FigmaUIBuilderTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class FigmaUIBuilderTests: XCTestCase {
+    func testGenerateViews() {
+        let json = "{\"nodes\":[{\"name\":\"Button\"},{\"name\":\"Label\"}]}"
+        let builder = FigmaUIBuilder()
+        XCTAssertEqual(builder.generateViews(from: json), ["Button", "Label"])
+    }
+}

--- a/Tests/CreatorCoreForgeTests/HybridQuantumTradingEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/HybridQuantumTradingEngineTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class HybridQuantumTradingEngineTests: XCTestCase {
+    func testEvaluateSignals() {
+        let engine = HybridQuantumTradingEngine()
+        XCTAssertEqual(engine.evaluateSignals([1, 2, 3]), "BUY")
+        XCTAssertEqual(engine.evaluateSignals([3, 2, 1]), "SELL")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/QuantumRealitySwitcherTests.swift
+++ b/Tests/CreatorCoreForgeTests/QuantumRealitySwitcherTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class QuantumRealitySwitcherTests: XCTestCase {
+    func testSwitchReality() {
+        let switcher = QuantumRealitySwitcher()
+        XCTAssertEqual(switcher.currentReality, "Base")
+        switcher.switchReality(to: "Alt")
+        XCTAssertEqual(switcher.currentReality, "Alt")
+    }
+}


### PR DESCRIPTION
## Summary
- add placeholder implementations for QuantumRealitySwitcher, HybridQuantumTradingEngine, FigmaUIBuilder and AIVocalProductionEngine
- cover new utilities with unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68568d5f528c8321bafc4a65675b80fb