### PR TITLE
Fix Windows installer build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,9 @@ screen files used for store submission.
 
 Cross-platform builds can be generated using `electron-builder`. Run
 `./scripts/build_desktop.sh` on macOS or Windows to produce `.dmg` and
-`.exe` installers for apps that include a `Desktop` project. See
+`.exe` installers for apps that include a `Desktop` project. macOS and Linux
+hosts must have `wine` and `mono` installed to generate the Windows builds.
+See
 `docs/CrossPlatformBuild.md` for details.
 
 Each app includes a `Desktop` folder with a starter Electron configuration for

--- a/docs/CrossPlatformBuild.md
+++ b/docs/CrossPlatformBuild.md
@@ -6,6 +6,7 @@ This document explains how to generate macOS `.dmg` and Windows `.exe` installer
 - Node.js 18 or later
 - `electron-builder` (installed automatically by the build script)
 - macOS and Windows build runners for signing and packaging
+- `wine` and `mono` (required on macOS/Linux hosts to build Windows installers)
 
 ## Usage
 Run the helper script from the repository root:

--- a/scripts/build_desktop.sh
+++ b/scripts/build_desktop.sh
@@ -32,8 +32,27 @@ for APP in "${APPS[@]}"; do
 
   PLATFORM="$(uname -s)"
   case "$PLATFORM" in
-    Darwin*) TARGETS="--mac --win" ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT) TARGETS="--win" ;;
+    Darwin*)
+      TARGETS="--mac"
+      if command -v wine >/dev/null 2>&1; then
+        TARGETS="$TARGETS --win"
+      else
+        echo "wine not found; Windows build skipped."
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT)
+      TARGETS="--win"
+      ;;
+    Linux*)
+      if command -v wine >/dev/null 2>&1; then
+        TARGETS="--win"
+      else
+        echo "Unsupported platform $PLATFORM. Skipping build."
+        popd >/dev/null
+        echo "-----"
+        continue
+      fi
+      ;;
     *)
       echo "Unsupported platform $PLATFORM. Skipping build."
       popd >/dev/null


### PR DESCRIPTION
## Summary
- improve `build_desktop.sh` so Windows builds only run when `wine` is available
- document `wine` and `mono` requirement for cross-platform builds
- mention the new requirement in README

## Testing
- `swift test -l`
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`


------
https://chatgpt.com/codex/tasks/task_e_6856d88c94c0832197b4625799b057df