### PR TITLE
Implement practical plan feature placeholders

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeBloom_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeBloom_MissingFeatures.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct CycleTracker {
+    public func predict(last: Date, cycleLength: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: cycleLength, to: last) ?? last
+    }
+}
+
+public struct WellnessReminder {
+    public func remind(_ note: String) -> String {
+        "Reminder: \(note)"
+    }
+}
+
+public struct WearableSync {
+    public func sync(data: [String: Int]) -> Int {
+        data.values.reduce(0, +)
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeBuild_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeBuild_MissingFeatures.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public struct CoreForgeBuildFeatures {
+    public init() {}
+
+    public func importFigma(file: String) -> [String] {
+        file.split(separator: ",").map { String($0) }
+    }
+
+    public func bundle(platforms: [String]) -> [String] {
+        platforms.map { "\($0)_bundle" }
+    }
+
+    public func debugHints(for message: String) -> [String] {
+        guard !message.isEmpty else { return [] }
+        return ["Check configuration for \(message)"]
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeDNA_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeDNA_MissingFeatures.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public struct DNATreeNode {
+    public var name: String
+    public var children: [DNATreeNode]
+    public init(name: String, children: [DNATreeNode] = []) {
+        self.name = name
+        self.children = children
+    }
+}
+
+public struct CoreForgeDNAFeatures {
+    public init() {}
+
+    public func visualize(_ root: DNATreeNode) -> [String] {
+        var result: [String] = []
+        func walk(_ node: DNATreeNode) {
+            result.append(node.name)
+            node.children.forEach { walk($0) }
+        }
+        walk(root)
+        return result
+    }
+
+    public func export(profile: [String: String]) -> Data {
+        (try? JSONSerialization.data(withJSONObject: profile)) ?? Data()
+    }
+
+    public func importProfile(data: Data) -> [String: String] {
+        (try? JSONSerialization.jsonObject(with: data)) as? [String: String] ?? [:]
+    }
+
+    public func merge(timelineA: [String], timelineB: [String]) -> [String] {
+        Array(Set(timelineA + timelineB)).sorted()
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeLeads_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeLeads_MissingFeatures.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public final class CreditLedger {
+    private(set) var credits: Int = 0
+    public init() {}
+    public func add(_ amount: Int) { credits += amount }
+    public func bill(_ amount: Int) -> Bool {
+        guard credits >= amount else { return false }
+        credits -= amount
+        return true
+    }
+}
+
+public struct GlobalExchange {
+    public func trade(id: String, for credit: Int) -> String {
+        "Traded \(id) for \(credit)"
+    }
+}
+
+public struct ScoringEngine {
+    public func score(leads: [Int]) -> Double {
+        guard !leads.isEmpty else { return 0 }
+        let total = leads.reduce(0, +)
+        return Double(total) / Double(leads.count)
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeLearn_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeLearn_MissingFeatures.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct CurriculumBuilder {
+    public func makeLesson(from text: String) -> [String] {
+        text.split(separator: ".").map { String($0.trimmingCharacters(in: .whitespaces)) }.filter { !$0.isEmpty }
+    }
+}
+
+public struct AITutor {
+    public func feedback(score: Int) -> String {
+        score > 80 ? "Great job" : "Keep practicing"
+    }
+}
+
+public struct OfflineSync {
+    private var cache: [String] = []
+    public mutating func add(_ record: String) { cache.append(record) }
+    public var count: Int { cache.count }
+}

--- a/Sources/CreatorCoreForge/CoreForgeMarket_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeMarket_MissingFeatures.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct QuantumTradingEngine {
+    public func analyze(prices: [Double]) -> Double {
+        prices.reduce(0, +) / Double(prices.count)
+    }
+}
+
+public final class TeamTrading {
+    private(set) var trades: [String] = []
+    public init() {}
+    public func addTrade(_ t: String) { trades.append(t) }
+}
+
+public struct BotMarketplace {
+    public func publish(bot: String) -> Bool { !bot.isEmpty }
+}

--- a/Sources/CreatorCoreForge/CoreForgeMind_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeMind_MissingFeatures.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public final class MoodJournal {
+    private var entries: [Date: String] = [:]
+    public init() {}
+    public func addEntry(_ text: String, date: Date = Date()) {
+        entries[date] = text
+    }
+    public var count: Int { entries.count }
+}
+
+public struct GuidedSessions {
+    public func play(session: String) -> String {
+        "Playing \(session)"
+    }
+}
+
+public final class PrivateVault {
+    private var store: [String: String] = [:]
+    public init() {}
+    public func save(key: String, value: String) { store[key] = value }
+    public func fetch(key: String) -> String? { store[key] }
+}

--- a/Sources/CreatorCoreForge/CoreForgeMusic_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeMusic_MissingFeatures.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct CoreForgeMusicFeatures {
+    public init() {}
+
+    public func produceVocals(track: String, voice: String) -> String {
+        "\(track)-vocals-\(voice)"
+    }
+
+    public func exportCommercial(track: String, license: String) -> String {
+        "\(track)-licensed(\(license))"
+    }
+
+    public func publishHook(name: String) -> Bool {
+        !name.isEmpty
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeQuest_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeQuest_MissingFeatures.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct ChallengeGenerator {
+    public func generate(from seed: String) -> [String] {
+        seed.split(separator: " ").map { String($0) }
+    }
+}
+
+public struct LeaderboardEvents {
+    public func rank(scores: [Int]) -> [Int] {
+        scores.sorted(by: >)
+    }
+}
+
+public struct MarketplaceItems {
+    public func trade(item: String, for coins: Int) -> String {
+        "\(item)-for-\(coins)"
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeVoiceLab_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeVoiceLab_MissingFeatures.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct RecordingTools {
+    public func trim(_ samples: [Float], to count: Int) -> [Float] {
+        Array(samples.prefix(count))
+    }
+}
+
+public struct TrainingPipeline {
+    public func prepare(samples: [Float]) -> Bool {
+        !samples.isEmpty
+    }
+}
+
+public struct ExportHooks {
+    public func send(name: String) -> String {
+        "Sent \(name)"
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
@@ -75,4 +75,109 @@ final class PracticalPlanFeatureTests: XCTestCase {
         let frames = export.export(frames: ["f"], watermark: "wm")
         XCTAssertEqual(frames.first, "f-wm(wm)")
     }
+    func testFigmaImporter() {
+        let build = CoreForgeBuildFeatures()
+        let parts = build.importFigma(file: "A,B")
+        XCTAssertEqual(parts, ["A", "B"])
+    }
+
+    func testUniversalBundler() {
+        let build = CoreForgeBuildFeatures()
+        let out = build.bundle(platforms: ["iOS"])
+        XCTAssertEqual(out, ["iOS_bundle"])
+    }
+
+    func testDebugAssistant() {
+        let build = CoreForgeBuildFeatures()
+        let hints = build.debugHints(for: "Error")
+        XCTAssertTrue(hints.first?.contains("Error") ?? false)
+    }
+
+    func testDNATreeUI() {
+        let child = DNATreeNode(name: "Child")
+        let root = DNATreeNode(name: "Root", children: [child])
+        let features = CoreForgeDNAFeatures()
+        XCTAssertEqual(features.visualize(root), ["Root", "Child"])
+    }
+
+    func testDNACrossAppSync() {
+        let features = CoreForgeDNAFeatures()
+        let data = features.export(profile: ["a": "b"])
+        let profile = features.importProfile(data: data)
+        XCTAssertEqual(profile["a"], "b")
+    }
+
+    func testDNAMultiverseMerge() {
+        let features = CoreForgeDNAFeatures()
+        let merged = features.merge(timelineA: ["A"], timelineB: ["B"])
+        XCTAssertEqual(Set(merged), ["A", "B"])
+    }
+
+    func testMusicFeatures() {
+        let music = CoreForgeMusicFeatures()
+        XCTAssertEqual(music.produceVocals(track: "beat", voice: "vox"), "beat-vocals-vox")
+        XCTAssertEqual(music.exportCommercial(track: "song", license: "cc"), "song-licensed(cc)")
+        XCTAssertTrue(music.publishHook(name: "hook"))
+    }
+
+    func testLeadsFeatures() {
+        let ledger = CreditLedger()
+        ledger.add(10)
+        XCTAssertTrue(ledger.bill(5))
+        let exchange = GlobalExchange()
+        XCTAssertTrue(exchange.trade(id: "L1", for: 5).contains("L1"))
+        let scoring = ScoringEngine()
+        XCTAssertEqual(scoring.score(leads: [1,3]), 2.0)
+    }
+
+    func testMindFeatures() {
+        let journal = MoodJournal()
+        journal.addEntry("hi")
+        XCTAssertEqual(journal.count, 1)
+        XCTAssertEqual(GuidedSessions().play(session: "med"), "Playing med")
+        let vault = PrivateVault()
+        vault.save(key: "k", value: "v")
+        XCTAssertEqual(vault.fetch(key: "k"), "v")
+    }
+
+    func testBloomFeatures() {
+        let tracker = CycleTracker()
+        let next = tracker.predict(last: Date(timeIntervalSince1970: 0), cycleLength: 28)
+        XCTAssertTrue(next > Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(WellnessReminder().remind("stretch"), "Reminder: stretch")
+        XCTAssertEqual(WearableSync().sync(data: ["steps": 5, "cal": 5]), 10)
+    }
+
+    func testLearnFeatures() {
+        let builder = CurriculumBuilder()
+        let lesson = builder.makeLesson(from: "A. B.")
+        XCTAssertEqual(lesson, ["A", "B"])
+        XCTAssertEqual(AITutor().feedback(score: 90), "Great job")
+        var sync = OfflineSync()
+        sync.add("x")
+        XCTAssertEqual(sync.count, 1)
+    }
+
+    func testQuestFeatures() {
+        let gen = ChallengeGenerator()
+        XCTAssertEqual(gen.generate(from: "go north"), ["go", "north"])
+        XCTAssertEqual(LeaderboardEvents().rank(scores: [1,3,2]), [3,2,1])
+        XCTAssertEqual(MarketplaceItems().trade(item: "sword", for: 5), "sword-for-5")
+    }
+
+    func testVoiceLabFeatures() {
+        let rec = RecordingTools()
+        XCTAssertEqual(rec.trim([1,2,3], to: 2), [1,2])
+        XCTAssertTrue(TrainingPipeline().prepare(samples: [0.1]))
+        XCTAssertEqual(ExportHooks().send(name: "voice"), "Sent voice")
+    }
+
+    func testMarketFeatures() {
+        let engine = QuantumTradingEngine()
+        XCTAssertEqual(engine.analyze(prices: [1.0, 3.0]), 2.0)
+        let team = TeamTrading()
+        team.addTrade("buy")
+        XCTAssertEqual(team.trades.count, 1)
+        XCTAssertTrue(BotMarketplace().publish(bot: "bot"))
+    }
 }


### PR DESCRIPTION
## Summary
- add placeholder modules for Build, DNA, Music, Leads, Mind, Bloom, Learn, Quest, VoiceLab, Market
- test new modules in `PracticalPlanFeatureTests`

## Testing
- `swift test`
- `npm test --silent --prefix VisualLab` *(fails: ts-node not found)*
- `npm test --silent --prefix VoiceLab` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568ebf1bd88321858b718ba176f69b