### PR TITLE
Add OpenAI and ElevenLabs integration

### DIFF
--- a/OpenAI-Integration.md
+++ b/OpenAI-Integration.md
@@ -55,3 +55,11 @@ the repository.
 ## Multi-App Interface
 All applications now include `OpenAIService` and `PromptTemplateLoader` for standardized prompts. See `docs/AI-Prompt-Migration.md` for migration steps.
 For local development copy `.env.example` to `.env` and supply your `OPENAI_API_KEY`. This file is ignored by git.
+
+### Electron/Desktop Apps
+Electron-based apps now import a shared `scripts/ai.js` module which exposes
+`generateText` and `synthesizeSpeech` helpers. These functions call the OpenAI
+Chat Completions API and ElevenLabs TTS API respectively using environment
+variables `OPENAI_API_KEY` and `ELEVEN_API_KEY`. Each desktop app's `main.js`
+demonstrates a basic invocation on launch. This ensures OpenAI and ElevenLabs
+services are available across all platforms.

--- a/apps/CoreForgeBloom/Desktop/main.js
+++ b/apps/CoreForgeBloom/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeBloom');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeBuild/Desktop/main.js
+++ b/apps/CoreForgeBuild/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeBuild');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeDNA/Desktop/main.js
+++ b/apps/CoreForgeDNA/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeDNA');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeLearn/Desktop/main.js
+++ b/apps/CoreForgeLearn/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeLearn');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeMind/Desktop/main.js
+++ b/apps/CoreForgeMind/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeMind');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeQuest/Desktop/main.js
+++ b/apps/CoreForgeQuest/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeQuest');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/apps/CoreForgeVoiceLab/Desktop/main.js
+++ b/apps/CoreForgeVoiceLab/Desktop/main.js
@@ -1,6 +1,23 @@
 const { app, BrowserWindow } = require('electron');
+const { generateText, synthesizeSpeech } = require('../../scripts/ai');
+
 function createWindow() {
   const win = new BrowserWindow({ width: 800, height: 600 });
   win.loadFile('index.html');
 }
-app.whenReady().then(createWindow);
+
+async function demo() {
+  try {
+    const text = await generateText('Hello from CoreForgeVoiceLab');
+    console.log('OpenAI:', text);
+    const audio = await synthesizeSpeech(text, '21m00Tcm4TlvDq8ikWAM');
+    console.log('ElevenLabs bytes:', audio.length);
+  } catch (err) {
+    console.error('AI error:', err.message);
+  }
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  demo();
+});

--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -1,0 +1,74 @@
+const https = require('https');
+
+function requestJSON(options, data) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, res => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          try {
+            resolve(JSON.parse(body));
+          } catch (err) {
+            reject(err);
+          }
+        } else {
+          reject(new Error(`Request failed ${res.statusCode} ${body}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    if (data) req.write(JSON.stringify(data));
+    req.end();
+  });
+}
+
+async function generateText(prompt, apiKey = process.env.OPENAI_API_KEY) {
+  if (!apiKey) throw new Error('OPENAI_API_KEY missing');
+  const options = {
+    hostname: 'api.openai.com',
+    path: '/v1/chat/completions',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    }
+  };
+  const data = {
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: prompt }]
+  };
+  const res = await requestJSON(options, data);
+  return res.choices && res.choices[0].message.content;
+}
+
+async function synthesizeSpeech(text, voiceID, apiKey = process.env.ELEVEN_API_KEY) {
+  if (!apiKey) throw new Error('ELEVEN_API_KEY missing');
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.elevenlabs.io',
+      path: `/v1/text-to-speech/${voiceID}`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      }
+    };
+    const req = https.request(options, res => {
+      const chunks = [];
+      res.on('data', c => chunks.push(c));
+      res.on('end', () => {
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          resolve(Buffer.concat(chunks));
+        } else {
+          reject(new Error(`Request failed ${res.statusCode}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(JSON.stringify({ text }));
+    req.end();
+  });
+}
+
+module.exports = { generateText, synthesizeSpeech };


### PR DESCRIPTION
## Summary
- add shared `scripts/ai.js` wrapper for OpenAI and ElevenLabs APIs
- integrate new helpers into all desktop apps
- document electron integration in `OpenAI-Integration.md`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6856f77785c88321beeab35b978221f1