### PR TITLE
Implement Visual multiverse manager

### DIFF
--- a/Sources/CreatorCoreForge/VisualMultiverseManager.swift
+++ b/Sources/CreatorCoreForge/VisualMultiverseManager.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Represents an alternate visual outcome for a scene.
+public struct VisualOutcome: Equatable {
+    public let id: UUID
+    public let sceneID: String
+    public let description: String
+    public let frames: [String]
+    public let project: String
+
+    public init(id: UUID = UUID(), sceneID: String, description: String, frames: [String], project: String) {
+        self.id = id
+        self.sceneID = sceneID
+        self.description = description
+        self.frames = frames
+        self.project = project
+    }
+}
+
+/// Stores alternate scene outcomes for multiverse rendering.
+public final class VisualMultiverseManager {
+    public static let shared = VisualMultiverseManager()
+
+    private var outcomes: [UUID: VisualOutcome] = [:]
+
+    public init() {}
+
+    /// Add a new visual outcome for a scene.
+    @discardableResult
+    public func addOutcome(sceneID: String, description: String, frames: [String], project: String) -> VisualOutcome {
+        let outcome = VisualOutcome(sceneID: sceneID, description: description, frames: frames, project: project)
+        outcomes[outcome.id] = outcome
+        return outcome
+    }
+
+    /// Return all outcomes for a scene within a project.
+    public func outcomes(for sceneID: String, project: String) -> [VisualOutcome] {
+        outcomes.values.filter { $0.sceneID == sceneID && $0.project == project }
+    }
+
+    /// Remove an outcome by its identifier.
+    public func removeOutcome(_ id: UUID) {
+        outcomes.removeValue(forKey: id)
+    }
+
+    /// Produce a map of scene IDs to number of alternate outcomes.
+    public func multiverseMap(for project: String) -> [String: Int] {
+        var map: [String: Int] = [:]
+        for outcome in outcomes.values where outcome.project == project {
+            map[outcome.sceneID, default: 0] += 1
+        }
+        return map
+    }
+
+    /// Clear all stored outcomes.
+    public func clearAll() {
+        outcomes.removeAll()
+    }
+}

--- a/Tests/CreatorCoreForgeTests/VisualMultiverseManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/VisualMultiverseManagerTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class VisualMultiverseManagerTests: XCTestCase {
+    func testAddAndQueryOutcomes() {
+        let manager = VisualMultiverseManager()
+        manager.clearAll()
+        let outcome1 = manager.addOutcome(sceneID: "1", description: "alt A", frames: ["f1"], project: "Book")
+        let outcome2 = manager.addOutcome(sceneID: "1", description: "alt B", frames: ["f2"], project: "Book")
+        let results = manager.outcomes(for: "1", project: "Book")
+        XCTAssertEqual(results.count, 2)
+        XCTAssertTrue(results.contains(outcome1))
+        XCTAssertTrue(results.contains(outcome2))
+        let map = manager.multiverseMap(for: "Book")
+        XCTAssertEqual(map["1"], 2)
+    }
+
+    func testRemoveOutcome() {
+        let manager = VisualMultiverseManager()
+        manager.clearAll()
+        let outcome = manager.addOutcome(sceneID: "s", description: "d", frames: [], project: "P")
+        manager.removeOutcome(outcome.id)
+        XCTAssertTrue(manager.outcomes(for: "s", project: "P").isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- support storing alternate scene outcomes in `VisualMultiverseManager`
- test basic add/remove logic

## Testing
- `npm test`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685aa7f3af94832199286174fa46cec0