### PR TITLE
Add long video assembly utility

### DIFF
--- a/apps/AI_VideoGenerator/README.md
+++ b/apps/AI_VideoGenerator/README.md
@@ -1,3 +1,13 @@
 # AI Video Generator
 
 This is an excerpt from the open source [ai-video-generator](https://github.com/Endergr/ai-video-generator) repository. It demonstrates how to run a FastAPI backend for generating AI-driven videos. Only the server file and MIT license are included here for reference.
+
+## Ultra Long Video Assembly
+
+For producing seamless ultra-long videos, use the `scripts/ultra_long_video_assembler.py` utility. Generate individual segments with the server and then pass them to the script:
+
+```bash
+python ../../scripts/ultra_long_video_assembler.py output.mp4 segment1.mp4 segment2.mp4 segment3.mp4
+```
+
+This uses `ffmpeg` under the hood to concatenate the segments without re-encoding.

--- a/apps/AI_VideoGenerator/server.py
+++ b/apps/AI_VideoGenerator/server.py
@@ -38,12 +38,12 @@ uploads_dir.mkdir(exist_ok=True)
 class VideoGenerationRequest(BaseModel):
     prompt: str
     style: str  # realistic, anime, cartoon, surreal, talking_image
-    duration: int = Field(default=7, ge=5, le=10)
+    duration: int = Field(default=7, ge=5, le=3600)
     nsfw_enabled: bool = Field(default=False)
 
 class ImageToVideoRequest(BaseModel):
     style: str  # character_animation, movement_overlay, talking_face
-    duration: int = Field(default=7, ge=5, le=10)
+    duration: int = Field(default=7, ge=5, le=3600)
     nsfw_enabled: bool = Field(default=False)
 
 class VideoResponse(BaseModel):
@@ -163,7 +163,7 @@ async def generate_text_to_video(request: VideoGenerationRequest):
 async def generate_image_to_video(
     file: UploadFile = File(...),
     style: str = Form(...),
-    duration: int = Form(7),
+    duration: int = Form(7, ge=5, le=3600),
     nsfw_enabled: bool = Form(False)
 ):
     """Generate video from uploaded image"""

--- a/scripts/ultra_long_video_assembler.py
+++ b/scripts/ultra_long_video_assembler.py
@@ -1,0 +1,42 @@
+import argparse
+import os
+import shutil
+import subprocess
+from typing import List
+
+
+def assemble_videos(inputs: List[str], output: str) -> None:
+    """Concatenate multiple video files using ffmpeg's concat demuxer."""
+    list_file = "video_list.txt"
+    with open(list_file, "w") as handle:
+        for path in inputs:
+            abs_path = os.path.abspath(path)
+            handle.write(f"file '{abs_path}'\n")
+
+    ffmpeg_cmd = [
+        shutil.which("ffmpeg") or "ffmpeg",
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        list_file,
+        "-c",
+        "copy",
+        output,
+    ]
+    subprocess.run(ffmpeg_cmd, check=True)
+    os.remove(list_file)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble segments into an ultra long video")
+    parser.add_argument("output", help="Output video filename")
+    parser.add_argument("inputs", nargs='+', help="Ordered list of video segments")
+    args = parser.parse_args()
+
+    assemble_videos(args.inputs, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- enable up to one-hour video durations in AI Video Generator
- add `ultra_long_video_assembler.py` script to merge multiple video clips
- document long video workflow in AI Video Generator README

## Testing
- `npm install` & `npm test` in VoiceLab
- `npm install` & `npm test` in VisualLab
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685776145f088321ad5e788234bfec85