### PR TITLE
Add universal build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,9 @@ Cross-platform builds can be generated using `electron-builder`. Run
 `.exe` installers for apps that include a `Desktop` project. macOS and Linux
 hosts must have `wine` and `mono` installed to generate the Windows builds.
 See
-`docs/CrossPlatformBuild.md` for details.
+`docs/CrossPlatformBuild.md` for details. For a full multi-platform build (iOS,
+Android, Web, Chrome, and Edge) execute `./scripts/universal_build.sh` which
+calls the appropriate tools when present.
 
 Each app includes a `Desktop` folder with a starter Electron configuration for
 building installers.

--- a/docs/CrossPlatformBuild.md
+++ b/docs/CrossPlatformBuild.md
@@ -1,6 +1,6 @@
 # Cross-Platform Build Guide
 
-This document explains how to generate macOS `.dmg` and Windows `.exe` installers for the CreatorCoreForge apps.
+This document explains how to generate installers and deployable builds for all supported platforms: iOS, Android, macOS, Windows, Web, Chrome, and Edge.
 
 ## Requirements
 - Node.js 18 or later
@@ -9,7 +9,7 @@ This document explains how to generate macOS `.dmg` and Windows `.exe` installer
 - `wine` and `mono` (required on macOS/Linux hosts to build Windows installers)
 
 ## Usage
-Run the helper script from the repository root:
+Run the desktop helper script from the repository root:
 
 ```bash
 ./scripts/build_desktop.sh
@@ -20,6 +20,22 @@ The script searches each app folder for a `Desktop` project containing a `packag
 Each app now includes a `Desktop` folder with a minimal Electron setup. Use these as templates when customizing the builds for your project.
 
 Artifacts are generated under each app's `Desktop/dist` directory. Upload these installers to your distribution channel or attach them to a release.
+
+## Mobile and Web Builds
+
+Use the universal build helper to generate all remaining targets:
+
+```bash
+./scripts/universal_build.sh
+```
+
+This script performs the following actions when the necessary tools are available:
+
+1. **iOS** – invokes Fastlane to build every Xcode project under `apps/`.
+2. **Android** – runs `./gradlew assembleRelease` for any Android projects.
+3. **Web** – executes `npm install` and `npm run build` for each `Web` directory.
+4. **Desktop** – calls `build_desktop.sh` for macOS and Windows installers.
+5. **Chrome/Edge** – builds browser extensions when `extensions/chrome` or `extensions/edge` exist.
 
 ## Continuous Integration
 A GitHub Actions workflow (`desktop-build.yml`) is provided to automate the process. Trigger the workflow manually or on push. It executes the build script on both `macos-latest` and `windows-latest` runners.

--- a/scripts/universal_build.sh
+++ b/scripts/universal_build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build iOS apps using Fastlane
+if command -v fastlane >/dev/null 2>&1; then
+  echo "Building iOS apps via fastlane"
+  (cd fastlane && fastlane build_all)
+else
+  echo "fastlane not found; skipping iOS build"
+fi
+
+# Build Android apps if gradlew files exist
+find apps -name gradlew | while read -r gradle_path; do
+  app_dir=$(dirname "$gradle_path")
+  echo "Building Android app in $app_dir"
+  (cd "$app_dir" && ./gradlew assembleRelease)
+  echo "-----"
+done
+
+# Build Web apps if a Web folder with package.json exists
+for web_dir in apps/*/Web; do
+  if [ -f "$web_dir/package.json" ]; then
+    echo "Building Web app in $web_dir"
+    (cd "$web_dir" && npm install && npm run build)
+    echo "-----"
+  fi
+done
+
+# Build desktop installers
+./scripts/build_desktop.sh
+
+# Build Chrome extension if present
+if [ -d extensions/chrome ]; then
+  echo "Building Chrome extension"
+  (cd extensions/chrome && npm install && npm run build)
+fi
+
+# Build Edge add-on if present
+if [ -d extensions/edge ]; then
+  echo "Building Edge add-on"
+  (cd extensions/edge && npm install && npm run build)
+fi
+


### PR DESCRIPTION
## Summary
- add `universal_build.sh` helper for multi-platform builds
- expand documentation to cover iOS, Android, Web, Chrome, and Edge
- reference new script in README

## Testing
- `npm test` in VoiceLab
- `npm test` in VisualLab
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68575e18a7488321b2e2701b8d674375