### PR TITLE
Implement simple dialogue formatter

### DIFF
--- a/Sources/CreatorCoreForge/AutoFormatDialogue.swift
+++ b/Sources/CreatorCoreForge/AutoFormatDialogue.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Automatically formats raw dialogue lines into a normalized script style.
+public struct AutoFormatDialogue {
+    public init() {}
+
+    /// Format a block of text so that consecutive lines from the same speaker
+    /// are grouped under the speaker name.
+    public func format(text: String) -> String {
+        var result = ""
+        var currentSpeaker: String?
+        for rawLine in text.split(separator: "\n") {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard let range = line.range(of: ":") else {
+                result += line + "\n"
+                continue
+            }
+            let speaker = String(line[..<range.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let utterance = String(line[range.upperBound...]).trimmingCharacters(in: .whitespaces)
+            if speaker != currentSpeaker {
+                if !result.isEmpty { result += "\n" }
+                result += "\(speaker):\n"
+                currentSpeaker = speaker
+            }
+            result += "  \(utterance)\n"
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AutoFormatDialogueTests.swift
+++ b/Tests/CreatorCoreForgeTests/AutoFormatDialogueTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AutoFormatDialogueTests: XCTestCase {
+    func testFormatsDialogue() {
+        let text = "Alice: Hello\nAlice: How are you?\nBob: I'm fine."
+        let formatted = AutoFormatDialogue().format(text: text)
+        let expected = "Alice:\n  Hello\n  How are you?\nBob:\n  I'm fine."
+        XCTAssertEqual(formatted, expected)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AutoFormatDialogue` to format speaker lines consistently
- test `AutoFormatDialogue`

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685874d5f8d48321b3a48230f07f8a82