### PR TITLE
Add placeholder Xcode projects

### DIFF
--- a/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeBloom/CoreForgeBloom.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeBloom/CoreForgeBloom.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeBuild/CoreForgeBuild.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeBuild/CoreForgeBuild.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeDNA/CoreForgeDNA.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeDNA/CoreForgeDNA.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeLeads/CoreForgeLeads.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeLeads/CoreForgeLeads.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeLearn/CoreForgeLearn.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeLearn/CoreForgeLearn.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeMarket/CoreForgeMarket.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeMarket/CoreForgeMarket.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeMind/CoreForgeMind.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeMind/CoreForgeMind.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeMusic/CoreForgeMusic.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeMusic/CoreForgeMusic.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeQuest/CoreForgeQuest.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeQuest/CoreForgeQuest.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeStudio/CoreForgeStudio.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeStudio/CoreForgeStudio.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeVisual/CoreForgeVisual.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeVisual/CoreForgeVisual.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeVoiceLab/CoreForgeVoiceLab.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeVoiceLab/CoreForgeVoiceLab.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}

--- a/apps/CoreForgeWriter/CoreForgeWriter.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeWriter/CoreForgeWriter.xcodeproj/project.pbxproj
@@ -1,0 +1,65 @@
+// !$*UTF8*$!
+{
+  archiveVersion = 1;
+  objectVersion = 56;
+  classes = {};
+  objects = {
+
+/* Begin PBXGroup section */
+    111111111111111111111113 = {
+      isa = PBXGroup;
+      children = (
+      );
+      sourceTree = "<group>";
+    };
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+    111111111111111111111111 /* Project object */ = {
+      isa = PBXProject;
+      attributes = {
+        LastUpgradeCheck = 1500;
+        ORGANIZATIONNAME = "";
+      };
+      buildConfigurationList = 111111111111111111111112 /* Build configuration list for PBXProject */;
+      compatibilityVersion = "Xcode 15.0";
+      developmentRegion = en;
+      hasScannedForEncodings = 0;
+      mainGroup = 111111111111111111111113;
+      targets = (
+      );
+      projectDirPath = "";
+      projectRoot = "";
+    };
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+    111111111111111111111114 /* Debug */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Debug;
+    };
+    111111111111111111111115 /* Release */ = {
+      isa = XCBuildConfiguration;
+      buildSettings = {
+      };
+      name = Release;
+    };
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+    111111111111111111111112 /* Build configuration list for PBXProject */ = {
+      isa = XCConfigurationList;
+      buildConfigurations = (
+        111111111111111111111114 /* Debug */,
+        111111111111111111111115 /* Release */,
+      );
+      defaultConfigurationIsVisible = 0;
+      defaultConfigurationName = Release;
+    };
+/* End XCConfigurationList section */
+
+  };
+  rootObject = 111111111111111111111111 /* Project object */;
+}


### PR DESCRIPTION
## Summary
- generate placeholder `.xcodeproj` folders across app directories

## Testing
- `swift test --enable-code-coverage`
- `cd VoiceLab && npm install && npm test`
- `cd VisualLab && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856b0793470832184cc36b97bfd5d90