### PR TITLE
Add module migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ For production releases, trigger `upload-appstore.yml` which calls the
 
 See `docs/AI-Prompt-Migration.md` for integrating the new OpenAI prompt interface across apps.
 See `docs/VoiceTrainerGuide.md` for using the local voice training engine.
+See `docs/ModuleMigrationGuide.md` for adopting shared Phase 8 modules across apps.
 All apps now include a `VideoShareManager` for posting generated videos directly to social media.
 The new `FusionEngine` wrapper automatically selects between `LocalAIEnginePro` and `OpenAIService` for each app, enabling offline-first development when `USE_LOCAL_AI` is set. It now supports contextual memory, parallel execution across multiple engines, emotion tracking, sandbox mode for isolated testing, cross-app voice memory, on-device summarization, and quick scene generation helpers.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,7 +5,7 @@ Purpose: Guides and phase roadmaps for CreatorCoreForge
 
 ### Tasks
 - [x] Keep PHASE_EIGHT.md synced with features-phase8.json
-- [ ] Update migration guides for new modules
+- [x] Update migration guides for new modules
 - [ ] Review diagrams and images for accuracy
 
 ---

--- a/docs/ModuleMigrationGuide.md
+++ b/docs/ModuleMigrationGuide.md
@@ -1,0 +1,16 @@
+# Module Migration Guide
+
+This guide describes how to migrate existing apps to use the shared engines and services introduced in Phase 8.
+
+## Core Libraries
+- **FusionEngine** – Handles AI routing and context. Replace direct `OpenAIService` calls with `FusionEngine` when you need adaptive prompts or local/offline support.
+- **LocalAIEnginePro** – Lightweight on-device model. Set the `USE_LOCAL_AI` environment variable to enable this engine for offline development.
+- **LocalVoiceAI** – Provides voice cloning and TTS without an internet connection. Instantiate `LocalVoiceAI()` in place of remote services when offline.
+
+## Migration Steps
+1. Import the `CreatorCoreForge` Swift package into your project.
+2. Replace previous direct service usages with the new shared modules above.
+3. Review existing code for duplicate implementations and remove them.
+4. Run `swift test` and the lab `npm test` commands to verify everything works.
+
+Refer to `AI-Prompt-Migration.md` for guidance on updating prompt templates.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@ Additional guides and phase planning documents for the CreatorCoreForge ecosyste
 - `PRACTICAL_PLAN.md` – initial TODO list across apps.
 - `PRODUCTION_ROADMAP.md` – high level approach for bringing every app to production.
 - `PHASE_EIGHT.md` – checklist of Phase 8 feature goals.
+- `ModuleMigrationGuide.md` – updating projects to use shared Phase 8 modules.


### PR DESCRIPTION
## Summary
- add a new ModuleMigrationGuide for updating apps to shared engines
- mark migration guide task complete
- list the new guide in docs and README

## Testing
- `swift test`
- `npm test` *(fails: jest not found)*
- `npm test` in VisualLab *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856919880d88321830f7f4bf6e85c52