### PR TITLE
Add shared NSFW database

### DIFF
--- a/Sources/CreatorCoreForge/NSFWContentManager.swift
+++ b/Sources/CreatorCoreForge/NSFWContentManager.swift
@@ -63,6 +63,13 @@ public final class NSFWContentManager: ObservableObject {
     public func logScene(chapter: String, label: String, intensity: NSFWIntensity) {
         let entry = NSFWScene(chapter: chapter, sceneLabel: label, intensity: intensity, timestamp: Date())
         nsfwSceneLog.append(entry)
+        let dbEntry = NSFWEntry(label: label,
+                                type: .text,
+                                tags: [chapter],
+                                timestamp: entry.timestamp,
+                                filePath: nil,
+                                notes: "Logged from NSFWContentManager")
+        NSFWDatabase.shared.add(dbEntry)
     }
 
     public func getRecentScenes(limit: Int = 10) -> [NSFWScene] {
@@ -154,6 +161,13 @@ public final class NSFWContentManager {
     public func logScene(chapter: String, label: String, intensity: NSFWIntensity) {
         let entry = NSFWScene(chapter: chapter, sceneLabel: label, intensity: intensity, timestamp: Date())
         nsfwSceneLog.append(entry)
+        let dbEntry = NSFWEntry(label: label,
+                                type: .text,
+                                tags: [chapter],
+                                timestamp: entry.timestamp,
+                                filePath: nil,
+                                notes: "Logged from NSFWContentManager")
+        NSFWDatabase.shared.add(dbEntry)
     }
 
     public func getRecentScenes(limit: Int = 10) -> [NSFWScene] {

--- a/Sources/CreatorCoreForge/NSFWDatabase.swift
+++ b/Sources/CreatorCoreForge/NSFWDatabase.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// Global NSFW entry used across all apps.
+public struct NSFWEntry: Codable, Identifiable {
+    public enum ContentType: String, Codable {
+        case text, audio, video, image
+    }
+
+    public var id: UUID = UUID()
+    public var label: String
+    public var type: ContentType
+    public var tags: [String]
+    public var timestamp: Date
+    public var filePath: String?
+    public var notes: String?
+}
+
+/// Lightweight JSON-backed database for NSFW entries.
+public final class NSFWDatabase {
+    public static let shared = NSFWDatabase()
+
+    private var entries: [NSFWEntry] = []
+    private let syncQueue = DispatchQueue(label: "nsfw.database.queue", attributes: .concurrent)
+    private let storeURL: URL
+
+    public init(directory: URL? = nil) {
+        let fm = FileManager.default
+        let dir = directory ?? fm.urls(for: .documentDirectory, in: .userDomainMask).first!
+        storeURL = dir.appendingPathComponent("nsfw_db.json")
+        loadFromDisk()
+    }
+
+    /// Add a new NSFW entry and persist it to disk.
+    public func add(_ entry: NSFWEntry) {
+        syncQueue.async(flags: .barrier) {
+            self.entries.append(entry)
+            self.saveToDisk()
+        }
+    }
+
+    /// Return all stored entries.
+    public func all() -> [NSFWEntry] {
+        var result: [NSFWEntry] = []
+        syncQueue.sync { result = entries }
+        return result
+    }
+
+    /// Search stored entries by keyword in label or tags.
+    public func search(_ keyword: String) -> [NSFWEntry] {
+        let lower = keyword.lowercased()
+        var result: [NSFWEntry] = []
+        syncQueue.sync {
+            result = entries.filter { entry in
+                entry.label.lowercased().contains(lower) ||
+                entry.tags.contains(where: { $0.lowercased().contains(lower) })
+            }
+        }
+        return result
+    }
+
+    private func saveToDisk() {
+        guard let data = try? JSONEncoder().encode(entries) else { return }
+        try? data.write(to: storeURL, options: .atomic)
+    }
+
+    private func loadFromDisk() {
+        if let data = try? Data(contentsOf: storeURL),
+           let arr = try? JSONDecoder().decode([NSFWEntry].self, from: data) {
+            entries = arr
+        } else {
+            entries = []
+        }
+    }
+}
+

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,3 +1,13 @@
 # Apps Directory
 
 This folder groups each major CreatorCoreForge application. Every app contains its own `README.md` and setup guides.
+
+## NSFW Database Integration
+Apps that enable NSFW features should import `NSFWDatabase` from the core package.
+This shared database keeps a log of all explicit scenes across the suite.
+
+Example usage:
+```swift
+let entry = NSFWEntry(label: "Prologue", type: .text, tags: ["Audio"], timestamp: Date())
+NSFWDatabase.shared.add(entry)
+```


### PR DESCRIPTION
## Summary
- add `NSFWDatabase` for global NSFW entries
- link `NSFWContentManager` to store scenes in the database
- document NSFW database integration for apps

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_6856937fae7483218b5a71a9205994a2