### PR TITLE
Implement export options for AudioExporter

### DIFF
--- a/Tests/CreatorCoreForgeTests/AudioExporterTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioExporterTests.swift
@@ -32,4 +32,22 @@ final class AudioExporterTests: XCTestCase {
         let zipPath = exporter.compressToZip(filePaths: ["a", "b"], zipName: "bundle")
         XCTAssertTrue(zipPath.hasSuffix("bundle.zip"))
     }
+
+    func testExportMultitrackOptionsExcludeLayers() {
+        let exporter = AudioExporter()
+        let voice = Data([0x00])
+        let ambient = Data([0x01])
+        let fx = Data([0x02])
+        let options = ExportOptions(includeAmbient: false, includeFX: false)
+        let path = exporter.exportMultitrack(voice: voice,
+                                             ambient: ambient,
+                                             fx: fx,
+                                             baseName: "mix",
+                                             options: options)
+        XCTAssertNotNil(path)
+        let base = FileManager.default.temporaryDirectory.appendingPathComponent("exports")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: base.appendingPathComponent("mix_ambient.wav").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: base.appendingPathComponent("mix_fx.wav").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: base.appendingPathComponent("mix_voice.wav").path))
+    }
 }


### PR DESCRIPTION
## Summary
- add `ExportOptions` struct for multitrack export customization
- allow `AudioExporter.exportMultitrack` to include or exclude ambient/FX layers
- test new options in `AudioExporterTests`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685ab18b6a148321bf47f433c585adcb