### PR TITLE
Add production roadmap documentation

### DIFF
--- a/docs/PRODUCTION_ROADMAP.md
+++ b/docs/PRODUCTION_ROADMAP.md
@@ -1,0 +1,100 @@
+# Production Approach for CreatorCoreForge Apps
+
+This roadmap outlines the high level steps required to bring each application in the CreatorCoreForge ecosystem to a production ready state. Use it alongside `docs/PRACTICAL_PLAN.md`, the individual `AGENTS.md` files, and `features-phase8.json`.
+
+---
+
+## Shared Requirements
+
+1. **Finalize Shared Engines** – ensure `FusionEngine`, `LocalAIEnginePro`, and `LocalVoiceAI` are integrated across all apps with consistent APIs.
+2. **Cross-Platform Builds** – verify that iOS, Android, macOS, Windows, and Web targets can be generated using the provided scripts and Fastlane lanes.
+3. **Automated Testing** – expand unit and integration tests in `Tests/` and run `npm test` for the labs. Continuous integration should remain green before publishing releases.
+4. **Security & Compliance** – audit data handling, NSFW gating, and privacy flows to satisfy GDPR, CCPA, and app store policies.
+5. **Installers & Store Assets** – produce `.ipa`, `.apk`, `.dmg`, and `.exe` packages. Collect icons, screenshots, and metadata for each store listing.
+6. **Documentation** – keep `docs/PHASE_EIGHT.md` and per-app READMEs up to date with new features.
+
+---
+
+## CoreForge Audio
+
+- Implement remaining Phase 8 features such as `SoundLayerEngine`, `ChapterAnalyticsService`, and `AutoCastingEngine`.
+- Polish the timeline editor and ambient mixer for final user experience.
+- Complete unit tests for the narration scheduler, emotion trackers, and export modules.
+- Package desktop installers and submit mobile builds via the Fastlane pipelines.
+
+## CoreForge Visual
+
+- Finish AR/VR playback support and the `RenderAnalyticsDashboard` module.
+- Add performance tests for ultra-long video exports and verify export presets.
+- Prepare marketing assets for store listings and verify cross-device playback.
+- Generate installers with `electron-builder` and validate TestFlight deployments.
+
+## CoreForge Writer
+
+- Finalize memory pinning and quantum-choice plotting services.
+- Build the initial community marketplace hooks and export flows to ePub and PDF.
+- Write regression tests for the outline generator and branching logic.
+- Submit builds to TestFlight and prepare desktop installers.
+
+## CoreForge Market
+
+- Scaffold the hybrid quantum trading engine and integrate team leaderboards.
+- Complete API endpoints for the bot marketplace and connect to the dashboard.
+- Add stress tests for real-time trade simulations and finalize compliance checks.
+- Package the PC build and coordinate beta testing for the mobile app.
+
+## CoreForge Build
+
+- Implement the Figma-driven UI builder and universal bundler.
+- Provide interactive debugging helpers and ensure generated apps compile on all platforms.
+- Expand unit tests around template generation and add user guides in the README.
+
+## CoreForge Studio
+
+- Complete real-time ensemble acting and the quantum edit mode options.
+- Polish the template monetization flow and add watermark features to exports.
+- Test the multi-track editor across macOS and Windows installers.
+
+## CoreForge Music
+
+- Integrate AI vocal production with commercial export tools.
+- Finalize voice cloning hooks and provide label-ready templates.
+- Run performance tests on render speed and memory usage before release.
+
+## CoreForge Leads
+
+- Finish the marketplace credit system and global lead exchange APIs.
+- Extend the scoring engine and add analytics dashboards in the UI.
+- Verify GDPR compliance for all stored leads and export functionalities.
+
+## CoreForge DNA
+
+- Polish the DNA tree UI and enable profile import/export across apps.
+- Add multiverse merge utilities and validate voice data encryption.
+- Bundle the standalone version with cross-platform installers.
+
+## CoreForge Mind & Bloom
+
+- Expand wellness tracking with mood journals and guided sessions.
+- Integrate private vaults for sensitive data and optional NSFW modules.
+- Provide wearables sync and finalize monetization flows.
+
+## CoreForge Learn
+
+- Implement the curriculum builder and offline sync features.
+- Add AI tutor analytics and ensure lesson data persists across devices.
+
+## CoreForge Quest
+
+- Finalize the challenge generator and reward marketplace items.
+- Test multiplayer events and leaderboard synchronization.
+- Package the Unity build for desktop and mobile stores.
+
+## CoreForge Voice Lab
+
+- Complete the recording tools and training pipeline.
+- Provide export hooks to the Audio and Music apps and verify dataset integrity.
+
+---
+
+Follow this roadmap to coordinate the remaining tasks for each application. When all checklist items are complete and tests are passing, the apps will be ready for full production release.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
 # Documentation
 
 Additional guides and phase planning documents for the CreatorCoreForge ecosystem live here.
+
+- `PRACTICAL_PLAN.md` – initial TODO list across apps.
+- `PRODUCTION_ROADMAP.md` – high level approach for bringing every app to production.
+- `PHASE_EIGHT.md` – checklist of Phase 8 feature goals.


### PR DESCRIPTION
## Summary
- create `PRODUCTION_ROADMAP.md` with steps for each app to reach production
- note the new doc in `docs/README.md`

## Testing
- `npm test` in VoiceLab
- `npm test` in VisualLab
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856901e63f883218d7dd62433fbec00