### PR TITLE
Implement task registry and async segment service

### DIFF
--- a/CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md
+++ b/CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md
@@ -1,0 +1,74 @@
+✅ CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md
+
+## Purpose:
+Codex should identify and enhance all currently open tasks across the CoreForge Build platform, ensuring each related file is:
+
+- Fully coded with complete logic
+- App Store compliant
+- Performance-optimized
+- Tested and integrated across all supported platforms
+
+---
+
+## 🔍 Step 1: Task Inventory Scan
+
+- [ ] Scan all `FEATURES-CODEX-COMPLETE.md` and `CODEX-TODO-*` files for:
+  - Open `[ ]` task checkboxes
+  - Descriptions of modules or features not yet implemented
+- [ ] Match each open task with expected source file(s) and language
+- [ ] Output a task-to-file map in `open_tasks_registry.json`
+
+---
+
+## 🛠 Step 2: File Creation & Enhancement
+
+For each open task, Codex should:
+
+### 🔧 Standard Task Format
+
+- [ ] **Task:** Implement or complete logic for `[OPEN TASK DESCRIPTION]`  
+  **Related File:** `[TARGET_FILENAME]`  
+  **Category:** `[UI / Logic / Parser / Export / Marketplace / Plugin / Security]`  
+  **Goal:** Complete this module for full production readiness  
+  **Requirements:**
+    - Must contain actual logic, state management, API calls, or component rendering
+    - Follow modular structure with typed inputs and testable outputs
+    - Include comments and comply with CoreForge feature standards
+  **Output:** Fully functional, tested file ready for deployment
+
+---
+
+## ✅ Sample Enhancements
+
+- [ ] Build `formGenerator.tsx`
+  - Task: “Auto-generate logic for forms from user prompt”
+  - Category: Form Builder
+  - File must accept schema input, render dynamic form, handle validation
+
+- [ ] Complete `LivePreviewPane.vue`
+  - Task: “Enable real-time preview for mobile and web app layouts”
+  - Category: Debug Preview
+  - Must display responsive view, trigger re-render on layout changes
+
+- [ ] Finish `PluginManager.ts`
+  - Task: “Load and validate marketplace plugins”
+  - Category: Plugin Loader
+  - Scan metadata, allow toggle, sandbox test before injection
+
+---
+
+## 🧪 Step 3: Validation
+
+- [ ] Run unit and integration tests for all created or updated files
+- [ ] Confirm output accuracy with test case assertions
+- [ ] Add updated files to GitHub commits with changelog
+- [ ] Track files in `enhanced_file_registry.json`
+
+---
+
+## 📦 Step 4: Final Review
+
+- [ ] Ensure every open Codex task has a completed file
+- [ ] Confirm all generated files meet App Store & platform export requirements
+- [ ] Mark tasks complete in all related markdowns and registry logs
+

--- a/Sources/CreatorCoreForge/SegmentService.swift
+++ b/Sources/CreatorCoreForge/SegmentService.swift
@@ -2,18 +2,45 @@ import Foundation
 
 /// Splits chapters into narration segments based on blank lines.
 public struct SegmentService {
+    private static var cache: [Int: [Segment]] = [:]
+
     public init() {}
 
+    /// Segments chapters synchronously. Used by legacy code paths.
     public func segment(_ chapters: [Chapter]) -> [Segment] {
-        var segments: [Segment] = []
+        chapters.flatMap { splitText($0.text) }
+    }
+
+    /// Segments chapters asynchronously in chunks to avoid blocking the main thread.
+    /// Results are cached using a simple hash of the chapter text.
+    public func segmentAsync(_ chapters: [Chapter],
+                             queue: DispatchQueue = .global(qos: .userInitiated),
+                             completion: @escaping ([Segment]) -> Void) {
+        var results: [Segment] = []
+        let group = DispatchGroup()
         for chap in chapters {
-            let parts = chap.text.components(separatedBy: "\n\n")
-            for part in parts {
-                let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
-                if trimmed.isEmpty { continue }
-                segments.append(Segment(text: trimmed))
+            group.enter()
+            queue.async {
+                let parts = self.splitText(chap.text)
+                DispatchQueue.main.async { results.append(contentsOf: parts); group.leave() }
             }
         }
+        group.notify(queue: .main) { completion(results) }
+    }
+
+    private func splitText(_ text: String) -> [Segment] {
+        let hash = text.hashValue
+        if let cached = SegmentService.cache[hash] {
+            return cached
+        }
+        var segments: [Segment] = []
+        let parts = text.components(separatedBy: "\n\n")
+        for part in parts {
+            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            segments.append(Segment(text: trimmed))
+        }
+        SegmentService.cache[hash] = segments
         return segments
     }
 }

--- a/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift
@@ -38,12 +38,22 @@ final class AudioVisualPhaseOneTests: XCTestCase {
     }
 
     func testSegmentServiceAndTTS() {
-        let chapters = [Chapter(title: "C1", text: "A\n\nB")] 
+        let chapters = [Chapter(title: "C1", text: "A\n\nB")]
         let segs = SegmentService().segment(chapters)
         XCTAssertEqual(segs.count, 2)
         let tts = TTSService()
         let blob = tts.renderSegment(segs[0], voiceId: "v1")
         XCTAssertTrue(String(data: blob, encoding: .utf8)?.contains("voice:v1") ?? false)
+    }
+
+    func testSegmentServiceAsync() async {
+        let chapters = [Chapter(title: "C1", text: "A\n\nB\n\nC")]
+        let expectation = XCTestExpectation(description: "async segments")
+        SegmentService().segmentAsync(chapters) { segs in
+            XCTAssertEqual(segs.count, 3)
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 1)
     }
 
     func testStreamAssembler() {

--- a/enhanced_file_registry.json
+++ b/enhanced_file_registry.json
@@ -1,0 +1,8 @@
+{
+  "enhanced_files": [
+    "Sources/CreatorCoreForge/SegmentService.swift",
+    "Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift",
+    "CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md",
+    "open_tasks_registry.json"
+  ]
+}

--- a/open_tasks_registry.json
+++ b/open_tasks_registry.json
@@ -1,0 +1,328 @@
+{
+  "open_tasks": [
+    {
+      "task": "Scan each file for:",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Evaluate all components for:",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Log findings to `performance_scan_report.json` with:",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "**Task:** Enhance `[FILENAME]`",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Optimize `SegmentService.swift`",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Enhance `TTSRenderer.ts`",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Refactor `ChapterEditor.vue`",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Run performance tests before/after each refactor",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Measure memory footprint and latency where applicable",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Confirm visual/functional behavior remains consistent",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Document improvements in module-level CHANGELOG",
+      "source_file": "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md"
+    },
+    {
+      "task": "Run `scripts/full_app_scan.py` to identify missing directories, file types, and incomplete implementations.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Review generated `full_app_scan_report.json` for issues per app and platform.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Implement any modules or files reported as missing.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Replace all placeholder or TODO code with production-ready logic.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Add test suites for new and existing modules.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Ensure `scripts/run_all_tests.sh` passes without errors.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Confirm build scripts generate output for iOS, Android, macOS, Windows, and Web.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Verify all assets and configuration files are in place for production.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "All folders and files exist with completed logic.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "All tests pass and coverage reports are up to date.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "Deployment artifacts are generated in the `dist/` directory for each platform.",
+      "source_file": "CODEX-TODO-FULL-APP-READINESS-CHECKLIST.md"
+    },
+    {
+      "task": "`BookImporter.import(file): Promise<Scene[]>`",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Parse EPUB/PDF/TXT into story blocks",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Extract visual scene descriptors and dialogue",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Normalize chapters into visual sequences",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "`SceneDetector.analyze(text): SceneMap`",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Detect scene shifts via NLP (e.g., time jump, location change)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Tag scenes with estimated tone, setting, pacing",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Save scene structure in persistent format",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Match characters with avatar templates",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Assign age, gender, personality traits",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Support facial expression presets (happy, angry, neutral)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Auto-suggest avatars by genre",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "`SceneBuilder.build(scene: Scene): RenderConfig`",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Match character(s), setting, props",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Annotate shot list (close-up, wide, over-shoulder)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Inject emotion or FX tags into each shot",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "`VisualRenderer.render(config: RenderConfig): VideoClip`",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Generate video from prompt + voice + ambient FX",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Integrate with external or local video model",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow rendering style: anime, fantasy, live-action, etc.",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Add scene-level visual effects (fog, sparks, neon glow)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Overlay genre-specific filters",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow real-time FX preview",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Sync facial movement and scene cuts to speech timing",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Support pre-recorded and generated voice tracks",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow lip-sync toggle for faster rendering",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Store character appearances across books",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Preserve visual continuity in sequels",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Handle outfit/age/mood consistency dynamically",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Track changes to scenes (e.g., visual DNA fork)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Let creators \u201clock\u201d scene visuals for canon",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Link scene DNA to multiverse system",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Display alternate visual paths for the same book",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow creators to preview multiple visual outcomes",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Tag scene outcomes with timeline markers",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Store viewer path history (timeline A/B/C)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Replay scenes with alternate visuals",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Adjust future render suggestions based on prior paths",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow 1 book-to-video conversion per month (Pro)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Allow 3 books/month for Creator Tier",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Sell extra video credits for $79.99 each",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Auto-upload unlock for $24.99 (2 platforms)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "NSFW unlock ($25/month or bundle $60/all apps)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Creator tab unlocked via promo code",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Toggle for erotic/fantasy/surreal scenes",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Hide NSFW previews unless verified",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Censor layer options for safe version rendering",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Scene fusion mode (blended timelines)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Hallucinogenic visual filters",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Realistic surrealism toggle (dream logic effects)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Export full video to device (MP4)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Auto-generate thumbnails and cover art",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Add platform-ready metadata",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Upload 1 platform/channel by default",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Add-on unlock for second channel/platform",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Show upload status and logs in dashboard",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Style picker (anime, noir, fantasy, etc.)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "NSFW mode toggle (off by default)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Developer console toggle (Creator tier)",
+      "source_file": "FEATURES-CODEX-COMPLETE.md"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md` with new enhancement checklist
- create `open_tasks_registry.json` to track open tasks
- log enhanced files in `enhanced_file_registry.json`
- optimize `SegmentService` with async chunk processing and caching
- test new async API in `AudioVisualPhaseOneTests`

## Testing
- `npm install` && `npm test` in **VoiceLab**
- `npm install` && `npm test` in **VisualLab**
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_685a026df410832191933f7f340152cd