### PR TITLE
Add 4K video export support

### DIFF
--- a/VisualLab/README.md
+++ b/VisualLab/README.md
@@ -20,3 +20,4 @@ node dist/demo.js
 
 This will generate `demo.mp4` in the `dist` directory with default settings. Customize the `src/demo.ts` file to experiment with different scenes and transitions.
 - **UnifiedAudioEngine** provides global volume control with fade transitions shared across apps.
+- **PerformanceService** now supports automatic 4K rendering when hardware allows.

--- a/VisualLab/src/PerformanceService.ts
+++ b/VisualLab/src/PerformanceService.ts
@@ -10,8 +10,14 @@ export interface PerformanceRenderOptions {
 
 export class PerformanceService {
   adjustSettings(deviceInfo: DeviceSpecs): PerformanceRenderOptions {
-    const resolution = deviceInfo.gpuScore > 5 ? 1080 : 720;
-    const bitrate = deviceInfo.memory > 4 ? 8000 : 4000;
+    const resolution =
+      deviceInfo.gpuScore > 8 ? 2160 : deviceInfo.gpuScore > 5 ? 1080 : 720;
+    const bitrate =
+      deviceInfo.memory > 8
+        ? 16000
+        : deviceInfo.memory > 4
+        ? 8000
+        : 4000;
     return { resolution, bitrate };
   }
 }

--- a/VisualLab/test/newFeatures.test.ts
+++ b/VisualLab/test/newFeatures.test.ts
@@ -38,7 +38,12 @@ generateSubtitles('hello');
 
 React.createElement(BranchingPathsUI, { options: [] });
 React.createElement(RenderAnalyticsDashboard, { metrics: [] });
-import { UnifiedAudioEngine, UnifiedVideoEngine, AdaptiveLearningEngine } from "../src/index.ts";
+import {
+  UnifiedAudioEngine,
+  UnifiedVideoEngine,
+  AdaptiveLearningEngine,
+  PerformanceService
+} from "../src/index.ts";
 const engine = UnifiedAudioEngine.shared;
 engine.setVolume(1.5);
 assert.strictEqual(engine.currentVolume(), 1);
@@ -57,6 +62,10 @@ const learn = AdaptiveLearningEngine.shared;
 learn.reset();
 learn.recordCompletion('l1');
 assert.strictEqual(learn.completionCount('l1'), 1);
+
+const perf = new PerformanceService();
+const opt = perf.adjustSettings({ gpuScore: 9, memory: 16 });
+assert.strictEqual(opt.resolution, 2160);
 
 
 console.log('New features tests passed');

--- a/docs/PHASE_EIGHT.md
+++ b/docs/PHASE_EIGHT.md
@@ -73,6 +73,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [x] WatermarkService
 - [x] SubtitleGenerator
 - [x] RenderAnalyticsDashboard
+- [ ] 4KVideoExport
 
 ### CoreForgeWriter
 - [ ] UnifiedAudioEngine

--- a/features-phase8.json
+++ b/features-phase8.json
@@ -82,6 +82,7 @@
       "WatermarkService",
       "SubtitleGenerator",
       "RenderAnalyticsDashboard",
+      "4KVideoExport",
       "VideoEffectsPipeline",
       "AudioEffectsPipeline"
     ],


### PR DESCRIPTION
## Summary
- support 4K rendering in `PerformanceService`
- document 4K video export goal in Phase 8 docs
- list `4KVideoExport` in phase8 features
- mention 4K rendering in VisualLab README
- test new 4K resolution behaviour

## Testing
- `npm test` in `VisualLab`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685700bcf21083219ff99047eeb16f23