### PR TITLE
Add LocalAI sentiment analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ---
 
 ## 🔧 Technology Stack
-- LocalAIEngine Pro – local text engine with embeddings and summarization
+- LocalAIEngine Pro – local text engine with embeddings, summarization, and simple sentiment analysis
 - LocalVoiceAI Advanced Mode – offline voice cloning with emotion control
 - FusionEngine™ (modular adaptive AI framework)
 - QuantumConnector™ (real/simulated quantum support)
@@ -172,7 +172,7 @@
 - **FusionEngine™:** Master AI layer handling:
   - Contextual memory, parallel cores, emotional logic, sandbox AI
 - **LocalVoiceAI:** Full ElevenLabs replacement with advanced cloning and emotion modulation. Includes offline voice cloning and synthesis APIs.
-- **LocalAIEngine Pro:** OpenAI-free LLM for text, dialogue, logic, and local summarization.
+ - **LocalAIEngine Pro:** OpenAI-free LLM for text, dialogue, logic, local summarization, and basic sentiment analysis.
 - **QuantumConnector:** Optional quantum computing toggle
 - **Virality Engine:** Trend detector, loop optimizer, replay bait, shock factor enhancer
   - Now implemented as a shared module so every app can analyze trending content

--- a/Sources/CreatorCoreForge/LocalAIEnginePro.swift
+++ b/Sources/CreatorCoreForge/LocalAIEnginePro.swift
@@ -72,4 +72,24 @@ public final class LocalAIEnginePro {
             completion(.success(String(bestSentence).trimmingCharacters(in: .whitespacesAndNewlines)))
         }
     }
+
+    /// Very small sentiment analyzer used for demos. Counts positive and
+    /// negative keywords and returns the dominant sentiment.
+    public enum Sentiment: String {
+        case positive, negative, neutral
+    }
+
+    public func analyzeSentiment(_ text: String) -> Sentiment {
+        let positives: Set<String> = ["good", "great", "excellent", "amazing", "wonderful", "positive"]
+        let negatives: Set<String> = ["bad", "terrible", "awful", "horrible", "negative", "poor"]
+
+        var score = 0
+        for word in text.lowercased().split(whereSeparator: { !$0.isLetter }) {
+            if positives.contains(String(word)) { score += 1 }
+            if negatives.contains(String(word)) { score -= 1 }
+        }
+        if score > 0 { return .positive }
+        if score < 0 { return .negative }
+        return .neutral
+    }
 }

--- a/Tests/CreatorCoreForgeTests/LocalAIEngineProTests.swift
+++ b/Tests/CreatorCoreForgeTests/LocalAIEngineProTests.swift
@@ -47,4 +47,16 @@ final class LocalAIEngineProTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1)
     }
+
+    func testAnalyzeSentimentDetectsPositive() {
+        let engine = LocalAIEnginePro()
+        let sentiment = engine.analyzeSentiment("This is great and wonderful")
+        XCTAssertEqual(sentiment, .positive)
+    }
+
+    func testAnalyzeSentimentDetectsNegative() {
+        let engine = LocalAIEnginePro()
+        let sentiment = engine.analyzeSentiment("This is awful and terrible")
+        XCTAssertEqual(sentiment, .negative)
+    }
 }


### PR DESCRIPTION
## Summary
- extend `LocalAIEnginePro` with a simple sentiment analyzer
- test new sentiment analyzer in `LocalAIEngineProTests`
- document sentiment capability in README

## Testing
- `swift test 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6856e93878908321afd287093cf7d5fa