### PR TITLE
Add LocalOpenAIReplacement guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ For production releases, trigger `upload-appstore.yml` which calls the
 `build_and_deliver` lane to submit the apps directly to App Store Connect.
 
 See `docs/AI-Prompt-Migration.md` for integrating the new OpenAI prompt interface across apps.
+See `docs/LocalOpenAIReplacement.md` for a primer on using the LocalAI engines to mimic OpenAI features without an internet connection.
 See `docs/VoiceTrainerGuide.md` for using the local voice training engine.
 See `docs/ModuleMigrationGuide.md` for adopting shared Phase 8 modules across apps.
 All apps now include a `VideoShareManager` for posting generated videos directly to social media.

--- a/docs/LocalOpenAIReplacement.md
+++ b/docs/LocalOpenAIReplacement.md
@@ -1,0 +1,29 @@
+# Local OpenAI Replacement Guide
+
+This guide explains how CreatorCoreForge provides OpenAI–level capabilities entirely offline through its built‑in modules. Use these steps to enable the same features across every app without relying on external APIs.
+
+## Core Modules
+
+- **LocalAIEnginePro** – Handles text generation, summarization, embeddings, sentiment analysis, and multilingual chat completions. Enable this engine by setting `USE_LOCAL_AI=1` in your environment.
+- **LocalVoiceAI** – Performs voice cloning and speech synthesis locally with emotion control.
+- **FusionEngine** – Routes prompts to either the local engines or remote services. When `USE_LOCAL_AI` is set, FusionEngine automatically selects the offline modules.
+- **AIStateTracker** – Maintains short‑term memory and context so prompts remain consistent across sessions.
+- **VoiceTrainer** – Allows custom voice model training completely offline.
+
+## Integration Steps
+
+1. Add `CreatorCoreForge` as a package dependency and import the shared modules in your app.
+2. Set the environment variable `USE_LOCAL_AI=1` before building or running tests.
+3. Replace direct `OpenAIService` calls with `FusionEngine` as described in `ModuleMigrationGuide.md`.
+4. Use `LocalVoiceAI` for speech synthesis and cloning tasks.
+5. Run `swift test` and `npm test` to confirm the offline engines are working as expected.
+
+## Features Enabled
+
+- Chat and completion style responses
+- Text summarization and embeddings queries
+- Local sentiment and emotion analysis
+- Voice generation with emotion modulation
+- Cross‑app memory via `VoiceMemoryManager` and `AIStateTracker`
+
+With these modules enabled, every CreatorCoreForge application can replicate the standard OpenAI workflow while remaining fully functional without internet access.


### PR DESCRIPTION
## Summary
- document how to use LocalAIEnginePro as an offline replacement for OpenAI
- crosslink the new guide in the main README

## Testing
- `swift test`
- `npm test` in VoiceLab
- `npm test` in VisualLab

------
https://chatgpt.com/codex/tasks/task_e_6856f94e87148321a933ab8eb6e958e9