### PR TITLE
Add basic codegen and language detection enhancements

### DIFF
--- a/Sources/CreatorCoreForge/ArchitectureDetector.swift
+++ b/Sources/CreatorCoreForge/ArchitectureDetector.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum AppArchitecture {
+    case spa
+    case mvc
+    case mvvm
+    case unknown
+}
+
+/// Detects simple architecture keywords from a prompt.
+public struct ArchitectureDetector {
+    public init() {}
+
+    public func detect(in text: String) -> AppArchitecture {
+        let lower = text.lowercased()
+        if lower.contains("single page") || lower.contains("spa") {
+            return .spa
+        }
+        if lower.contains("model-view-controller") || lower.contains("mvc") {
+            return .mvc
+        }
+        if lower.contains("mvvm") {
+            return .mvvm
+        }
+        return .unknown
+    }
+}

--- a/Sources/CreatorCoreForge/BackendScaffolder.swift
+++ b/Sources/CreatorCoreForge/BackendScaffolder.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum BackendFramework {
+    case express
+    case fastAPI
+    case firebase
+}
+
+/// Generates minimal backend scaffolding examples.
+public struct BackendScaffolder {
+    public init() {}
+
+    public func generate(for framework: BackendFramework) -> String {
+        switch framework {
+        case .express:
+            return "const express = require('express');\nconst app = express();\napp.get('/', (req, res) => res.send('ok'));\nmodule.exports = app;"
+        case .fastAPI:
+            return "from fastapi import FastAPI\napp = FastAPI()\n@app.get('/')\ndef read_root():\n    return {'status': 'ok'}"
+        case .firebase:
+            return "import * as functions from 'firebase-functions';\nexport const helloWorld = functions.https.onRequest((req, res) => { res.send('ok'); });"
+        }
+    }
+}

--- a/Sources/CreatorCoreForge/CodeGenerator.swift
+++ b/Sources/CreatorCoreForge/CodeGenerator.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Supported output languages for simple UI scaffolds.
 public enum CodeLanguage {
     case react, vue, flutter, swiftUI, html
+    case swift, kotlin, python, typescript
 }
 
 /// Very small demo code generator to illustrate language switching.
@@ -21,6 +22,14 @@ public struct CodeGenerator {
             return "struct \(name): View { var body: some View { Text(\"\(name)\") } }"
         case .html:
             return "<div>\(name)</div>"
+        case .swift:
+            return "class \(name): UIViewController {}"
+        case .kotlin:
+            return "class \(name) : AppCompatActivity() { override fun onCreate(b: Bundle?) { super.onCreate(b) } }"
+        case .python:
+            return "class \(name):\n    pass"
+        case .typescript:
+            return "export function \(name)() { return '<div>\(name)</div>'; }"
         }
     }
 }

--- a/Sources/CreatorCoreForge/MultilingualEngine.swift
+++ b/Sources/CreatorCoreForge/MultilingualEngine.swift
@@ -8,6 +8,7 @@ public final class MultilingualEngine {
         case french  = "fr"
         case german  = "de"
         case italian = "it"
+        case chinese = "zh"
         case unknown = "unknown"
     }
 
@@ -28,6 +29,9 @@ public final class MultilingualEngine {
         if lower.contains("ciao") || text.range(of: "[àèìòù]", options: .regularExpression) != nil {
             return .italian
         }
+        if text.unicodeScalars.contains(where: { $0.value >= 0x4E00 && $0.value <= 0x9FFF }) {
+            return .chinese
+        }
         if text.range(of: "[a-zA-Z]", options: .regularExpression) != nil {
             return .english
         }
@@ -42,6 +46,7 @@ public final class MultilingualEngine {
         case .french:  return "LocalVoiceAI-Fr"
         case .german:  return "LocalVoiceAI-De"
         case .italian: return "LocalVoiceAI-It"
+        case .chinese: return "LocalVoiceAI-Zh"
         case .unknown: return "LocalVoiceAI-Default"
         }
     }

--- a/Tests/CreatorCoreForgeTests/ArchitectureDetectorTests.swift
+++ b/Tests/CreatorCoreForgeTests/ArchitectureDetectorTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ArchitectureDetectorTests: XCTestCase {
+    func testDetection() {
+        let detector = ArchitectureDetector()
+        XCTAssertEqual(detector.detect(in: "This is a SPA app"), .spa)
+        XCTAssertEqual(detector.detect(in: "Built with MVC"), .mvc)
+        XCTAssertEqual(detector.detect(in: "Uses MVVM pattern"), .mvvm)
+        XCTAssertEqual(detector.detect(in: "unknown"), .unknown)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/CodeGeneratorTests.swift
+++ b/Tests/CreatorCoreForgeTests/CodeGeneratorTests.swift
@@ -6,5 +6,13 @@ final class CodeGeneratorTests: XCTestCase {
         let gen = CodeGenerator()
         let output = gen.generateComponent(named: "MyView", language: .react)
         XCTAssertTrue(output.contains("function MyView"))
+        XCTAssertTrue(gen.generateComponent(named: "Klass", language: .swift).contains("class"))
+    }
+
+    func testBackendScaffold() {
+        let scaffold = BackendScaffolder()
+        XCTAssertTrue(scaffold.generate(for: .express).contains("express"))
+        XCTAssertTrue(scaffold.generate(for: .fastAPI).contains("FastAPI"))
+        XCTAssertTrue(scaffold.generate(for: .firebase).contains("helloWorld"))
     }
 }

--- a/Tests/CreatorCoreForgeTests/MultilingualEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/MultilingualEngineTests.swift
@@ -8,6 +8,7 @@ final class MultilingualEngineTests: XCTestCase {
         XCTAssertEqual(engine.detectLanguage(of: "Bonjour"), .french)
         XCTAssertEqual(engine.detectLanguage(of: "Guten Morgen"), .german)
         XCTAssertEqual(engine.detectLanguage(of: "Ciao"), .italian)
+        XCTAssertEqual(engine.detectLanguage(of: "你好"), .chinese)
         XCTAssertEqual(engine.detectLanguage(of: "Hello"), .english)
     }
 
@@ -17,6 +18,7 @@ final class MultilingualEngineTests: XCTestCase {
         XCTAssertEqual(engine.modelForText("Bonjour"), "LocalVoiceAI-Fr")
         XCTAssertEqual(engine.modelForText("Guten Tag"), "LocalVoiceAI-De")
         XCTAssertEqual(engine.modelForText("Ciao"), "LocalVoiceAI-It")
+        XCTAssertEqual(engine.modelForText("你好"), "LocalVoiceAI-Zh")
         XCTAssertEqual(engine.modelForText("Hi"), "LocalVoiceAI-En")
     }
 }


### PR DESCRIPTION
## Summary
- add Chinese support to `MultilingualEngine`
- expand `CodeGenerator` with more languages
- add minimal backend scaffolder
- add architecture detector helper
- test new parser logic and scaffolds

## Testing
- `swift test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a7d0757a08321b73f847322ed41b8