### PR TITLE
Implement audio/visual phase one basics

### DIFF
--- a/Sources/CreatorCoreForge/BookImporter.swift
+++ b/Sources/CreatorCoreForge/BookImporter.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Result of importing a text file into chapters with metadata.
+public struct ImportedBook {
+    public let title: String
+    public let author: String?
+    public let chapters: [Chapter]
+
+    public init(title: String, author: String?, chapters: [Chapter]) {
+        self.title = title
+        self.author = author
+        self.chapters = chapters
+    }
+}
+
+/// Parses raw text into `Chapter` objects by blank lines.
+public struct ChapterParser {
+    public static func parse(_ text: String) -> [Chapter] {
+        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n")
+        let blocks = normalized.components(separatedBy: "\n\n")
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        var chapters: [Chapter] = []
+        var idx = 1
+        for b in blocks {
+            let lines = b.split(separator: "\n")
+            guard let first = lines.first else { continue }
+            var title = String(first).trimmingCharacters(in: .whitespaces)
+            var start = 1
+            if !title.lowercased().hasPrefix("chapter") {
+                title = "Chapter \(idx)"
+                start = 0
+            }
+            let body = lines.dropFirst(start).joined(separator: " ")
+            if body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { continue }
+            chapters.append(Chapter(title: title, text: body))
+            idx += 1
+        }
+        return chapters
+    }
+}
+
+/// Imports TXT, PDF, and EPUB files from disk.
+public final class BookImporter {
+    public init() {}
+
+    public func `import`(fileURL: URL) throws -> ImportedBook {
+        let ext = fileURL.pathExtension.lowercased()
+        let raw = try String(contentsOf: fileURL)
+        let meta = Self.extractMetadata(from: raw, fileName: fileURL.lastPathComponent)
+        let body = meta.body
+        let chapters: [Chapter]
+        switch ext {
+        case "txt":
+            chapters = ChapterParser.parse(body)
+        case "pdf", "epub":
+            chapters = [Chapter(title: "Chapter 1", text: body.replacingOccurrences(of: "\n", with: " "))]
+        default:
+            throw NSError(domain: "BookImporter", code: 1)
+        }
+        return ImportedBook(title: meta.title, author: meta.author, chapters: chapters)
+    }
+
+    private static func extractMetadata(from text: String, fileName: String) -> (title: String, author: String?, body: String) {
+        let lines = text.replacingOccurrences(of: "\r\n", with: "\n").split(separator: "\n")
+        var title = fileName.replacingOccurrences(of: "." + fileName.split(separator: ".").last!, with: "")
+        var author: String?
+        var index = 0
+        if index < lines.count, lines[index].lowercased().hasPrefix("title:") {
+            title = lines[index].dropFirst(6).trimmingCharacters(in: .whitespaces)
+            index += 1
+        } else if index < lines.count, lines[index].hasPrefix("#") {
+            title = lines[index].trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+            index += 1
+        }
+        if index < lines.count, lines[index].lowercased().hasPrefix("author:") {
+            author = lines[index].dropFirst(7).trimmingCharacters(in: .whitespaces)
+            index += 1
+        }
+        let body = lines.dropFirst(index).joined(separator: "\n")
+        return (title, author, body)
+    }
+}
+

--- a/Sources/CreatorCoreForge/ChapterDetector.swift
+++ b/Sources/CreatorCoreForge/ChapterDetector.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Location of a detected chapter within raw text.
+public struct ChapterBoundary {
+    public let title: String
+    public let range: Range<String.Index>
+
+    public init(title: String, range: Range<String.Index>) {
+        self.title = title
+        self.range = range
+    }
+}
+
+/// Detects chapter boundaries using simple heuristics.
+public struct ChapterDetector {
+    public static func detect(in text: String) -> [ChapterBoundary] {
+        let pattern = "(?i)chapter\\s+\\d+"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return [ChapterBoundary(title: "Chapter 1", range: text.startIndex..<text.endIndex)]
+        }
+        let nsrange = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = regex.matches(in: text, range: nsrange)
+        guard !matches.isEmpty else {
+            return [ChapterBoundary(title: "Chapter 1", range: text.startIndex..<text.endIndex)]
+        }
+        var boundaries: [ChapterBoundary] = []
+        var last = text.startIndex
+        for (idx, match) in matches.enumerated() {
+            let r = Range(match.range, in: text)!
+            if last < r.lowerBound {
+                let range = last..<r.lowerBound
+                let title = "Chapter \(idx)"
+                boundaries.append(ChapterBoundary(title: title, range: range))
+            }
+            last = r.lowerBound
+        }
+        let finalRange = last..<text.endIndex
+        boundaries.append(ChapterBoundary(title: "Chapter \(boundaries.count + 1)", range: finalRange))
+        return boundaries
+    }
+}
+

--- a/Sources/CreatorCoreForge/NSFWService.swift
+++ b/Sources/CreatorCoreForge/NSFWService.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Flags text containing simple NSFW keywords.
+public struct NSFWService {
+    private static let words = ["sex", "nude", "xxx"]
+
+    public init() {}
+
+    public func flag(text: String) -> Bool {
+        let pattern = "\\b(" + Self.words.joined(separator: "|") + ")\\b"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return false
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.firstMatch(in: text, range: range) != nil
+    }
+}
+

--- a/Sources/CreatorCoreForge/SegmentService.swift
+++ b/Sources/CreatorCoreForge/SegmentService.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Splits chapters into narration segments based on blank lines.
+public struct SegmentService {
+    public init() {}
+
+    public func segment(_ chapters: [Chapter]) -> [Segment] {
+        var segments: [Segment] = []
+        for chap in chapters {
+            let parts = chap.text.components(separatedBy: "\n\n")
+            for part in parts {
+                let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty { continue }
+                segments.append(Segment(text: trimmed))
+            }
+        }
+        return segments
+    }
+}
+

--- a/Sources/CreatorCoreForge/StoryboardPanel.swift
+++ b/Sources/CreatorCoreForge/StoryboardPanel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Simple panel representing a list of scenes.
+public struct StoryboardPanel {
+    private(set) var scenes: [String] = []
+    public init() {}
+
+    public mutating func addScene(_ scene: String) {
+        scenes.append(scene)
+    }
+
+    public mutating func moveScene(from index: Int, to newIndex: Int) {
+        guard scenes.indices.contains(index), scenes.indices.contains(newIndex) else { return }
+        let item = scenes.remove(at: index)
+        scenes.insert(item, at: newIndex)
+    }
+
+    public func list() -> [String] {
+        scenes
+    }
+}
+

--- a/Sources/CreatorCoreForge/StreamAssembler.swift
+++ b/Sources/CreatorCoreForge/StreamAssembler.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Combines audio blobs into a single data stream.
+public struct StreamAssembler {
+    public init() {}
+
+    public func assemble(_ blobs: [AudioBlob]) -> AudioBlob {
+        var data = Data()
+        for blob in blobs { data.append(blob) }
+        return data
+    }
+}
+

--- a/Sources/CreatorCoreForge/TTSService.swift
+++ b/Sources/CreatorCoreForge/TTSService.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public typealias AudioBlob = Data
+
+/// Simple TTS renderer that encodes text with a voice prefix.
+public struct TTSService {
+    public init() {}
+
+    public func renderSegment(_ segment: Segment, voiceId: String) -> AudioBlob {
+        let string = "voice:\(voiceId)\n\(segment.text)"
+        return Data(string.utf8)
+    }
+}
+

--- a/Sources/CreatorCoreForge/TimelineEditor.swift
+++ b/Sources/CreatorCoreForge/TimelineEditor.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Generic timeline editor for arranging clips.
+public final class TimelineEditor<Clip> {
+    private var clips: [Clip] = []
+    public init() {}
+
+    public func addClip(_ clip: Clip) {
+        clips.append(clip)
+    }
+
+    public func timeline() -> [Clip] {
+        clips
+    }
+}
+

--- a/Sources/CreatorCoreForge/VideoExportService.swift
+++ b/Sources/CreatorCoreForge/VideoExportService.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Minimal video export that packages frame names as a text blob.
+public final class VideoExportService {
+    public init() {}
+
+    public func exportVideo(frames: [String], format: String) -> Data {
+        let joined = frames.joined(separator: "\n")
+        return Data(joined.utf8)
+    }
+}
+

--- a/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AudioVisualPhaseOneTests: XCTestCase {
+    func testBookImporter() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("book.txt")
+        try "Title: Sample\nAuthor: A\nChapter 1\nHello".write(to: tmp, atomically: true, encoding: .utf8)
+        let importer = BookImporter()
+        let book = try importer.import(fileURL: tmp)
+        XCTAssertEqual(book.title, "Sample")
+        XCTAssertEqual(book.author, "A")
+        XCTAssertEqual(book.chapters.count, 1)
+    }
+
+    func testSegmentServiceAndTTS() {
+        let chapters = [Chapter(title: "C1", text: "A\n\nB")] 
+        let segs = SegmentService().segment(chapters)
+        XCTAssertEqual(segs.count, 2)
+        let tts = TTSService()
+        let blob = tts.renderSegment(segs[0], voiceId: "v1")
+        XCTAssertTrue(String(data: blob, encoding: .utf8)?.contains("voice:v1") ?? false)
+    }
+
+    func testStreamAssembler() {
+        let a = Data([0,1])
+        let b = Data([2])
+        let out = StreamAssembler().assemble([a,b])
+        XCTAssertEqual(out, Data([0,1,2]))
+    }
+
+    func testNSFWService() {
+        let svc = NSFWService()
+        XCTAssertTrue(svc.flag(text: "explicit sex scene"))
+        XCTAssertFalse(svc.flag(text: "hello"))
+    }
+
+    func testTimelineEditor() {
+        let editor = TimelineEditor<String>()
+        editor.addClip("a")
+        XCTAssertEqual(editor.timeline(), ["a"])
+    }
+
+    func testStoryboardPanel() {
+        var panel = StoryboardPanel()
+        panel.addScene("s1")
+        panel.addScene("s2")
+        panel.moveScene(from: 0, to: 1)
+        XCTAssertEqual(panel.list(), ["s2", "s1"])
+    }
+}
+


### PR DESCRIPTION
## Summary
- add BookImporter and chapter detection utilities
- split chapters into segments and render TTS blobs
- include NSFW flagging and stream assembly helpers
- add simple timeline and storyboard helpers
- provide minimal video export service
- test the new audio and visual components

## Testing
- `swift test --filter AudioVisualPhaseOneTests/testBookImporter`
- `swift test --filter AudioVisualPhaseOneTests/testSegmentServiceAndTTS`
- `swift test --filter AudioVisualPhaseOneTests/testStreamAssembler`
- `swift test --filter AudioVisualPhaseOneTests/testNSFWService`
- `swift test --filter AudioVisualPhaseOneTests/testTimelineEditor`
- `swift test --filter AudioVisualPhaseOneTests/testStoryboardPanel`
- `swift test --filter AudioVisualPhaseOneTests`

------
https://chatgpt.com/codex/tasks/task_e_6856966f01208321a5dfba24ad53eed7