### PR TITLE
Add universal media generator

### DIFF
--- a/Sources/CreatorCoreForge/UniversalMediaGenerator.swift
+++ b/Sources/CreatorCoreForge/UniversalMediaGenerator.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Generates audio, video, and action sequences from input text using
+/// existing pipelines. This is a lightweight coordinator for Phase 8
+/// experimentation.
+public struct GeneratedMedia {
+    public let audioTrack: String
+    public let clip: RenderedClip
+    public let actions: [String]
+    public init(audioTrack: String, clip: RenderedClip, actions: [String]) {
+        self.audioTrack = audioTrack
+        self.clip = clip
+        self.actions = actions
+    }
+}
+
+public final class UniversalMediaGenerator {
+    private let sceneGenerator: SceneGenerator
+    private let audioPipeline: AudioEffectsPipeline
+    private let videoPipeline: VideoEffectsPipeline
+    private let actionEngine: MacroWorkflowEngine
+
+    public init(sceneGenerator: SceneGenerator = SceneGenerator(),
+                audioPipeline: AudioEffectsPipeline = AudioEffectsPipeline(),
+                videoPipeline: VideoEffectsPipeline = VideoEffectsPipeline(),
+                actionEngine: MacroWorkflowEngine = MacroWorkflowEngine()) {
+        self.sceneGenerator = sceneGenerator
+        self.audioPipeline = audioPipeline
+        self.videoPipeline = videoPipeline
+        self.actionEngine = actionEngine
+    }
+
+    /// Generates processed audio, video frames, and recorded actions.
+    /// The return value is a `GeneratedMedia` struct containing a mixed
+    /// audio track label, a rendered clip placeholder, and the list of
+    /// actions recorded during generation.
+    public func generate(from text: String) -> GeneratedMedia {
+        // Scenes from text
+        let scenes = sceneGenerator.generateScenes(from: text)
+        actionEngine.record("generateScenes")
+
+        // Placeholder audio samples for each scene
+        let samples = scenes.enumerated().map { "sound\($0.offset)" }
+        var processed = audioPipeline.addEcho(to: samples)
+        processed = audioPipeline.shiftPitch(of: processed, factor: 1.0)
+        let audioTrack = audioPipeline.mix(samples: processed)
+        actionEngine.record("generateAudio")
+
+        // Placeholder frames for each scene
+        let frames = scenes.enumerated().map { "frame\($0.offset)" }
+        let faded = videoPipeline.applyFadeTransitions(to: frames)
+        let watermarked = videoPipeline.addWatermark(to: faded, watermark: "wm")
+        let clip = videoPipeline.composeVideo(frames: watermarked, audio: audioTrack)
+        actionEngine.record("generateVideo")
+
+        let actions = actionEngine.replay()
+        return GeneratedMedia(audioTrack: audioTrack, clip: clip, actions: actions)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/UniversalMediaGeneratorTests.swift
+++ b/Tests/CreatorCoreForgeTests/UniversalMediaGeneratorTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class UniversalMediaGeneratorTests: XCTestCase {
+    func testGenerate() {
+        let generator = UniversalMediaGenerator()
+        let media = generator.generate(from: "A. B.")
+        XCTAssertFalse(media.audioTrack.isEmpty)
+        XCTAssertFalse(media.clip.frames.isEmpty)
+        XCTAssertTrue(media.actions.contains("generateAudio"))
+        XCTAssertTrue(media.actions.contains("generateVideo"))
+    }
+}


### PR DESCRIPTION
## Summary
- add `UniversalMediaGenerator` for scenes, audio effects, video effects, and macro actions
- test new generator

## Testing
- `npm test --silent` in `VoiceLab`
- `npm test --silent` in `VisualLab`
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6856cbef4a6c8321915ce216ec891154