### PR TITLE
Add FilingsDatabase module

### DIFF
--- a/Sources/CreatorCoreForge/FilingsDatabase.swift
+++ b/Sources/CreatorCoreForge/FilingsDatabase.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Represents a single filing document.
+public struct Filing: Codable, Equatable {
+    public var id: UUID
+    public var title: String
+    public var date: Date
+    public var url: URL
+
+    public init(id: UUID = UUID(), title: String, date: Date, url: URL) {
+        self.id = id
+        self.title = title
+        self.date = date
+        self.url = url
+    }
+}
+
+/// Simple JSON-backed storage for `Filing` records.
+public final class FilingsDatabase {
+    private let fileURL: URL
+    private let fileManager: FileManager
+    private var filings: [Filing] = []
+
+    public init(directory: URL? = nil, fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        let dir = directory ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        self.fileURL = dir.appendingPathComponent("filings.json")
+        load()
+    }
+
+    /// Persist a filing to disk.
+    public func save(_ filing: Filing) throws {
+        filings.append(filing)
+        try persist()
+    }
+
+    /// Return all saved filings.
+    public func list() -> [Filing] {
+        filings
+    }
+
+    /// Remove all filings from storage.
+    public func clear() throws {
+        filings.removeAll()
+        try persist()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        if let decoded = try? JSONDecoder().decode([Filing].self, from: data) {
+            filings = decoded
+        }
+    }
+
+    private func persist() throws {
+        let data = try JSONEncoder().encode(filings)
+        try fileManager.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FilingsDatabaseTests.swift
+++ b/Tests/CreatorCoreForgeTests/FilingsDatabaseTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class FilingsDatabaseTests: XCTestCase {
+    func testSaveAndList() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let db = FilingsDatabase(directory: tempDir)
+        let filing = Filing(title: "Test", date: Date(timeIntervalSince1970: 0), url: URL(string: "https://example.com")!)
+        try db.save(filing)
+        XCTAssertEqual(db.list().count, 1)
+        XCTAssertEqual(db.list().first?.title, "Test")
+    }
+
+    func testClear() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let db = FilingsDatabase(directory: tempDir)
+        let filing = Filing(title: "Test", date: Date(), url: URL(string: "https://example.com")!)
+        try db.save(filing)
+        try db.clear()
+        XCTAssertTrue(db.list().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add `FilingsDatabase` for storing filing records
- test saving, listing and clearing filings

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856918635208321b3c41f99451e3e81