### PR TITLE
Replace placeholder scripts with working examples

### DIFF
--- a/generated/CoreForgeQuest/Cross_platform_progress_sync.py
+++ b/generated/CoreForgeQuest/Cross_platform_progress_sync.py
@@ -1,4 +1,22 @@
-# Auto-generated for Cross-platform progress sync
-def cross_platform_progress():
-    """Cross-platform progress sync"""
-    pass
+"""Simple in-memory cross-platform progress synchronization."""
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass
+class Progress:
+    level: int
+    points: int
+
+class ProgressSync:
+    """Track progress for players across multiple devices."""
+    def __init__(self) -> None:
+        self._data: Dict[str, Progress] = {}
+
+    def update(self, player_id: str, level: int, points: int) -> None:
+        self._data[player_id] = Progress(level, points)
+
+    def retrieve(self, player_id: str) -> Progress | None:
+        return self._data.get(player_id)
+
+progress_sync = ProgressSync()

--- a/generated/CoreForgeQuest/Multiplayer_events_and_leaderboards.py
+++ b/generated/CoreForgeQuest/Multiplayer_events_and_leaderboards.py
@@ -1,4 +1,24 @@
-# Auto-generated for Multiplayer events and leaderboards
-def multiplayer_events_and():
-    """Multiplayer events and leaderboards"""
-    pass
+"""Utilities for basic multiplayer events and leaderboards."""
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+@dataclass(order=True)
+class LeaderboardEntry:
+    score: int
+    player_id: str = field(compare=False)
+
+class Leaderboard:
+    def __init__(self) -> None:
+        self._entries: Dict[str, int] = {}
+
+    def record_score(self, player_id: str, score: int) -> None:
+        if score > self._entries.get(player_id, 0):
+            self._entries[player_id] = score
+
+    def top(self, n: int = 10) -> List[LeaderboardEntry]:
+        return sorted(
+            [LeaderboardEntry(score, pid) for pid, score in self._entries.items()],
+            reverse=True
+        )[:n]
+
+leaderboard = Leaderboard()

--- a/generated/CoreForgeQuest/Reward_marketplace_for_avatars_and_items.py
+++ b/generated/CoreForgeQuest/Reward_marketplace_for_avatars_and_items.py
@@ -1,4 +1,21 @@
-# Auto-generated for Reward marketplace for avatars and items
-def reward_marketplace_for():
-    """Reward marketplace for avatars and items"""
-    pass
+"""In-memory reward marketplace for avatars and items."""
+from dataclasses import dataclass
+from typing import Dict, List
+
+@dataclass
+class Item:
+    id: str
+    name: str
+    price: int
+
+class Marketplace:
+    def __init__(self) -> None:
+        self._inventory: Dict[str, Item] = {}
+
+    def add_item(self, item_id: str, name: str, price: int) -> None:
+        self._inventory[item_id] = Item(item_id, name, price)
+
+    def list_items(self) -> List[Item]:
+        return list(self._inventory.values())
+
+marketplace = Marketplace()

--- a/generated/docs/ModuleMigrationGuide_md_updating_projects_to_use_shared_Phase_8_modules.py
+++ b/generated/docs/ModuleMigrationGuide_md_updating_projects_to_use_shared_Phase_8_modules.py
@@ -1,4 +1,21 @@
-# Auto-generated for `ModuleMigrationGuide.md` – updating projects to use shared Phase 8 modules.
-def modulemigrationguide_md_updating():
-    """`ModuleMigrationGuide.md` – updating projects to use shared Phase 8 modules."""
-    pass
+"""Extract migration steps from the ModuleMigrationGuide."""
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "ModuleMigrationGuide.md"
+
+def modulemigrationguide_md_updating() -> list[str]:
+    """Return bullet list items under the 'Migration Steps' section."""
+    if not DOC_PATH.exists():
+        return []
+    in_section = False
+    steps: list[str] = []
+    for line in DOC_PATH.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("## Migration Steps"):
+            in_section = True
+            continue
+        if in_section:
+            if line.startswith("## ") and not line.startswith("## Migration Steps"):
+                break
+            if line.strip().startswith("-") or line.strip().startswith("1."):
+                steps.append(line.strip("- ").strip())
+    return steps

--- a/generated/docs/PHASE_NINE_md_open_tasks_for_the_next_audio_milestone.py
+++ b/generated/docs/PHASE_NINE_md_open_tasks_for_the_next_audio_milestone.py
@@ -1,4 +1,15 @@
-# Auto-generated for `PHASE_NINE.md` – open tasks for the next audio milestone.
-def phase_nine_md_open():
-    """`PHASE_NINE.md` – open tasks for the next audio milestone."""
-    pass
+"""Utilities for retrieving open Phase Nine tasks from the documentation."""
+from pathlib import Path
+import re
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "PHASE_NINE.md"
+
+def phase_nine_md_open() -> list[str]:
+    """Return all unchecked Phase Nine tasks from the markdown file."""
+    tasks: list[str] = []
+    if DOC_PATH.exists():
+        for line in DOC_PATH.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"- \[ \] (.+)", line.strip())
+            if m:
+                tasks.append(m.group(1))
+    return tasks

--- a/generated/docs/PRODUCTION_ROADMAP_md_high_level_approach_for_bringing_every_app_to_production.py
+++ b/generated/docs/PRODUCTION_ROADMAP_md_high_level_approach_for_bringing_every_app_to_production.py
@@ -1,4 +1,15 @@
-# Auto-generated for `PRODUCTION_ROADMAP.md` – high level approach for bringing every app to production.
-def production_roadmap_md_high():
-    """`PRODUCTION_ROADMAP.md` – high level approach for bringing every app to production."""
-    pass
+"""Summaries for the production roadmap documentation."""
+from pathlib import Path
+import re
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "PRODUCTION_ROADMAP.md"
+
+def production_roadmap_md_high() -> list[str]:
+    """Return top-level sections from the production roadmap."""
+    if not DOC_PATH.exists():
+        return []
+    sections: list[str] = []
+    for line in DOC_PATH.read_text(encoding="utf-8").splitlines():
+        if line.startswith("## "):
+            sections.append(line[3:])
+    return sections


### PR DESCRIPTION
## Summary
- expand placeholder docs utilities to extract data from the markdown files
- flesh out Quest helper modules for cross-platform progress, leaderboards, and marketplace

## Testing
- `swift test`
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`


------
https://chatgpt.com/codex/tasks/task_e_6858bff254a083219e158a00c642b5d2