### PR TITLE
Add undo and clear to MacroWorkflowEngine

### DIFF
--- a/Sources/CreatorCoreForge/MacroWorkflowEngine.swift
+++ b/Sources/CreatorCoreForge/MacroWorkflowEngine.swift
@@ -3,12 +3,29 @@ import Foundation
 /// Records and replays simple UI action macros.
 public final class MacroWorkflowEngine {
     private var actions: [String] = []
+
     public init() {}
 
+    /// Returns the number of recorded actions.
+    public var count: Int { actions.count }
+
+    /// Records a UI action for later playback.
     public func record(_ action: String) {
         actions.append(action)
     }
 
+    /// Removes the most recently recorded action and returns it.
+    @discardableResult
+    public func undo() -> String? {
+        actions.popLast()
+    }
+
+    /// Clears all recorded actions.
+    public func clear() {
+        actions.removeAll()
+    }
+
+    /// Returns the list of recorded actions in order.
     public func replay() -> [String] {
         actions
     }

--- a/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
@@ -67,7 +67,15 @@ final class PracticalPlanFeatureTests: XCTestCase {
     func testMacroWorkflowEngine() {
         let engine = MacroWorkflowEngine()
         engine.record("tap")
+        engine.record("swipe")
+        XCTAssertEqual(engine.replay(), ["tap", "swipe"])
+        XCTAssertEqual(engine.count, 2)
+        XCTAssertEqual(engine.undo(), "swipe")
         XCTAssertEqual(engine.replay(), ["tap"])
+        XCTAssertEqual(engine.count, 1)
+        engine.clear()
+        XCTAssertEqual(engine.replay(), [])
+        XCTAssertEqual(engine.count, 0)
     }
 
     func testExportProduction() {


### PR DESCRIPTION
## Summary
- extend MacroWorkflowEngine with undo, clear and count helpers
- test new MacroWorkflowEngine functionality

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856af57ac188321ac76d6331adf0285