### PR TITLE
Implement basic quiz and marketplace for Learn app

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeLearn_MissingFeatures.swift
+++ b/Sources/CreatorCoreForge/CoreForgeLearn_MissingFeatures.swift
@@ -17,3 +17,32 @@ public struct OfflineSync {
     public mutating func add(_ record: String) { cache.append(record) }
     public var count: Int { cache.count }
 }
+
+public struct QuizBuilder {
+    public struct Question {
+        public let prompt: String
+        public let answer: String
+    }
+
+    private var questions: [Question] = []
+
+    public mutating func add(prompt: String, answer: String) {
+        questions.append(Question(prompt: prompt, answer: answer))
+    }
+
+    public func grade(responses: [String]) -> Int {
+        zip(questions, responses).filter { $0.answer == $1 }.count
+    }
+}
+
+public struct CourseMarketplace {
+    private var courses: [String] = []
+
+    public mutating func publish(course: String) {
+        courses.append(course)
+    }
+
+    public func list() -> [String] {
+        courses
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/PracticalPlanFeatureTests.swift
@@ -164,6 +164,14 @@ final class PracticalPlanFeatureTests: XCTestCase {
         var sync = OfflineSync()
         sync.add("x")
         XCTAssertEqual(sync.count, 1)
+
+        var quiz = QuizBuilder()
+        quiz.add(prompt: "1+1?", answer: "2")
+        XCTAssertEqual(quiz.grade(responses: ["2"]), 1)
+
+        var market = CourseMarketplace()
+        market.publish(course: "Swift")
+        XCTAssertEqual(market.list(), ["Swift"])
     }
 
     func testQuestFeatures() {


### PR DESCRIPTION
## Summary
- build `QuizBuilder` and `CourseMarketplace` in Learn missing features
- test new Learn features

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6857e18a67708321933728eb77728677