### PR TITLE
Add SocialMediaManager and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ See `docs/AI-Prompt-Migration.md` for integrating the new OpenAI prompt interfac
 See `docs/VoiceTrainerGuide.md` for using the local voice training engine.
 See `docs/ModuleMigrationGuide.md` for adopting shared Phase 8 modules across apps.
 All apps now include a `VideoShareManager` for posting generated videos directly to social media.
+The new `SocialMediaManager` module lets apps connect user accounts and post text updates or other content programmatically.
 An accompanying `VideoEffectsPipeline` adds fade transitions and watermarking so every generated clip looks professional across apps.
 The new `AudioEffectsPipeline` provides echo and pitch-shift utilities so exported audio sounds consistent across apps.
 The new `FusionEngine` wrapper automatically selects between `LocalAIEnginePro` and `OpenAIService` for each app, enabling offline-first development when `USE_LOCAL_AI` is set. It now supports contextual memory, parallel execution across multiple engines, emotion tracking, sandbox mode for isolated testing, cross-app voice memory, on-device summarization, and quick scene generation helpers.

--- a/Sources/CreatorCoreForge/SocialMediaManager.swift
+++ b/Sources/CreatorCoreForge/SocialMediaManager.swift
@@ -1,0 +1,31 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Connects to social media endpoints and posts updates.
+public final class SocialMediaManager {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    /// Establish a connection using an authentication token. Returns `true` if the token is non-empty.
+    public func connect(token: String, completion: @escaping (Bool) -> Void) {
+        completion(!token.isEmpty)
+    }
+
+    /// Post an update to the specified endpoint with the given token.
+    /// Returns `true` when the HTTP status code is 200.
+    public func postUpdate(_ text: String, to endpoint: URL, token: String, completion: @escaping (Bool) -> Void) {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try? JSONEncoder().encode(["message": text])
+        session.dataTask(with: request) { _, response, _ in
+            let success = (response as? HTTPURLResponse)?.statusCode == 200
+            completion(success)
+        }.resume()
+    }
+}

--- a/Tests/CreatorCoreForgeTests/SocialMediaManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/SocialMediaManagerTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import CreatorCoreForge
+
+final class SocialMediaManagerTests: XCTestCase {
+    private class MockURLProtocol: URLProtocol {
+        static var statusCode: Int = 200
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            let response = HTTPURLResponse(url: request.url!, statusCode: Self.statusCode, httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    func testPostUpdateSuccess() {
+        MockURLProtocol.statusCode = 200
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let manager = SocialMediaManager(session: URLSession(configuration: config))
+        let exp = expectation(description: "post")
+        manager.postUpdate("hello", to: URL(string: "https://example.com")!, token: "t") { success in
+            XCTAssertTrue(success)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testPostUpdateFailure() {
+        MockURLProtocol.statusCode = 400
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let manager = SocialMediaManager(session: URLSession(configuration: config))
+        let exp = expectation(description: "post")
+        manager.postUpdate("fail", to: URL(string: "https://example.com")!, token: "t") { success in
+            XCTAssertFalse(success)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}


### PR DESCRIPTION
## Summary
- add `SocialMediaManager` module for connecting accounts and posting updates
- document new social media module in the README
- cover posting logic with unit tests

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6856f97613ec8321ba16bdf3d0fd39cb