### PR TITLE
Implement partial phase 1-2 Build features

### DIFF
--- a/apps/CoreForgeBuild/package.json
+++ b/apps/CoreForgeBuild/package.json
@@ -9,9 +9,11 @@
     "test": "node -r ts-node/register test/index.test.ts"
   },
   "devDependencies": {
+    "@types/diff": "^7.0.2",
+    "@types/react": "^19.1.8",
+    "diff": "^5.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.3.3",
-    "@types/react": "^19.1.8"
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "react": "^18.3.1"

--- a/apps/CoreForgeBuild/services/CodeGenService.ts
+++ b/apps/CoreForgeBuild/services/CodeGenService.ts
@@ -4,21 +4,44 @@ import { UIElement } from '../models/UIElement';
  * CodeGenService turns a parsed UI layout into source code for various
  * front-end frameworks. This is a minimal proof of concept used for tests.
  */
+export type FrontendTarget = 'react' | 'vue' | 'flutter' | 'swiftui' | 'html';
+export type BackendTarget = 'express' | 'fastapi' | 'firebase';
+export type OutputStyle = 'minimal' | 'intermediate' | 'verbose';
+
 export class CodeGenService {
-  generate(layout: UIElement[], target: 'react' | 'vue' | 'flutter' | 'swiftui' | 'html'): string {
+  generate(
+    layout: UIElement[],
+    target: FrontendTarget | BackendTarget,
+    style: OutputStyle = 'intermediate'
+  ): string {
+    let code: string;
     switch (target) {
       case 'react':
-        return this.generateReact(layout);
+        code = this.generateReact(layout);
+        break;
       case 'vue':
-        return this.generateVue(layout);
+        code = this.generateVue(layout);
+        break;
       case 'flutter':
-        return this.wrapComment('Flutter code generation not yet implemented');
+        code = this.generateFlutter(layout);
+        break;
       case 'swiftui':
-        return this.wrapComment('SwiftUI code generation not yet implemented');
+        code = this.generateSwiftUI(layout);
+        break;
+      case 'express':
+        code = this.generateExpress();
+        break;
+      case 'fastapi':
+        code = this.generateFastAPI();
+        break;
+      case 'firebase':
+        code = this.generateFirebase();
+        break;
       case 'html':
       default:
-        return this.generateHTML(layout);
+        code = this.generateHTML(layout);
     }
+    return this.applyStyle(code, style);
   }
 
   private wrapComment(text: string): string {
@@ -91,5 +114,72 @@ export class CodeGenService {
       default:
         return `${pad}<div></div>`;
     }
+  }
+
+  /** Placeholder Flutter generator */
+  private generateFlutter(layout: UIElement[]): string {
+    const body = layout.map((el) => this.elementToFlutter(el, 4)).join(',\n');
+    return `// AI-generated Flutter code\nWidget build() {\n  return Column(children:[\n${body}\n  ]);\n}`;
+  }
+
+  private elementToFlutter(el: UIElement, indent: number): string {
+    const pad = ' '.repeat(indent);
+    switch (el.type) {
+      case 'header':
+        return `${pad}Text('${el.props?.text}', style: TextStyle(fontSize: 24))`;
+      case 'paragraph':
+        return `${pad}Text('${el.props?.text}')`;
+      case 'list':
+        const items = el.children?.map((c) => this.elementToFlutter(c, indent + 2)).join(',\n');
+        return `${pad}Column(children:[\n${items}\n${pad}])`;
+      case 'item':
+        return `${pad}Text('${el.props?.text}')`;
+      default:
+        return `${pad}Container()`;
+    }
+  }
+
+  private generateSwiftUI(layout: UIElement[]): string {
+    const body = layout.map((el) => this.elementToSwiftUI(el, 4)).join('\n');
+    return `// AI-generated SwiftUI code\nvar body: some View {\n    VStack {\n${body}\n    }\n}`;
+  }
+
+  private elementToSwiftUI(el: UIElement, indent: number): string {
+    const pad = ' '.repeat(indent);
+    switch (el.type) {
+      case 'header':
+        return `${pad}Text(\"${el.props?.text}\").font(.title)`;
+      case 'paragraph':
+        return `${pad}Text(\"${el.props?.text}\")`;
+      case 'list':
+        const items = el.children?.map((c) => this.elementToSwiftUI(c, indent + 2)).join('\n');
+        return `${pad}VStack {\n${items}\n${pad}}`;
+      case 'item':
+        return `${pad}Text(\"${el.props?.text}\")`;
+      default:
+        return `${pad}EmptyView()`;
+    }
+  }
+
+  private generateExpress(): string {
+    return `// AI-generated Express backend\nconst express = require('express');\nconst app = express();\napp.get('/', (req, res) => res.send('Hello'));\nmodule.exports = app;`;
+  }
+
+  private generateFastAPI(): string {
+    return `# AI-generated FastAPI backend\nfrom fastapi import FastAPI\napp = FastAPI()\n@app.get('/')\ndef read_root():\n    return {'Hello': 'World'}`;
+  }
+
+  private generateFirebase(): string {
+    return `// AI-generated Firebase Functions\nconst functions = require('firebase-functions');\nexports.hello = functions.https.onRequest((req, res) => {\n  res.send('Hello');\n});`;
+  }
+
+  private applyStyle(code: string, style: OutputStyle): string {
+    if (style === 'minimal') {
+      return code.replace(/^\s*\/\/.*$/gm, '').trim();
+    }
+    if (style === 'verbose') {
+      return `// Verbose mode\n${code}`;
+    }
+    return code;
   }
 }

--- a/apps/CoreForgeBuild/services/DiffService.ts
+++ b/apps/CoreForgeBuild/services/DiffService.ts
@@ -1,0 +1,17 @@
+import { diffLines } from 'diff';
+
+export class DiffService {
+  diff(oldStr: string, newStr: string): string {
+    const parts = diffLines(oldStr, newStr);
+    return parts
+      .map(p => {
+        const prefix = p.added ? '+' : p.removed ? '-' : ' ';
+        return p.value
+          .split('\n')
+          .filter(Boolean)
+          .map(line => `${prefix}${line}`)
+          .join('\n');
+      })
+      .join('\n');
+  }
+}

--- a/apps/CoreForgeBuild/services/EventBus.ts
+++ b/apps/CoreForgeBuild/services/EventBus.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from 'events';
+import { ParseResult } from './PromptParser';
+
+export interface GeneratedEvent {
+  target: string;
+  code: string;
+}
+
+export class EventBus extends EventEmitter {
+  emitParsed(result: ParseResult) {
+    this.emit('parsed', result);
+  }
+  emitGenerated(target: string, code: string) {
+    const payload: GeneratedEvent = { target, code };
+    this.emit('generated', payload);
+  }
+}

--- a/apps/CoreForgeBuild/services/FigmaImporter.ts
+++ b/apps/CoreForgeBuild/services/FigmaImporter.ts
@@ -1,0 +1,22 @@
+import { UIElement } from '../models/UIElement';
+
+export class FigmaImporter {
+  parse(input: string | Record<string, any>): UIElement[] {
+    const obj = typeof input === 'string' ? JSON.parse(input) : input;
+    if (!obj) return [];
+    const nodes = this.collectNodes(obj);
+    return nodes.map(n => ({
+      type: (n.type || 'frame').toLowerCase(),
+      props: { name: n.name || '' },
+      children: n.children ? this.parse(n.children) : undefined
+    }));
+  }
+
+  private collectNodes(obj: any): any[] {
+    if (Array.isArray(obj)) return obj;
+    if (obj.nodes) return Array.isArray(obj.nodes) ? obj.nodes : Object.values(obj.nodes);
+    if (obj.document && obj.document.children) return obj.document.children;
+    if (obj.children) return obj.children;
+    return [];
+  }
+}

--- a/apps/CoreForgeBuild/services/VersionHistory.ts
+++ b/apps/CoreForgeBuild/services/VersionHistory.ts
@@ -1,0 +1,23 @@
+import { UIElement } from '../models/UIElement';
+
+export interface VersionEntry {
+  timestamp: number;
+  prompt: string;
+  layout: UIElement[];
+}
+
+export class VersionHistory {
+  private history: VersionEntry[] = [];
+
+  add(entry: VersionEntry) {
+    this.history.push(entry);
+  }
+
+  latest(): VersionEntry | null {
+    return this.history[this.history.length - 1] || null;
+  }
+
+  all(): VersionEntry[] {
+    return [...this.history];
+  }
+}

--- a/apps/CoreForgeBuild/test/index.test.ts
+++ b/apps/CoreForgeBuild/test/index.test.ts
@@ -1,6 +1,9 @@
 import { TemplateService } from '../services/TemplateService';
 import { PromptParser } from '../services/PromptParser';
 import { CodeGenService } from '../services/CodeGenService';
+import { FigmaImporter } from '../services/FigmaImporter';
+import { EventBus } from '../services/EventBus';
+import { DiffService } from '../services/DiffService';
 import assert from 'node:assert';
 
 const svc = new TemplateService();
@@ -14,6 +17,24 @@ assert.strictEqual(result.layout.length, 2);
 const codegen = new CodeGenService();
 const reactCode = codegen.generate(result.layout, 'react');
 assert(reactCode.includes('<ul>'));
+
+// additional service tests
+const figma = new FigmaImporter();
+const nodes = figma.parse('{"nodes": [{"name": "Frame1", "type": "FRAME"}]}');
+assert.strictEqual(nodes.length, 1);
+
+const bus = new EventBus();
+let generated: string | null = null;
+bus.on('generated', (e) => (generated = e.code));
+bus.emitGenerated('react', '<div />');
+assert.strictEqual(generated, '<div />');
+
+const diff = new DiffService();
+const diffOutput = diff.diff('a', 'b');
+assert(diffOutput.includes('-a') && diffOutput.includes('+b'));
+
+const expressCode = codegen.generate([], 'express', 'minimal');
+assert(expressCode.includes('express'));
 
 console.log('CoreForgeBuild tests passed');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,299 @@
       "name": "creatorcoreforge-root",
       "workspaces": [
         "VisualLab",
-        "VoiceLab"
+        "VoiceLab",
+        "apps/CoreForgeBuild"
       ]
+    },
+    "apps/CoreForgeBuild": {
+      "name": "coreforge-build",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/diff": "^7.0.2",
+        "@types/react": "^19.1.8",
+        "diff": "^5.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.3.3"
+      }
+    },
+    "apps/CoreForgeBuild/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/coreforge-build": {
+      "resolved": "apps/CoreForgeBuild",
+      "link": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/visual-lab": {
       "resolved": "VisualLab",
@@ -17,6 +308,16 @@
     "node_modules/voicelab": {
       "resolved": "VoiceLab",
       "link": true
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "VisualLab": {
       "name": "visual-lab",
@@ -30,39 +331,6 @@
         "cross-env": "^7.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.3"
-      }
-    },
-    "VisualLab/node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "VisualLab/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "VisualLab/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "VisualLab/node_modules/@sentry-internal/tracing": {
@@ -132,75 +400,6 @@
         "node": ">=8"
       }
     },
-    "VisualLab/node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/@types/node": {
-      "version": "24.0.3",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
-    "VisualLab/node_modules/@types/react": {
-      "version": "19.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "VisualLab/node_modules/acorn": {
-      "version": "8.15.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "VisualLab/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "VisualLab/node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "VisualLab/node_modules/cross-env": {
       "version": "7.0.3",
       "dev": true,
@@ -231,19 +430,6 @@
         "node": ">= 8"
       }
     },
-    "VisualLab/node_modules/csstype": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VisualLab/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "VisualLab/node_modules/immediate": {
       "version": "3.0.6",
       "license": "MIT"
@@ -252,10 +438,6 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "VisualLab/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
     },
     "VisualLab/node_modules/lie": {
       "version": "3.1.1",
@@ -271,37 +453,12 @@
         "lie": "3.1.1"
       }
     },
-    "VisualLab/node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "VisualLab/node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
-    },
     "VisualLab/node_modules/path-key": {
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "VisualLab/node_modules/react": {
-      "version": "18.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "VisualLab/node_modules/shebang-command": {
@@ -323,71 +480,6 @@
         "node": ">=8"
       }
     },
-    "VisualLab/node_modules/ts-node": {
-      "version": "10.9.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "VisualLab/node_modules/typescript": {
-      "version": "5.8.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "VisualLab/node_modules/undici-types": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "VisualLab/node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "VisualLab/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -400,14 +492,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "VisualLab/node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "VoiceLab": {
@@ -919,17 +1003,6 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
-    },
-    "VoiceLab/node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "VoiceLab/node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
@@ -1836,34 +1909,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "VoiceLab/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "VoiceLab/node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "VoiceLab/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VoiceLab/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "VoiceLab/node_modules/@nodelib/fs.scandir": {
@@ -2121,26 +2172,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "VoiceLab/node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VoiceLab/node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VoiceLab/node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "VoiceLab/node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "VoiceLab/node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
@@ -2231,27 +2262,11 @@
         "parse5": "^7.0.0"
       }
     },
-    "VoiceLab/node_modules/@types/node": {
-      "version": "24.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
     "VoiceLab/node_modules/@types/prop-types": {
       "version": "15.7.15",
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "VoiceLab/node_modules/@types/react": {
-      "version": "19.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
     },
     "VoiceLab/node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2491,34 +2506,12 @@
       "dev": true,
       "license": "ISC"
     },
-    "VoiceLab/node_modules/acorn": {
-      "version": "8.15.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "VoiceLab/node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "VoiceLab/node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "VoiceLab/node_modules/agent-base": {
@@ -2602,11 +2595,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "VoiceLab/node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "VoiceLab/node_modules/argparse": {
       "version": "2.0.1",
@@ -3041,11 +3029,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "VoiceLab/node_modules/create-require": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "VoiceLab/node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -3075,11 +3058,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "VoiceLab/node_modules/csstype": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "VoiceLab/node_modules/data-urls": {
       "version": "5.0.0",
@@ -3209,14 +3187,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "VoiceLab/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "VoiceLab/node_modules/diff-sequences": {
@@ -5308,10 +5278,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "VoiceLab/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "VoiceLab/node_modules/js-yaml": {
       "version": "4.1.0",
       "dev": true,
@@ -5487,16 +5453,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "VoiceLab/node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "VoiceLab/node_modules/lru-cache": {
       "version": "5.1.1",
       "dev": true,
@@ -5537,11 +5493,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "VoiceLab/node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "VoiceLab/node_modules/makeerror": {
       "version": "1.0.12",
@@ -6067,16 +6018,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "VoiceLab/node_modules/react": {
-      "version": "18.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "VoiceLab/node_modules/react-dom": {
       "version": "18.3.1",
@@ -6778,48 +6719,6 @@
         }
       }
     },
-    "VoiceLab/node_modules/ts-node": {
-      "version": "10.9.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "VoiceLab/node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -6849,23 +6748,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "VoiceLab/node_modules/typescript": {
-      "version": "5.8.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "VoiceLab/node_modules/undici-types": {
-      "version": "7.8.0",
-      "dev": true,
-      "license": "MIT"
     },
     "VoiceLab/node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -6903,11 +6785,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "VoiceLab/node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "VoiceLab/node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -7185,14 +7062,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "VoiceLab/node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "VoiceLab/node_modules/yocto-queue": {


### PR DESCRIPTION
## Summary
- extend `CodeGenService` with additional targets and output style support
- add Figma importer, event bus, diff service, and version history utilities
- update tests to cover new services
- install `diff` and `@types/diff` dev dependencies

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685aad51d8e88321bc06c4aa3d6c993f