### PR TITLE
Fix TypeScript export conflicts

### DIFF
--- a/VisualLab/src/CacheService.ts
+++ b/VisualLab/src/CacheService.ts
@@ -1,13 +1,13 @@
-export interface VideoClip { frames: any[]; }
+export interface CachedVideoClip { frames: any[]; }
 
 export class CacheService {
-  private cache = new Map<string, VideoClip>();
+  private cache = new Map<string, CachedVideoClip>();
 
-  async cacheClip(id: string, clip: VideoClip): Promise<void> {
+  async cacheClip(id: string, clip: CachedVideoClip): Promise<void> {
     this.cache.set(id, clip);
   }
 
-  async loadClip(id: string): Promise<VideoClip | undefined> {
+  async loadClip(id: string): Promise<CachedVideoClip | undefined> {
     return this.cache.get(id);
   }
 }

--- a/VisualLab/src/DRMService.ts
+++ b/VisualLab/src/DRMService.ts
@@ -1,8 +1,11 @@
 export interface DRMConfig { watermark: string; }
-export interface VideoClip { frames: any[]; }
+export interface DRMVideoClip { frames: any[]; }
 
 export class DRMService {
-  async embedWatermark(video: VideoClip, config: DRMConfig): Promise<VideoClip> {
+  async embedWatermark(
+    video: DRMVideoClip,
+    config: DRMConfig
+  ): Promise<DRMVideoClip> {
     return video;
   }
 }

--- a/VisualLab/src/GPUVideoRenderer.ts
+++ b/VisualLab/src/GPUVideoRenderer.ts
@@ -1,14 +1,17 @@
-export interface RenderOptions {
+export interface RendererOptions {
   width: number;
   height: number;
 }
 
-export interface VideoClip {
+export interface GPUVideoClip {
   frames: any[];
 }
 
 export class GPUVideoRenderer {
-  async render(frames: any[], options: RenderOptions): Promise<VideoClip> {
+  async render(
+    frames: any[],
+    options: RendererOptions
+  ): Promise<GPUVideoClip> {
     return { frames };
   }
 }

--- a/VisualLab/src/LocalizationService.ts
+++ b/VisualLab/src/LocalizationService.ts
@@ -1,7 +1,10 @@
-export interface VideoClip { frames: any[]; }
+export interface LocalizationClip { frames: any[]; }
 
 export class LocalizationService {
-  async translateClip(clip: VideoClip, targetLang: string): Promise<VideoClip> {
+  async translateClip(
+    clip: LocalizationClip,
+    targetLang: string
+  ): Promise<LocalizationClip> {
     return clip;
   }
 }

--- a/VisualLab/src/PerformanceService.ts
+++ b/VisualLab/src/PerformanceService.ts
@@ -3,13 +3,13 @@ export interface DeviceSpecs {
   memory: number;
 }
 
-export interface RenderOptions {
+export interface PerformanceRenderOptions {
   resolution: number;
   bitrate: number;
 }
 
 export class PerformanceService {
-  adjustSettings(deviceInfo: DeviceSpecs): RenderOptions {
+  adjustSettings(deviceInfo: DeviceSpecs): PerformanceRenderOptions {
     const resolution = deviceInfo.gpuScore > 5 ? 1080 : 720;
     const bitrate = deviceInfo.memory > 4 ? 8000 : 4000;
     return { resolution, bitrate };

--- a/VisualLab/src/TileStreamer.ts
+++ b/VisualLab/src/TileStreamer.ts
@@ -1,8 +1,11 @@
-export interface VideoClip { frames: any[]; }
+export interface TileStreamClip { frames: any[]; }
 export interface Rect { x: number; y: number; width: number; height: number; }
 
 export class TileStreamer {
-  async streamTiles(clip: VideoClip, viewport: Rect): Promise<any[]> {
+  async streamTiles(
+    clip: TileStreamClip,
+    viewport: Rect
+  ): Promise<any[]> {
     return clip.frames;
   }
 }


### PR DESCRIPTION
## Summary
- rename video clip and render option interfaces in VisualLab
- adjust dependent services to use new types
- keep project build & tests happy

## Testing
- `npm test` within `VoiceLab`
- `npm test` within `VisualLab`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856d5954fb08321accdbf39452b3c55