### PR TITLE
Enable 10x playback speed

### DIFF
--- a/Sources/CreatorCoreForge/AudioPlaybackEngine.swift
+++ b/Sources/CreatorCoreForge/AudioPlaybackEngine.swift
@@ -39,7 +39,7 @@ public final class AudioPlaybackEngine {
     }
 
     public func setSpeed(_ rate: Double) {
-        speed = max(0.5, min(rate, 5.0))
+        speed = max(0.5, min(rate, 10.0))
         print("⚡️ Speed set to \(speed)x")
     }
 

--- a/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
+++ b/Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift
@@ -32,6 +32,8 @@ public final class PlaybackManager {
     private var currentIndex = 0
     private var bookmarkIndex: Int?
     private var isPlaying = false
+    /// Playback speed multiplier. Range: 0.5x - 10x. Defaults to 1x.
+    private var playbackSpeed: Double = 1.0
 
     public init() {}
 
@@ -52,9 +54,9 @@ public final class PlaybackManager {
         isPlaying = true
         let chapter = chapters[currentIndex]
         if let url = chapter.audioURL {
-            print("▶️ Playing Chapter \(currentIndex + 1): \(chapter.title) at \(url)")
+            print("▶️ Playing Chapter \(currentIndex + 1) at speed \(playbackSpeed)x: \(chapter.title) at \(url)")
         } else {
-            print("▶️ Playing Chapter \(currentIndex + 1): \(chapter.title)")
+            print("▶️ Playing Chapter \(currentIndex + 1) at speed \(playbackSpeed)x: \(chapter.title)")
         }
         return true
     }
@@ -109,6 +111,12 @@ public final class PlaybackManager {
         currentIndex = idx
         bookmarkIndex = nil
         return playCurrentChapter()
+    }
+
+    /// Sets the playback speed, clamping between 0.5x and 10x.
+    public func setPlaybackSpeed(_ speed: Double) {
+        playbackSpeed = min(max(speed, 0.5), 10.0)
+        print("⏩ Playback speed set to \(playbackSpeed)x")
     }
 }
 

--- a/Tests/CreatorCoreForgeTests/AudioPlaybackEngineSpeedTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioPlaybackEngineSpeedTests.swift
@@ -5,7 +5,7 @@ final class AudioPlaybackEngineSpeedTests: XCTestCase {
     func testSpeedClamped() {
         let engine = AudioPlaybackEngine()
         engine.setSpeed(10)
-        XCTAssertEqual(engine.currentSpeed(), 5.0, accuracy: 0.0001)
+        XCTAssertEqual(engine.currentSpeed(), 10.0, accuracy: 0.0001)
         engine.setSpeed(0.1)
         XCTAssertEqual(engine.currentSpeed(), 0.5, accuracy: 0.0001)
     }

--- a/docs/PHASE_EIGHT.md
+++ b/docs/PHASE_EIGHT.md
@@ -19,7 +19,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -70,7 +70,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -99,7 +99,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -117,7 +117,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -135,7 +135,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -153,7 +153,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -171,7 +171,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner
@@ -189,7 +189,7 @@ This document collects the major feature goals for Phase 8 of the CreatorCoreFor
 - [ ] HighQualityVoiceLibrary
 - [ ] GlobalLanguageSupport
 - [x] OfflineMP3Downloader
-- [ ] TenTimesPlaybackSpeed
+- [x] TenTimesPlaybackSpeed
 - [ ] AdvancedSkipImport
 - [x] AISummaryChatService
 - [x] DocVideoScanner


### PR DESCRIPTION
## Summary
- add 10x speed cap in `AudioPlaybackEngine`
- expose playback speed in `PlaybackManager`
- update playback speed unit tests
- mark TenTimesPlaybackSpeed tasks complete in Phase 8 checklist

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6857de0517f48321bb32596ab40c4654