### PR TITLE
Fix merge errors in AGENTS headers

### DIFF
--- a/VoiceLab/AGENTS.md
+++ b/VoiceLab/AGENTS.md
@@ -4,7 +4,7 @@
 Language: TypeScript
 Purpose: Voice analysis and transcription components
 
--### Tasks
+### Tasks
 - [x] Ensure voice training scripts run via CI
 - [x] Keep React components typed and tested
 - [x] Integrate with OpenAI service

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -3,7 +3,7 @@
 ## Directory: apps
 Purpose: Consolidate all CreatorCoreForge application packages
 
--### Tasks
+### Tasks
 - [ ] Keep each subfolder in sync with master roadmap
 - [x] Maintain per-app AGENTS.md files
 - [ ] Coordinate shared assets and templates


### PR DESCRIPTION
## Summary
- fix stray `-` characters in AGENTS headers under `apps` and `VoiceLab`
- ensure task lists display correctly

## Testing
- `swift test --enable-test-discovery`
- `npm test` in `VisualLab`

------
https://chatgpt.com/codex/tasks/task_e_6857eb1f27ec8321a5547333275414b1