### PR TITLE
Add missing CoreForge module stubs

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeStudio_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeStudio_MissingFeatures.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct SmartCameraDirector {
+    public init() {}
+    public func suggestAngles(for scene: String) -> [String] {
+        guard !scene.isEmpty else { return [] }
+        return ["wide", "close-up", "pan"]
+    }
+}
+
+public struct WhatIfCutsceneMode {
+    public init() {}
+    public func alternateScenes(scene: String) -> [String] {
+        [scene, "What if \(scene)?"]
+    }
+}
+
+public struct AutoPublishPipeline {
+    public init() {}
+    public func publish(video url: URL) -> String {
+        "Published \(url.lastPathComponent)"
+    }
+}

--- a/Sources/CreatorCoreForge/CoreForgeWriter_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeWriter_MissingFeatures.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct SeriesMemoryTracker {
+    private var arcs: [String: [String]] = [:]
+    public init() {}
+    public mutating func record(book: String, events: [String]) {
+        arcs[book] = events
+    }
+    public func allEvents() -> [String] {
+        arcs.values.flatMap { $0 }
+    }
+}
+
+public struct PromoCodeHandler {
+    public init() {}
+    public func apply(code: String, to total: Double) -> Double {
+        if code.lowercased().hasPrefix("free") {
+            return 0
+        }
+        return max(total - 5, 0)
+    }
+}
+
+public struct WritingMoodTuner {
+    public init() {}
+    public func tune(text: String, mood: String) -> String {
+        "\(mood): \(text)"
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
@@ -188,4 +188,24 @@ final class PracticalPlanFeatureTests: XCTestCase {
         XCTAssertEqual(team.trades.count, 1)
         XCTAssertTrue(BotMarketplace().publish(bot: "bot"))
     }
+
+    func testWriterFeatures() {
+        var tracker = SeriesMemoryTracker()
+        tracker.record(book: "Book1", events: ["A"])
+        XCTAssertEqual(tracker.allEvents(), ["A"])
+        let handler = PromoCodeHandler()
+        XCTAssertEqual(handler.apply(code: "FREE100", to: 10), 0)
+        let tuner = WritingMoodTuner()
+        XCTAssertEqual(tuner.tune(text: "Hello", mood: "Happy"), "Happy: Hello")
+    }
+
+    func testStudioFeatures() {
+        let director = SmartCameraDirector()
+        XCTAssertEqual(director.suggestAngles(for: "scene").count, 3)
+        let alt = WhatIfCutsceneMode().alternateScenes(scene: "Scene1")
+        XCTAssertEqual(alt.last, "What if Scene1?")
+        let pipeline = AutoPublishPipeline()
+        let url = URL(fileURLWithPath: "video.mp4")
+        XCTAssertTrue(pipeline.publish(video: url).contains("video.mp4"))
+    }
 }


### PR DESCRIPTION
## Summary
- implement placeholder features for CoreForge Writer
- implement placeholder features for CoreForge Studio
- test new Writer and Studio stubs

## Testing
- `swift test -q`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856e88a893083219f731373be2fa869