### PR TITLE
Fix Swift test warnings

### DIFF
--- a/Tests/CreatorCoreForgeTests/CharacterTrackManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/CharacterTrackManagerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class CharacterTrackManagerTests: XCTestCase {
     func testAppendAndRetrieve() {
-        var data = Data([1,2,3])
+        let data = Data([1, 2, 3])
         let manager = CharacterTrackManager()
         manager.append(data, for: "Alice")
         XCTAssertEqual(manager.allCharacters, ["Alice"])


### PR DESCRIPTION
## Summary
- fix mutated variable warning in `CharacterTrackManagerTests`

## Testing
- `swift test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685974c9e8748321850854cff04044b4