### PR TITLE
Add shared emotion database

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@
 - **EmotionalArcTracker:** Records emotion intensity for characters over time
 
 - **EmotionHeatmap:** Generates normalized emotion intensity heatmaps from text
+- **EmotionDatabase:** Shared dictionary of emotion records and synonyms used by
+  CoreForge Audio, Visual, Writer, and Mind for emotion cues
 
 - **NSFWMoodHeatmap:** Normalizes logged NSFW intensity levels for analytics
 

--- a/Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift
@@ -48,6 +48,11 @@ public struct CoreForgeAudioFeatures {
         return VoiceProfile(name: "Narrator", emotion: "neutral")
     }
 
+    /// Access the shared emotion database for additional emotion context.
+    public func emotionInfo(for label: String) -> EmotionRecord? {
+        EmotionDatabase.shared.record(for: label)
+    }
+
     private static func detectChapters(in text: String) -> [String] {
         let pattern = "(?i)chapter\\s+\\d+"
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [text] }

--- a/Sources/CreatorCoreForge/CoreForgeMind_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeMind_MissingFeatures.swift
@@ -21,3 +21,8 @@ public final class PrivateVault {
     public func save(key: String, value: String) { store[key] = value }
     public func fetch(key: String) -> String? { store[key] }
 }
+
+/// Utility access to the shared emotion database for wellness tracking.
+public func emotionInfo(for label: String) -> EmotionRecord? {
+    EmotionDatabase.shared.record(for: label)
+}

--- a/Sources/CreatorCoreForge/CoreForgeVisual_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeVisual_MissingFeatures.swift
@@ -76,6 +76,11 @@ public struct CoreForgeVisualFeatures {
         "Uploaded \(url.lastPathComponent) to \(platform)"
     }
 
+    /// Retrieve emotion details from the shared database for scene tuning.
+    public func emotionInfo(for label: String) -> EmotionRecord? {
+        EmotionDatabase.shared.record(for: label)
+    }
+
     #if canImport(AVFoundation)
     private static func makePixelBuffer(text: String, font: CTFont) -> CVPixelBuffer? {
         let attrs: [CFString: Any] = [

--- a/Sources/CreatorCoreForge/EmotionDatabase.swift
+++ b/Sources/CreatorCoreForge/EmotionDatabase.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Represents a single human emotion with synonyms and a general category.
+public struct EmotionRecord: Codable, Equatable {
+    public let name: String
+    public let synonyms: [String]
+    public let category: String
+
+    public init(name: String, synonyms: [String], category: String) {
+        self.name = name
+        self.synonyms = synonyms
+        self.category = category
+    }
+}
+
+/// In-memory database of common emotions shared across apps.
+public final class EmotionDatabase {
+    public static let shared = EmotionDatabase()
+
+    /// All emotion records loaded in memory.
+    public private(set) var records: [EmotionRecord] = EmotionDatabase.defaultRecords
+
+    public init() {}
+
+    /// Returns the emotion record matching the provided name or synonym.
+    public func record(for label: String) -> EmotionRecord? {
+        let lowered = label.lowercased()
+        return records.first { $0.name.lowercased() == lowered || $0.synonyms.contains(where: { $0.lowercased() == lowered }) }
+    }
+
+    /// Default set of human emotions with basic categories.
+    private static let defaultRecords: [EmotionRecord] = [
+        EmotionRecord(name: "joy", synonyms: ["happiness", "delight", "cheer"], category: "positive"),
+        EmotionRecord(name: "sadness", synonyms: ["sorrow", "melancholy", "gloom"], category: "negative"),
+        EmotionRecord(name: "anger", synonyms: ["rage", "fury", "irritation"], category: "negative"),
+        EmotionRecord(name: "fear", synonyms: ["anxiety", "terror", "dread"], category: "negative"),
+        EmotionRecord(name: "surprise", synonyms: ["astonishment", "amazement"], category: "neutral"),
+        EmotionRecord(name: "disgust", synonyms: ["revulsion", "contempt"], category: "negative"),
+        EmotionRecord(name: "trust", synonyms: ["confidence", "faith"], category: "positive"),
+        EmotionRecord(name: "anticipation", synonyms: ["expectation", "hope"], category: "positive"),
+        EmotionRecord(name: "love", synonyms: ["affection", "adoration"], category: "positive"),
+        EmotionRecord(name: "boredom", synonyms: ["indifference", "apathy"], category: "neutral"),
+        EmotionRecord(name: "calm", synonyms: ["peace", "serenity"], category: "positive"),
+        EmotionRecord(name: "confusion", synonyms: ["bewilderment", "perplexity"], category: "neutral"),
+        EmotionRecord(name: "envy", synonyms: ["jealousy", "resentment"], category: "negative"),
+        EmotionRecord(name: "guilt", synonyms: ["remorse", "shame"], category: "negative"),
+        EmotionRecord(name: "pride", synonyms: ["self-respect", "ego"], category: "positive"),
+        EmotionRecord(name: "relief", synonyms: ["release", "reassurance"], category: "positive"),
+        EmotionRecord(name: "nostalgia", synonyms: ["longing", "yearning"], category: "neutral"),
+        EmotionRecord(name: "hope", synonyms: ["optimism", "expectancy"], category: "positive"),
+        EmotionRecord(name: "shame", synonyms: ["humiliation", "embarrassment"], category: "negative"),
+        EmotionRecord(name: "loneliness", synonyms: ["isolation", "solitude"], category: "negative"),
+        EmotionRecord(name: "compassion", synonyms: ["empathy", "kindness"], category: "positive"),
+        EmotionRecord(name: "frustration", synonyms: ["annoyance", "irritation"], category: "negative"),
+        EmotionRecord(name: "gratitude", synonyms: ["thankfulness", "appreciation"], category: "positive"),
+        EmotionRecord(name: "admiration", synonyms: ["respect", "esteem"], category: "positive"),
+        EmotionRecord(name: "anxiety", synonyms: ["worry", "nervousness"], category: "negative"),
+        EmotionRecord(name: "curiosity", synonyms: ["inquisitiveness", "interest"], category: "positive"),
+        EmotionRecord(name: "despair", synonyms: ["hopelessness", "desperation"], category: "negative"),
+        EmotionRecord(name: "excitement", synonyms: ["thrill", "enthusiasm"], category: "positive"),
+        EmotionRecord(name: "sympathy", synonyms: ["pity", "understanding"], category: "positive"),
+        EmotionRecord(name: "awe", synonyms: ["wonder", "reverence"], category: "neutral"),
+        EmotionRecord(name: "embarrassment", synonyms: ["awkwardness", "mortification"], category: "negative"),
+        EmotionRecord(name: "contentment", synonyms: ["satisfaction", "ease"], category: "positive"),
+        EmotionRecord(name: "resentment", synonyms: ["bitterness", "grudge"], category: "negative")
+    ]
+}

--- a/Tests/CreatorCoreForgeTests/EmotionDatabaseTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionDatabaseTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class EmotionDatabaseTests: XCTestCase {
+    func testLookupByName() {
+        let db = EmotionDatabase()
+        let record = db.record(for: "joy")
+        XCTAssertEqual(record?.category, "positive")
+        XCTAssertTrue(record?.synonyms.contains("happiness") ?? false)
+    }
+
+    func testLookupBySynonym() {
+        let db = EmotionDatabase()
+        let record = db.record(for: "fury")
+        XCTAssertEqual(record?.name, "anger")
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmotionDatabase` with emotion definitions
- integrate emotion lookup into Audio, Visual, and Mind utility files
- document new database in README
- test `EmotionDatabase`

## Testing
- `swift test -l`

------
https://chatgpt.com/codex/tasks/task_e_685693634440832185a97ee3af3efb3c