### PR TITLE
Fix npm test dependency issue

### DIFF
--- a/VisualLab/package.json
+++ b/VisualLab/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
+    "pretest": "npm install",
     "build": "tsc",
     "test": "cross-env TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm test/index.test.ts && cross-env TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm test/newFeatures.test.ts"
   },

--- a/VoiceLab/package.json
+++ b/VoiceLab/package.json
@@ -3,11 +3,12 @@
   "version": "1.0.0",
   "type": "module",
   "main": "dist/index.js",
-  "scripts": {
-    "build": "tsc",
-    "test": "rimraf dist && jest",
-    "lint": "eslint 'src/**/*.{ts,tsx}'"
-  },
+    "scripts": {
+    "pretest": "npm install",
+      "build": "tsc",
+      "test": "rimraf dist && jest",
+      "lint": "eslint 'src/**/*.{ts,tsx}'"
+    },
   "devDependencies": {
     "@types/jest": "^29.5.4",
     "@types/react": "^19.1.8",


### PR DESCRIPTION
## Summary
- ensure VoiceLab and VisualLab install deps before running tests

## Testing
- `npm test` in VoiceLab
- `npm test` in VisualLab
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856da37d7d88321bddfdd4e72e6bcca