### PR TITLE
Add n8n fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,3 +356,7 @@ This ensures `jest`, `ts-node`, and other dev tools are available.
 ## CI/CD
 The repository uses GitHub Actions workflows for building, testing, and releasing the apps across platforms. See the files in [.github/workflows](./.github/workflows) for details.
 
+
+## Fetching n8n Workflow Engine
+
+Use `./scripts/fetch_n8n.sh` to clone or update the [n8n](https://github.com/n8n-io/n8n) automation engine under `external/n8n`. Review the license printed at the end of the script before integrating it into your projects.

--- a/scripts/fetch_n8n.sh
+++ b/scripts/fetch_n8n.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clone or update the n8n automation engine for local workflow integration.
+# The repository is placed under external/n8n.
+
+TARGET_DIR="external/n8n"
+REPO_URL="https://github.com/n8n-io/n8n.git"
+
+if [ -d "$TARGET_DIR" ]; then
+  echo "Updating existing n8n repository..."
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  echo "Cloning n8n repository..."
+  mkdir -p external
+  git clone --depth=1 "$REPO_URL" "$TARGET_DIR"
+fi
+cat "$TARGET_DIR"/LICENSE.md | head -n 5
+


### PR DESCRIPTION
## Summary
- add helper script to fetch n8n repo under `external/n8n`
- document n8n fetch workflow in README

## Testing
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68576c4a205c8321ac730583bf7edd51