### PR TITLE
Add global tasks summary generator

### DIFF
--- a/docs/GLOBAL_TASK_SUMMARY.md
+++ b/docs/GLOBAL_TASK_SUMMARY.md
@@ -1,0 +1,179 @@
+# Global Task Summary
+
+## Tests
+- Expand coverage for AI engines
+- Ensure continuous integration runs pass
+- Add regression tests for bug fixes
+
+## VoiceLab
+- Ensure voice training scripts run via CI
+- Keep React components typed and tested
+- Integrate with OpenAI service
+- Document new APIs
+
+## apps
+- Keep each subfolder in sync with master roadmap
+- Maintain per-app AGENTS.md files
+- Coordinate shared assets and templates
+
+## apps/CoreForgeBloom
+- Cycle tracking and predictions
+- Sexual wellness insights and reminders
+- Private vault with consent logs
+- Wearable data integration
+- Finalize production UI components
+
+## apps/CoreForgeBuild
+- Pull code and plugins from public sources (Codex)
+- Next-gen AI reasoning engine for debugging and enhancements (Codex)
+- Monetization logic builder (subscriptions, IAPs) (Codex)
+- Finalize production UI components
+
+## apps/CoreForgeDNA
+- Character DNA tree and visualization
+- Memory linking across apps
+- Export and import DNA profiles
+- Multiverse DNA merges and comparisons
+- Complete `.pbxproj` project file
+
+## apps/CoreForgeLeads
+- Fix and complete the `.pbxproj` project file (Codex)
+- Finalize production UI components
+
+## apps/CoreForgeLearn
+- Curriculum designer and quiz builder
+- AI tutor and progress analytics
+- Course marketplace and user sharing
+- Offline mode with cross-device sync
+
+## apps/CoreForgeMarket
+- Fully functional AI trading, alerts, analytics, multi-platform
+- Persistent memory, multi-strategy, social trading, and dashboards
+- Compliance, risk management, and white label/enterprise features
+- Real-time bot marketplace and plugin extension
+- Portfolio and analytics dashboards
+- Settings for risk, strategy, notifications
+- Dark/light mode, accessibility
+- Copy trading, social sharing, leaderboards
+- Alerts, notifications, trade confirmation UI
+- LocalAI, plugin modules, secure API keys
+- GDPR, CCPA, KYC/AML compliance
+- Firebase/Firestore: Auth, Data, Analytics
+- Auto-updater, platform config, app store compliance
+- Export: CSV, PDF, JSON
+- All platform project files
+- UI/UX (all platforms)
+- Performance, compliance, risk, security
+- GitHub Actions, tagging, changelogs, auto-deploy
+- README.md, APISetup.md, PromptTemplates.md, DeveloperSetup.md
+- Quantum/AI hybrid mode, parallel simulation, anomaly detection
+- Multibrain risk/speed/profit settings
+- Team/group trading, portfolio sharing, leaderboards
+- Marketplace for bots, plugins, signals, analytics
+- API for external tools, compliance/legal automation
+- All platform project files
+- Final UI polish, onboarding, tutorial flows
+- Full CI/CD deployment test, compliance review
+
+## apps/CoreForgeMind
+- Daily mood journal with AI analysis
+- Guided meditation and soundscapes
+- Secure vault for private entries
+- Finalize production UI components
+
+## apps/CoreForgeMusic
+- Voice cloning & AI vocal production (Codex)
+- Commercial export + label pitch toolkit (Codex)
+- Fix and complete the `.pbxproj` project file (Codex)
+- Finalize production UI components
+
+## apps/CoreForgeQuest
+- Procedural challenge generator
+- Multiplayer events and leaderboards
+- Reward marketplace for avatars and items
+- Cross-platform progress sync
+- Finalize production UI components
+
+## apps/CoreForgeStudio
+- Enable "What If" cutscene mode (Codex)
+- Fix and complete the `.pbxproj` project file (Codex)
+- Finalize production UI components
+- Smart wardrobe generator per scene tone
+- AI casting director tool (fictional actor/voice matching)
+- Fan cameo generator (render fan avatars into scenes)
+- Scene lighting synced to emotion
+- Hybrid visual style merger (anime/noir/fantasy combos)
+- Directorial note system for each scene or shot
+- Action rhythm controller (tempo pacing for dynamic scenes)
+- Audiovisual director diary (scene logs)
+- Subtitle dialect localizer (slang, accents, formal, etc.)
+- Trigger warning detector (auto flag sensitive content)
+- Overlay FX editor for text and post-processing
+- Location soundscape auto-generator
+- Emotion layer system (alternate tone variants per scene)
+- Scene performance estimator (views, replays, saves)
+- Alternate ending generator
+- Interactive video QTE (viewer-triggered choices)
+- Self-rating engine (scene quality based on AI criteria)
+- Replay prediction engine (likely rewatch scenes)
+- Add AI Scene Editor Timeline View
+- Build Smart Camera Direction AI (zoom/pan/hold)
+- Add Lip Sync + Voice Sync to Visuals
+- Auto-add crowd and ambient SFX
+- Enable Style Export: Anime, Noir, Realistic, Fantasy
+- Build Emotion Arc Visualizer for cinematic flow
+- Add Live Dubbing Room + Creator Voice Import
+- Add What-If Mode for branching episode possibilities
+- Create Auto-Publish pipeline to YouTube/TikTok with metadata
+- Auto-generate Trailer + Behind-the-Scenes packs
+- Add voice/scene-to-video alignment overlays
+
+## apps/CoreForgeVisual
+- UI/UX interaction tests (all platforms)
+- Stress and performance tests (ultra-long video, multi-scene)
+- Accessibility validation (subtitles, voiceover, visual clarity)
+
+## apps/CoreForgeVoiceLab
+- Voice recording and analysis tools
+- Training pipeline for custom voices
+- Quality metrics and tuning controls
+- Export to CoreForge Audio or Music
+- Finalize production UI components
+
+## apps/CoreForgeWriter
+- Finalize production UI components
+- Scene temperature dial for delivery mood (cold/neutral/hot)
+- Meta writing mode (4th-wall awareness)
+- Book-to-song interlude generator
+- Dual-edit co-author editor with live AI collaboration
+- Timeline visualizer of all story events
+- Serialized release engine (auto episodic drop)
+- Historical time period checker
+- Romance path visual heatmap
+- Real dialogue tone checker (based on real speech data)
+- Tag/tracker for literary symbols and metaphors
+- Legacy continuation mode (generate from unfinished stories)
+- Reverse plot planner (end-first logic fill-in)
+- Tone lock system to maintain story feel
+- Genre rewrite engine (sci-fi → noir, etc.)
+- Hidden bonus chapter unlock engine
+- Book-to-NFT or collectible printable setup
+- Monetization-split tracking per co-author
+- Accessibility scoring and feedback panel
+- Emotional writing boost generator (mood-based prompts)
+- Add Genre Mimicry Engine and Thematic Analyzer
+- Build AI outline → full manuscript generator
+- Add writing mood tuner (slow burn, fast-paced, dark, comedic)
+- Build AI Sandbox co-author tool
+- Add auto-expand subplots + side character arcs
+- Add Royalty-Free Illustration bundle creator
+- Embed Booktok Trailer Generator + auto-caption tool
+- Integrate reader relatability + pacing metrics
+- Enable Book-to-Pitch feature (TV/Film pitch toolkit)
+- Export script to CoreForge Studio with assigned voices
+
+## fastlane
+- Maintain Fastfile lanes for all apps
+- Update ExportOptions.plist for new entitlements
+- Document usage in README
+

--- a/scripts/aggregate_tasks.py
+++ b/scripts/aggregate_tasks.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import os
+import re
+import argparse
+
+TASK_PATTERN = re.compile(r"^-\s*\[ \]\s*(.+)")
+
+
+def parse_tasks(agent_path: str):
+    tasks = []
+    with open(agent_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            match = TASK_PATTERN.match(line.strip())
+            if match:
+                tasks.append(match.group(1))
+    return tasks
+
+
+def aggregate_tasks(repo_root: str):
+    all_tasks = {}
+    for root, dirs, files in os.walk(repo_root):
+        if 'AGENTS.md' in files:
+            path = os.path.join(root, 'AGENTS.md')
+            tasks = parse_tasks(path)
+            if tasks:
+                rel = os.path.relpath(root, repo_root)
+                all_tasks[rel] = tasks
+    return all_tasks
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Aggregate open tasks from AGENTS.md files.')
+    parser.add_argument('repo_root', nargs='?', default='.')
+    parser.add_argument('-o', '--output', default='docs/GLOBAL_TASK_SUMMARY.md')
+    args = parser.parse_args()
+
+    tasks_map = aggregate_tasks(os.path.abspath(args.repo_root))
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        f.write('# Global Task Summary\n\n')
+        for section in sorted(tasks_map.keys()):
+            f.write(f'## {section}\n')
+            for task in tasks_map[section]:
+                f.write(f'- {task}\n')
+            f.write('\n')
+    print(f'Generated {args.output}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create `aggregate_tasks.py` to collect open tasks from all `AGENTS.md` files
- generate `docs/GLOBAL_TASK_SUMMARY.md` using the new script

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6856f7bbcdb48321a5b08df17ee644b4