### PR TITLE
Add video topics dataset

### DIFF
--- a/docs/video_topics_database.json
+++ b/docs/video_topics_database.json
@@ -1,0 +1,89 @@
+{
+  "subjects": [
+    {
+      "name": "Pre-production",
+      "topics": [
+        "Scriptwriting",
+        "Storyboarding",
+        "Budgeting",
+        "Location Scouting",
+        "Casting",
+        "Scheduling"
+      ]
+    },
+    {
+      "name": "Production",
+      "topics": [
+        "Camera Operation",
+        "Lighting Techniques",
+        "Directing",
+        "Audio Capture",
+        "Set Design",
+        "Acting",
+        "Cinematography",
+        "On-set Safety"
+      ]
+    },
+    {
+      "name": "Post-production",
+      "topics": [
+        "Video Editing",
+        "Sound Design",
+        "Color Grading",
+        "Visual Effects",
+        "Animation",
+        "Motion Graphics",
+        "Audio Mixing",
+        "Subtitles and Captioning"
+      ]
+    },
+    {
+      "name": "Distribution",
+      "topics": [
+        "Video Platforms",
+        "Marketing Strategies",
+        "Monetization",
+        "Analytics",
+        "Archiving"
+      ]
+    },
+    {
+      "name": "Technology and Tools",
+      "topics": [
+        "Cameras and Lenses",
+        "Drones",
+        "Capture Cards",
+        "Editing Software",
+        "Render Engines",
+        "Storage Solutions",
+        "Codecs and Formats",
+        "Frame Rates",
+        "Streaming Protocols"
+      ]
+    },
+    {
+      "name": "Specialties",
+      "topics": [
+        "Documentary Filmmaking",
+        "Animation Production",
+        "Virtual Reality",
+        "Augmented Reality",
+        "Live Streaming",
+        "Short Form Content",
+        "Feature Films",
+        "Music Videos"
+      ]
+    },
+    {
+      "name": "Creative Techniques",
+      "topics": [
+        "Storytelling",
+        "Visual Composition",
+        "Editing Styles",
+        "Soundtrack Selection",
+        "Motion Capture",
+        "Compositing"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create `video_topics_database.json` listing subjects and topics for video development

## Testing
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856940f86948321b77cf9e2cfd4dbee