### PR TITLE
Add capabilities sections to app docs

### DIFF
--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -237,3 +237,11 @@ This file is a full checklist of every feature required for code completion and 
 ## Codex/AI Agent Note
 Treat every unchecked item as a high-priority deliverable. Use this file as the definitive requirements list for app completion, verification, and compliance.  
 **Upon completion, all items must be checked and validated in the corresponding GitHub repo.**
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Real-time emotion adaptation
+- Voice DNA visualization

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -61,3 +61,12 @@ keys can be securely stored using `SecureStore.storeApiKey` which writes the
 value to the iOS Keychain.
 An `AppStoreAssets` directory provides screenshots and
 additional artwork required by the store.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Real-time emotion adaptation
+- Voice DNA visualization

--- a/apps/CoreForgeBuild/AGENTS.md
+++ b/apps/CoreForgeBuild/AGENTS.md
@@ -39,3 +39,11 @@ Purpose: AI-driven app builder with automated code generation and packaging
 - [x] AISummaryChatService
 - [x] DocVideoScanner
 - [x] BookScanAnalyzer
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Figma-driven UI builder
+- Auto bundler for all platforms

--- a/apps/CoreForgeBuild/README.md
+++ b/apps/CoreForgeBuild/README.md
@@ -95,3 +95,12 @@ This agent is responsible for building, validating, and maintaining all features
 
 ## Codex/AI Agent Note
 Every unchecked item is a high-priority task. Use as completion requirements and onboarding doc.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Figma-driven UI builder
+- Auto bundler for all platforms

--- a/apps/CoreForgeLeads/AGENTS.md
+++ b/apps/CoreForgeLeads/AGENTS.md
@@ -53,3 +53,11 @@ Purpose: Next-gen AI tool for lead generation, prospecting, and B2B intelligence
 - [x] AISummaryChatService
 - [x] DocVideoScanner
 - [x] BookScanAnalyzer
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Marketplace credit system
+- Global lead exchange

--- a/apps/CoreForgeLeads/README.md
+++ b/apps/CoreForgeLeads/README.md
@@ -96,3 +96,12 @@ This agent is responsible for building, validating, and maintaining all features
 
 ## Codex/AI Agent Note
 Treat every unchecked item as a requirement for app completion, compliance, and launch.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Marketplace credit system
+- Global lead exchange

--- a/apps/CoreForgeMarket/AGENTS.md
+++ b/apps/CoreForgeMarket/AGENTS.md
@@ -103,3 +103,11 @@ This agent is responsible for building, validating, and maintaining all features
 
 ## Codex/AI Agent Note
 Treat every unchecked item as a high-priority deliverable. Use as requirements for completion, testing, and launch.
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Hybrid quantum trading engine
+- Team trading and leaderboards

--- a/apps/CoreForgeMarket/README.md
+++ b/apps/CoreForgeMarket/README.md
@@ -23,3 +23,12 @@ services.
 CoreForge Market can operate without network connectivity. Set `USE_LOCAL_AI=1`
 before running to route prompts through `LocalAIEnginePro` via `FusionEngine`.
 
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Hybrid quantum trading engine
+- Team trading and leaderboards

--- a/apps/CoreForgeMusic/AGENTS.md
+++ b/apps/CoreForgeMusic/AGENTS.md
@@ -46,3 +46,11 @@ Purpose: Hit songwriting engine with AI beat matching, hooks, and lyric generati
 - [x] AISummaryChatService
 - [x] DocVideoScanner
 - [x] BookScanAnalyzer
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- AI vocal production
+- Commercial export tools

--- a/apps/CoreForgeMusic/README.md
+++ b/apps/CoreForgeMusic/README.md
@@ -28,3 +28,12 @@ set.
 
 ## Shared Module
 VerseForgeAI links against the **CreatorCoreForge** Swift package for components like `AutoUpdater`. Add the local package when opening the project.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- AI vocal production
+- Commercial export tools

--- a/apps/CoreForgeStudio/AGENTS.md
+++ b/apps/CoreForgeStudio/AGENTS.md
@@ -91,3 +91,11 @@ Purpose: Converts full books into dramatized AI-generated cinematic videos
 - [x] AISummaryChatService
 - [x] DocVideoScanner
 - [x] BookScanAnalyzer
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Real-time ensemble acting
+- Quantum edit mode

--- a/apps/CoreForgeStudio/README.md
+++ b/apps/CoreForgeStudio/README.md
@@ -97,3 +97,12 @@ This agent is responsible for building, validating, and maintaining all features
 
 ## Codex/AI Agent Note
 Treat every unchecked item as a requirement for app completion, testing, and launch.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Real-time ensemble acting
+- Quantum edit mode

--- a/apps/CoreForgeVisual/AGENTS.md
+++ b/apps/CoreForgeVisual/AGENTS.md
@@ -161,3 +161,11 @@ This agent is responsible for building, validating, and maintaining every featur
 
 ## Codex/AI Agent Note
 Every unchecked item is a top-priority task. Use this file as the app's full requirements for completion, verification, and compliance.
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Adaptive scene completion
+- AR/VR playback

--- a/apps/CoreForgeVisual/README.md
+++ b/apps/CoreForgeVisual/README.md
@@ -33,3 +33,12 @@ CoreForge Visual supports offline development. Set `USE_LOCAL_AI=1` to activate
 
 ## Shared Module
 This app relies on the root **CreatorCoreForge** Swift package for core utilities such as `AutoUpdater` and `ContentPolicyManager`. Ensure the package is linked when building.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Adaptive scene completion
+- AR/VR playback

--- a/apps/CoreForgeWriter/AGENTS.md
+++ b/apps/CoreForgeWriter/AGENTS.md
@@ -92,3 +92,11 @@ Advanced AI writing assistant for creating books, series, and self-help guides w
 - [x] AISummaryChatService
 - [x] DocVideoScanner
 - [x] BookScanAnalyzer
+
+### App Capabilities
+
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Memory pinning
+- Quantum-choice plotting

--- a/apps/CoreForgeWriter/README.md
+++ b/apps/CoreForgeWriter/README.md
@@ -105,3 +105,12 @@ This agent is responsible for building, validating, and maintaining every featur
 
 ## Codex/AI Agent Note
 Every unchecked item is a priority. Use as requirements for app completion, verification, and compliance.
+
+## App Capabilities
+
+Highlighted capabilities from `features-phase8.json`:
+- UnifiedAudioEngine
+- UnifiedVideoEngine
+- AdaptiveLearningEngine
+- Memory pinning
+- Quantum-choice plotting


### PR DESCRIPTION
## Summary
- add highlighted capabilities from features-phase8.json to each app README
- mirror those capabilities in the AGENTS files

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6857efddb62c8321af81570f7b614c8d