### PR TITLE
feat: add async book importer

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
+++ b/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
@@ -1,17 +1,27 @@
 import Foundation
 
 /// Manages chapter-based audio playback with simple bookmarking support.
-public struct Chapter {
+public struct Chapter: Codable {
     /// Title of the chapter if known.
     public let title: String
     /// Raw text contents for narration or analysis.
     public let text: String
+    /// Order within the book. Defaults to zero when unspecified.
+    public let order: Int
+    /// Optional additional metadata for the chapter.
+    public var metadata: [String: String]?
     /// Optional URL to pre-rendered audio for playback.
     public var audioURL: String?
 
-    public init(title: String, text: String, audioURL: String? = nil) {
+    public init(title: String,
+                text: String,
+                order: Int = 0,
+                metadata: [String: String]? = nil,
+                audioURL: String? = nil) {
         self.title = title
         self.text = text
+        self.order = order
+        self.metadata = metadata
         self.audioURL = audioURL
     }
 }

--- a/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
@@ -2,14 +2,11 @@ import XCTest
 @testable import CreatorCoreForge
 
 final class AudioVisualPhaseOneTests: XCTestCase {
-    func testBookImporter() throws {
+    func testBookImporter() async throws {
         let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("book.txt")
-        try "Title: Sample\nAuthor: A\nChapter 1\nHello".write(to: tmp, atomically: true, encoding: .utf8)
-        let importer = BookImporter()
-        let book = try importer.import(fileURL: tmp)
-        XCTAssertEqual(book.title, "Sample")
-        XCTAssertEqual(book.author, "A")
-        XCTAssertEqual(book.chapters.count, 1)
+        try "Chapter 1\nHello".write(to: tmp, atomically: true, encoding: .utf8)
+        let chapters = try await BookImporter.importBook(from: tmp)
+        XCTAssertEqual(chapters.count, 1)
     }
 
     func testSegmentServiceAndTTS() {


### PR DESCRIPTION
## Summary
- extend Chapter struct with metadata fields
- add async BookImporter supporting TXT/PDF with PDFKit optional
- update AudioVisualPhaseOne tests for async importer

## Testing
- `npm test --silent` within VoiceLab
- `npm test --silent` within VisualLab
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685699d88a5883219b631f6400b72e34