### PR TITLE
Implement user flow parsing

### DIFF
--- a/apps/CoreForgeBuild/services/PromptParser.ts
+++ b/apps/CoreForgeBuild/services/PromptParser.ts
@@ -3,6 +3,7 @@ import { UIElement } from '../models/UIElement';
 export interface ParseResult {
   language: string;
   layout: UIElement[];
+  flows: string[][];
 }
 
 /**
@@ -20,7 +21,8 @@ export class PromptParser {
     const language = this.detectLanguage(prompt);
     const normalized = this.normalize(prompt);
     const layout = this.parseMarkdown(normalized);
-    return { language, layout };
+    const flows = this.parseFlows(normalized);
+    return { language, layout, flows };
   }
 
   /**
@@ -76,5 +78,27 @@ export class PromptParser {
       }
     }
     return result;
+  }
+
+  /**
+   * Parse simple user flow descriptions like
+   * "login -> dashboard -> settings" into arrays
+   * of step names.
+   */
+  private parseFlows(text: string): string[][] {
+    const flows: string[][] = [];
+    const lines = text.split(/\n+/);
+    for (const line of lines) {
+      if (line.includes('->')) {
+        const steps = line
+          .split(/->/)
+          .map((s) => s.trim())
+          .filter(Boolean);
+        if (steps.length > 1) {
+          flows.push(steps);
+        }
+      }
+    }
+    return flows;
   }
 }

--- a/apps/CoreForgeBuild/test/index.test.ts
+++ b/apps/CoreForgeBuild/test/index.test.ts
@@ -10,9 +10,11 @@ const svc = new TemplateService();
 assert.strictEqual(svc.list().length, 2);
 
 const parser = new PromptParser();
-const result = parser.parse('# Login\n- Email\n- Password');
+const result = parser.parse('# Login\n- Email\n- Password\nlogin -> dashboard -> settings');
 assert.strictEqual(result.language, 'en');
-assert.strictEqual(result.layout.length, 2);
+assert.strictEqual(result.layout.length, 3);
+assert.strictEqual(result.flows.length, 1);
+assert.deepStrictEqual(result.flows[0], ['login', 'dashboard', 'settings']);
 
 const codegen = new CodeGenService();
 const reactCode = codegen.generate(result.layout, 'react');


### PR DESCRIPTION
## Summary
- extend `PromptParser` to detect user flow lines with `->`
- update tests to cover parsed flows

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685aaafe76788321984feb0f5bd464cf