### PR TITLE
Add offline ElevenLabs client

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@
 - **FusionEngine™:** Master AI layer handling:
   - Contextual memory, parallel cores, emotional logic, sandbox AI
 - **LocalVoiceAI:** Full ElevenLabs replacement with advanced cloning and emotion modulation. Includes offline voice cloning and synthesis APIs.
+- **LocalElevenLabsClient:** Mirrors the ElevenLabs API surface to run entirely offline by delegating to `LocalVoiceAI`.
  - **LocalAIEngine Pro:** OpenAI-free LLM for text, dialogue, logic, local summarization, and basic sentiment analysis.
 - **QuantumConnector:** Optional quantum computing toggle
 - **Virality Engine:** Trend detector, loop optimizer, replay bait, shock factor enhancer

--- a/Sources/CreatorCoreForge/LocalElevenLabsClient.swift
+++ b/Sources/CreatorCoreForge/LocalElevenLabsClient.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Offline replacement for `ElevenLabsClient` using `LocalVoiceAI`.
+/// Provides a minimal subset of ElevenLabs-style APIs without any
+/// network access. Voices can be added at runtime and synthesis is
+/// performed locally via `LocalVoiceAI`.
+public struct LocalElevenLabsClient {
+    private var voices: [String: VoiceProfile]
+    private let engine = LocalVoiceAI()
+
+    /// Creates the client with an optional array of voices.
+    public init(voices: [VoiceProfile] = [VoiceProfile(name: "Default")]) {
+        self.voices = Dictionary(uniqueKeysWithValues: voices.map { ($0.id, $0) })
+    }
+
+    /// Returns all available voices.
+    public func listVoices() -> [VoiceProfile] {
+        Array(voices.values)
+    }
+
+    /// Fetches info for a specific voice id if present.
+    public func voiceInfo(id: String) -> VoiceProfile? {
+        voices[id]
+    }
+
+    /// Synthesizes the provided text using the stored voice profile.
+    public func synthesize(text: String, voiceID: String, completion: @escaping (Result<Data, Error>) -> Void) {
+        guard let profile = voices[voiceID] else {
+            completion(.failure(NSError(domain: "LocalElevenLabs", code: -1)))
+            return
+        }
+        engine.synthesize(text: text, with: profile, completion: completion)
+    }
+
+    /// Adds a new voice to the local catalog.
+    public mutating func addVoice(_ profile: VoiceProfile) {
+        voices[profile.id] = profile
+    }
+}

--- a/Tests/CreatorCoreForgeTests/LocalElevenLabsClientTests.swift
+++ b/Tests/CreatorCoreForgeTests/LocalElevenLabsClientTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class LocalElevenLabsClientTests: XCTestCase {
+    func testListVoicesReturnsDefault() {
+        let client = LocalElevenLabsClient()
+        XCTAssertFalse(client.listVoices().isEmpty)
+    }
+
+    func testVoiceInfoRetrieval() {
+        var client = LocalElevenLabsClient(voices: [])
+        let profile = VoiceProfile(name: "Sample")
+        client.addVoice(profile)
+        XCTAssertEqual(client.voiceInfo(id: profile.id)?.name, "Sample")
+    }
+
+    func testSynthesizeProducesData() {
+        let profile = VoiceProfile(name: "Tester")
+        let client = LocalElevenLabsClient(voices: [profile])
+        let exp = expectation(description: "synth")
+        client.synthesize(text: "Hi", voiceID: profile.id) { result in
+            switch result {
+            case .success(let data):
+                XCTAssertFalse(data.isEmpty)
+            case .failure:
+                XCTFail("Unexpected failure")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}

--- a/docs/VoiceTrainerGuide.md
+++ b/docs/VoiceTrainerGuide.md
@@ -13,3 +13,4 @@ if trainer.trainVoice(for: "Hero") {
 ```
 
 Use `listTrainedVoices()` to print all available custom voices. Samples can be shared between apps via `VoiceMemoryManager`.
+The new `LocalElevenLabsClient` wraps these voices and exposes an ElevenLabs-compatible API for offline synthesis.


### PR DESCRIPTION
## Summary
- implement `LocalElevenLabsClient` using `LocalVoiceAI` for offline synthesis
- add unit tests for the new client
- document offline ElevenLabs client in README and VoiceTrainer guide

## Testing
- `swift test --skip-build`
- `(cd VoiceLab && npm test --silent)`
- `(cd VisualLab && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_685700580b608321aee2ef348b2ad901