### PR TITLE
Improve text analysis and tests

### DIFF
--- a/Sources/CreatorCoreForge/AIEmotionEngine.swift
+++ b/Sources/CreatorCoreForge/AIEmotionEngine.swift
@@ -29,7 +29,8 @@ public final class AIEmotionEngine: ObservableObject {
     public func analyze(text: String) -> EmotionProfile {
         let lowered = text.lowercased()
         for cue in emotionCues {
-            if lowered.contains(cue.textTrigger.lowercased()) {
+            let pattern = "\\b" + NSRegularExpression.escapedPattern(for: cue.textTrigger.lowercased()) + "\\b"
+            if let _ = lowered.range(of: pattern, options: [.regularExpression]) {
                 return cue.emotion
             }
         }

--- a/Sources/CreatorCoreForge/LocalAIEnginePro.swift
+++ b/Sources/CreatorCoreForge/LocalAIEnginePro.swift
@@ -57,15 +57,23 @@ public final class LocalAIEnginePro {
                 return
             }
 
+            let stopWords: Set<String> = [
+                "the", "a", "an", "and", "is", "it", "of", "to", "in", "on", "for",
+                "with", "that", "this", "at", "by", "from", "as", "are", "be"
+            ]
             let allWords = text.lowercased().split { !$0.isLetter }
+                .map { String($0) }
+                .filter { !stopWords.contains($0) }
             var freq: [String: Int] = [:]
-            for w in allWords { freq[String(w), default: 0] += 1 }
+            for w in allWords { freq[w, default: 0] += 1 }
 
             var bestSentence = sentences.first!
             var bestScore = -1
             for sentence in sentences {
                 let words = sentence.lowercased().split { !$0.isLetter }
-                let score = words.reduce(0) { $0 + (freq[String($1)] ?? 0) }
+                    .map { String($0) }
+                    .filter { !stopWords.contains($0) }
+                let score = words.reduce(0) { $0 + (freq[$1] ?? 0) }
                 if score > bestScore { bestScore = score; bestSentence = sentence }
             }
 

--- a/Tests/CreatorCoreForgeTests/AIEmotionEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/AIEmotionEngineTests.swift
@@ -7,6 +7,7 @@ final class AIEmotionEngineTests: XCTestCase {
         engine.clearCues()
         engine.registerCue(trigger: "sobbed", emotion: .sad, intensity: 0.9)
         XCTAssertEqual(engine.analyze(text: "He sobbed loudly."), .sad)
+        XCTAssertEqual(engine.analyze(text: "He absorbed knowledge."), .neutral)
     }
 
     #if canImport(AVFoundation)

--- a/Tests/CreatorCoreForgeTests/LocalAIEngineProTests.swift
+++ b/Tests/CreatorCoreForgeTests/LocalAIEngineProTests.swift
@@ -33,13 +33,14 @@ final class LocalAIEngineProTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testSummarizeReturnsFirstSentence() {
+    func testSummarizePrefersKeywordDenseSentence() {
         let engine = LocalAIEnginePro()
         let expectation = XCTestExpectation(description: "summary")
-        engine.summarize("First. Second.") { result in
+        let text = "The cat is on the mat. Cats chase mice in gardens." // second sentence has more keywords
+        engine.summarize(text) { result in
             switch result {
             case .success(let summary):
-                XCTAssertFalse(summary.isEmpty)
+                XCTAssertEqual(summary, "Cats chase mice in gardens")
             case .failure:
                 XCTFail("Unexpected failure")
             }


### PR DESCRIPTION
## Summary
- refine emotion cue detection with word boundary regex
- improve `LocalAIEnginePro` summarization by ignoring common stop words
- update tests for new summarization and emotion cue logic

## Testing
- `npm test`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6858c3cc98688321b1f4680c7c1fc6f1