### PR TITLE
Add form wizard and plugin code injection

### DIFF
--- a/Sources/CreatorCoreForge/CustomCodeInjector.swift
+++ b/Sources/CreatorCoreForge/CustomCodeInjector.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Simple engine that converts text snippets into executable plugins.
+/// Only a limited mini-syntax is supported.
+public final class CustomCodeInjector {
+    public init() {}
+
+    /// Parses a snippet and returns a plugin when possible.
+    /// Currently supports "replace:token=value" rule.
+    public func plugin(from snippet: String) -> FusionEnginePlugin? {
+        guard snippet.hasPrefix("replace:") else { return nil }
+        let remainder = snippet.dropFirst("replace:".count)
+        let parts = remainder.split(separator: "=", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return nil }
+        let token = parts[0]
+        let value = parts[1]
+        return CodePlugin(name: "replace-\(token)") { prompt in
+            prompt.replacingOccurrences(of: token, with: value)
+        } responseTransform: { $0 }
+    }
+}
+
+/// Plugin backed by closures for prompt and response transformation.
+public struct CodePlugin: FusionEnginePlugin {
+    public var name: String
+    let promptTransform: (String) -> String
+    let responseTransform: (String) -> String
+
+    public init(name: String,
+                promptTransform: @escaping (String) -> String,
+                responseTransform: @escaping (String) -> String) {
+        self.name = name
+        self.promptTransform = promptTransform
+        self.responseTransform = responseTransform
+    }
+
+    public func processPrompt(_ prompt: String) -> String {
+        promptTransform(prompt)
+    }
+
+    public func processResponse(_ response: String) -> String {
+        responseTransform(response)
+    }
+}

--- a/Sources/CreatorCoreForge/FormWizard.swift
+++ b/Sources/CreatorCoreForge/FormWizard.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Represents a single step in a multi-step form wizard.
+public struct FormStep {
+    public let template: FormTemplate
+    public let condition: (([String: String]) -> Bool)?
+    public init(template: FormTemplate, condition: (([String: String]) -> Bool)? = nil) {
+        self.template = template
+        self.condition = condition
+    }
+}
+
+/// Handles progression through a sequence of form steps.
+public final class FormWizard {
+    private let binding: InputBindingEngine
+    public private(set) var steps: [FormStep]
+    public private(set) var currentIndex: Int = 0
+
+    public init(steps: [FormStep], binding: InputBindingEngine = InputBindingEngine()) {
+        self.steps = steps
+        self.binding = binding
+    }
+
+    /// Returns the currently active form template.
+    public var currentStep: FormTemplate? {
+        guard currentIndex < steps.count else { return nil }
+        return steps[currentIndex].template
+    }
+
+    /// Advance to the next step if available and any condition is met.
+    public func next() {
+        let nextIndex = currentIndex + 1
+        guard nextIndex < steps.count else { return }
+        let nextStep = steps[nextIndex]
+        if let condition = nextStep.condition {
+            if condition(binding.allValues) {
+                currentIndex = nextIndex
+            }
+        } else {
+            currentIndex = nextIndex
+        }
+    }
+
+    /// Move back to the previous step.
+    public func previous() {
+        currentIndex = max(0, currentIndex - 1)
+    }
+}

--- a/Sources/CreatorCoreForge/InputBindingEngine.swift
+++ b/Sources/CreatorCoreForge/InputBindingEngine.swift
@@ -3,16 +3,38 @@ import Foundation
 /// Simple input binding state manager.
 public final class InputBindingEngine {
     private var values: [String: String] = [:]
+    private var computedTransforms: [String: ([String: String]) -> String] = [:]
     public init() {}
 
-    /// Bind a value to a field name.
+    /// Bind a value to a field name and update computed fields.
     public func bind(field: String, value: String) {
         values[field] = value
+        evaluateComputed()
+    }
+
+    /// Bind a computed field that derives its value from other inputs.
+    public func bindComputed(field: String, transform: @escaping ([String: String]) -> String) {
+        computedTransforms[field] = transform
+        values[field] = transform(values)
+    }
+
+    /// Evaluate all computed field transforms.
+    public func evaluateComputed() {
+        for (field, block) in computedTransforms {
+            values[field] = block(values)
+        }
     }
 
     /// Retrieve current value for a field.
     public func value(for field: String) -> String? {
-        values[field]
+        evaluateComputed()
+        return values[field]
+    }
+
+    /// All current values, including computed fields.
+    public var allValues: [String: String] {
+        evaluateComputed()
+        return values
     }
 
     /// Returns computed fields using a transform closure.

--- a/Tests/CreatorCoreForgeTests/CustomCodeInjectorTests.swift
+++ b/Tests/CreatorCoreForgeTests/CustomCodeInjectorTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class CustomCodeInjectorTests: XCTestCase {
+    func testReplacePlugin() {
+        let injector = CustomCodeInjector()
+        let plugin = injector.plugin(from: "replace:foo=bar") as? CodePlugin
+        XCTAssertNotNil(plugin)
+        XCTAssertEqual(plugin?.processPrompt("foo"), "bar")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FormWizardTests.swift
+++ b/Tests/CreatorCoreForgeTests/FormWizardTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class FormWizardTests: XCTestCase {
+    func testStepProgressionWithCondition() {
+        let step1 = FormTemplate(name: "one", fields: [FormField(name: "age", type: .number)])
+        let step2 = FormTemplate(name: "two", fields: [FormField(name: "name", type: .text)])
+        let engine = InputBindingEngine()
+        engine.bind(field: "age", value: "20")
+        let wizard = FormWizard(steps: [
+            FormStep(template: step1),
+            FormStep(template: step2, condition: { vals in
+                if let a = Int(vals["age"] ?? "") { return a >= 18 }
+                return false
+            })
+        ], binding: engine)
+        XCTAssertEqual(wizard.currentStep?.name, "one")
+        wizard.next()
+        XCTAssertEqual(wizard.currentStep?.name, "two")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/InputBindingEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/InputBindingEngineTests.swift
@@ -20,4 +20,14 @@ final class InputBindingEngineSimpleTests: XCTestCase {
         }
         XCTAssertEqual(sum, "3")
     }
+
+    func testComputedWatcherUpdates() {
+        let engine = InputBindingEngine()
+        engine.bindComputed(field: "full") { vals in
+            (vals["first"] ?? "") + (vals["last"] ?? "")
+        }
+        engine.bind(field: "first", value: "A")
+        engine.bind(field: "last", value: "B")
+        XCTAssertEqual(engine.value(for: "full"), "AB")
+    }
 }


### PR DESCRIPTION
## Summary
- expand `InputBindingEngine` with computed bindings and state helpers
- add `FormWizard` for multi-step forms
- create `CustomCodeInjector` and `CodePlugin`
- test new functionality for form wizard, code injector, and computed bindings

## Testing
- `swift test`
- `npm test` within `VisualLab`
- `npm test` within `VoiceLab`


------
https://chatgpt.com/codex/tasks/task_e_685a6a4b88b083218f303f9ee8aec8b9