### PR TITLE
Add Chatterbox script audio converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,12 @@ A snapshot of the open source `ebook2audiobook` project is included under `apps/
 
 This invokes the Python pipeline to generate WAV files in the given directory.
 
+## Chatterbox Script Conversion
+Use `scripts/chatterbox_bridge.py` to generate a narrated play from a simple `SPEAKER: line` script. Place `speaker.mp3` samples next to your script and set `CHATTERBOX_API_URL` before running:
+```bash
+./scripts/chatterbox_bridge.py script.txt
+```
+
 ## Running Tests
 
 Install Node dependencies for the labs before running the test suites:

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -31,6 +31,8 @@ Xcode and reference `Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swi
 for additional helper functions. These utilities provide an offline download
 queue and an eBook–to–audio converter that complement the app's own classes.
 For advanced conversions using the Python pipeline, run `../../scripts/ebook2audiobook_bridge.py MyBook.epub`.
+You can also turn a dialogue script into audio using `../../scripts/chatterbox_bridge.py script.txt` once your Chatterbox API endpoint is configured.
+
 
 ## Building (iOS)
 1. Open `VocalVerseFull/VocalVerse.xcodeproj` in Xcode.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,5 @@
 # Scripts
 
 Utility shell and Python scripts used for building projects and auditing features. See each script for details.
+
+- `chatterbox_bridge.py` – convert a simple `SPEAKER: line` script into a single audio file using a Chatterbox API. Requires `pydub`, `tqdm`, `requests`, and a `CHATTERBOX_API_URL` environment variable.

--- a/scripts/chatterbox_bridge.py
+++ b/scripts/chatterbox_bridge.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Generate an audio play from a simple script file using a Chatterbox API."""
+import argparse
+import hashlib
+import os
+import sys
+from typing import List
+
+from dotenv import load_dotenv
+from pydub import AudioSegment
+import requests
+from tqdm import tqdm
+
+
+class ChatterboxClient:
+    """Minimal client for the Chatterbox API."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+
+    def synthesize(self, text: str, prompt_path: str) -> bytes:
+        """Send a synthesis request and return audio data."""
+        with open(prompt_path, "rb") as f:
+            files = {"audio_prompt": f}
+            data = {"text": text}
+            resp = requests.post(f"{self.base_url}/synthesize", files=files, data=data)
+            resp.raise_for_status()
+            return resp.content
+
+
+def parse_script(path: str) -> List[tuple[str, str]]:
+    lines = []
+    with open(path, "r", encoding="utf-8") as f:
+        for raw in f:
+            if ":" not in raw:
+                continue
+            speaker, line = raw.split(":", 1)
+            lines.append((speaker.strip().lower(), line.strip().strip('"').strip("'")))
+    return lines
+
+
+def md5_hash(text: str) -> str:
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert script to combined audio")
+    parser.add_argument("script", help="Path to the script file")
+    parser.add_argument("--output", default="combined_audio.mp3", help="Output file")
+    parser.add_argument("--cache", default="audios", help="Cache directory for segments")
+    args = parser.parse_args()
+
+    load_dotenv()
+    api_url = os.getenv("CHATTERBOX_API_URL")
+    if not api_url:
+        print("CHATTERBOX_API_URL not set")
+        sys.exit(1)
+
+    client = ChatterboxClient(api_url)
+    os.makedirs(args.cache, exist_ok=True)
+
+    script_lines = parse_script(args.script)
+    segments: List[AudioSegment] = []
+
+    for speaker, line in tqdm(script_lines, desc="Generating", unit="line"):
+        key = md5_hash(speaker + line)
+        path = os.path.join(args.cache, f"{key}.mp3")
+        if os.path.exists(path):
+            segment = AudioSegment.from_file(path)
+        else:
+            prompt = f"{speaker}.mp3"
+            audio_data = client.synthesize(line, prompt)
+            with open(path, "wb") as f:
+                f.write(audio_data)
+            segment = AudioSegment.from_file(path)
+        segments.append(segment)
+
+    combined = sum(segments[1:], segments[0]) if segments else AudioSegment.empty()
+    combined.export(args.output, format="mp3")
+    print(f"Saved {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `chatterbox_bridge.py` for converting dialogue scripts to audio via Chatterbox API
- document the new script in root README, script README, and CoreForge Audio README

## Testing
- `npm test --prefix VoiceLab`
- `npm test --prefix VisualLab`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68576d86b2488321a9da44ed0777cac4