### PR TITLE
Add markdown layout parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Optimized `SegmentService` with chunked async processing and LRU caching.
+- Added layout instruction parsing to `MarkdownLayoutParser` and updated Build AGENTS checklist.
 - Added `UnifiedAudioEngine` shared module and updated all app feature lists.
 - Added `UnifiedVideoEngine` and `AdaptiveLearningEngine` modules for cross-platform video rendering and adaptive learning.
 - Enhanced `AdaptiveLearningEngine` to track lesson completion timestamps.

--- a/Sources/CreatorCoreForge/MarkdownLayoutParser.swift
+++ b/Sources/CreatorCoreForge/MarkdownLayoutParser.swift
@@ -5,6 +5,8 @@ public enum ASUIMElement: Equatable {
     case heading(text: String, level: Int)
     case paragraph(String)
     case bullet(String)
+    /// Layout description such as "2-column login form".
+    case layout(columns: Int, description: String)
 }
 
 /// Converts Markdown-style text into an array of `ASUIMElement` items.
@@ -22,10 +24,26 @@ public struct MarkdownLayoutParser {
             } else if trimmed.hasPrefix("-") {
                 let text = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
                 elements.append(.bullet(String(text)))
+            } else if let layout = MarkdownLayoutParser.parseLayout(from: trimmed) {
+                elements.append(layout)
             } else if !trimmed.isEmpty {
                 elements.append(.paragraph(trimmed))
             }
         }
         return elements
+    }
+
+    private static func parseLayout(from line: String) -> ASUIMElement? {
+        let pattern = "^(\\d+)-column\\s+(.+)"
+        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) {
+            let range = NSRange(location: 0, length: line.utf16.count)
+            if let match = regex.firstMatch(in: line, options: [], range: range),
+               let colRange = Range(match.range(at: 1), in: line),
+               let descRange = Range(match.range(at: 2), in: line),
+               let cols = Int(line[colRange]) {
+                return .layout(columns: cols, description: String(line[descRange]))
+            }
+        }
+        return nil
     }
 }

--- a/Tests/CreatorCoreForgeTests/MarkdownLayoutParserTests.swift
+++ b/Tests/CreatorCoreForgeTests/MarkdownLayoutParserTests.swift
@@ -8,4 +8,11 @@ final class MarkdownLayoutParserTests: XCTestCase {
         let elements = parser.parse(md)
         XCTAssertEqual(elements, [.heading(text: "Title", level: 1), .bullet("Item"), .paragraph("Paragraph")])
     }
+
+    func testParsesLayoutInstruction() {
+        let parser = MarkdownLayoutParser()
+        let md = "2-column login form"
+        let elements = parser.parse(md)
+        XCTAssertEqual(elements, [.layout(columns: 2, description: "login form")])
+    }
 }

--- a/apps/CoreForgeBuild/AGENTS.md
+++ b/apps/CoreForgeBuild/AGENTS.md
@@ -60,9 +60,8 @@ Key points from `README.md`:
 
 ## Full Phase Checklist (Phases 1–9)
 
-### Phase 1 – Core Input Engine & UI Parsing Logic
 - [ ] Accept natural language prompts to describe app ideas and interface goals
-- [ ] Enable markdown-style layout instructions (e.g., "2-column login form")
+- [x] Enable markdown-style layout instructions (e.g., "2-column login form")
 - [ ] Support drag-and-drop UI builder with AI-generated suggestions
 - [ ] Parse screenshots or hand-drawn wireframes into editable layout code
 - [ ] Extract UI structure from Figma, Sketch, and Adobe XD import

--- a/enhanced_file_registry.json
+++ b/enhanced_file_registry.json
@@ -1,10 +1,13 @@
 {
   "enhanced_files": [
+    "CHANGELOG.md",
+    "CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md",
+    "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md",
+    "Sources/CreatorCoreForge/MarkdownLayoutParser.swift",
     "Sources/CreatorCoreForge/SegmentService.swift",
     "Tests/CreatorCoreForgeTests/AudioVisualPhaseOneTests.swift",
-    "CODEX-TODO-ENHANCE-ALL-OPEN-TASKS.md",
-    "open_tasks_registry.json",
-    "CODEX-TODO-ENHANCE-CODE-QUALITY-PERFORMANCE.md",
-    "CHANGELOG.md"
+    "Tests/CreatorCoreForgeTests/MarkdownLayoutParserTests.swift",
+    "apps/CoreForgeBuild/AGENTS.md",
+    "open_tasks_registry.json"
   ]
 }

--- a/open_tasks_registry.json
+++ b/open_tasks_registry.json
@@ -325,6 +325,12 @@
     {
       "task": "Developer console toggle (Creator tier)",
       "source_file": "FEATURES-CODEX-COMPLETE.md"
+    },
+    {
+      "task": "Enable markdown-style layout instructions (e.g., \"2-column login form\")",
+      "source_file": "apps/CoreForgeBuild/AGENTS.md",
+      "target_file": "Sources/CreatorCoreForge/MarkdownLayoutParser.swift",
+      "language": "Swift"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- support layout instructions in `MarkdownLayoutParser`
- add unit test for layout instruction parsing
- mark markdown layout checklist item as complete
- record new enhancements in `CHANGELOG`
- update registries

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a66747e70832180b8847c0f5eecb1