### PR TITLE
Implement input watchers for Build forms

### DIFF
--- a/Sources/CreatorCoreForge/InputBindingEngine.swift
+++ b/Sources/CreatorCoreForge/InputBindingEngine.swift
@@ -4,24 +4,29 @@ import Foundation
 public final class InputBindingEngine {
     private var values: [String: String] = [:]
     private var computedTransforms: [String: ([String: String]) -> String] = [:]
+    private var watchers: [String: [(String) -> Void]] = [:]
+
     public init() {}
 
     /// Bind a value to a field name and update computed fields.
     public func bind(field: String, value: String) {
         values[field] = value
         evaluateComputed()
+        triggerWatchers(for: field)
     }
 
     /// Bind a computed field that derives its value from other inputs.
     public func bindComputed(field: String, transform: @escaping ([String: String]) -> String) {
         computedTransforms[field] = transform
         values[field] = transform(values)
+        triggerWatchers(for: field)
     }
 
     /// Evaluate all computed field transforms.
     public func evaluateComputed() {
         for (field, block) in computedTransforms {
             values[field] = block(values)
+            triggerWatchers(for: field)
         }
     }
 
@@ -40,5 +45,18 @@ public final class InputBindingEngine {
     /// Returns computed fields using a transform closure.
     public func computed(_ name: String, transform: ([String: String]) -> String) -> String {
         return transform(values)
+    }
+
+    /// Register a closure to run when a specific field value changes.
+    public func addWatcher(for field: String, action: @escaping (String) -> Void) {
+        watchers[field, default: []].append(action)
+    }
+
+    /// Trigger watchers for a particular field.
+    private func triggerWatchers(for field: String) {
+        let val = values[field] ?? ""
+        for action in watchers[field] ?? [] {
+            action(val)
+        }
     }
 }

--- a/Tests/CreatorCoreForgeTests/InputBindingEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/InputBindingEngineTests.swift
@@ -30,4 +30,12 @@ final class InputBindingEngineSimpleTests: XCTestCase {
         engine.bind(field: "last", value: "B")
         XCTAssertEqual(engine.value(for: "full"), "AB")
     }
+
+    func testWatcherCallbackRuns() {
+        let engine = InputBindingEngine()
+        var captured = ""
+        engine.addWatcher(for: "name") { captured = $0 }
+        engine.bind(field: "name", value: "Jane")
+        XCTAssertEqual(captured, "Jane")
+    }
 }


### PR DESCRIPTION
## Summary
- extend `InputBindingEngine` with value watchers for backend hooks
- trigger watchers on bind and computed updates
- test watcher callbacks

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_685a7cef2a3c832180e576e91f082824