### PR TITLE
Add scene shift detection

### DIFF
--- a/Sources/CreatorCoreForge/SceneDetector.swift
+++ b/Sources/CreatorCoreForge/SceneDetector.swift
@@ -1,10 +1,16 @@
 import Foundation
 
 /// Represents a single detected scene within raw text.
+public enum SceneShift: String, Codable {
+    case timeJump
+    case locationChange
+}
+
 public struct SceneMarker {
     public let index: Int
     public let text: String
     public let sentiment: LocalAIEnginePro.Sentiment
+    public let shifts: [SceneShift]
 }
 
 /// Collection of scene markers returned by `SceneDetector`.
@@ -25,12 +31,39 @@ public final class SceneDetector {
     public func analyze(text: String) -> SceneMap {
         let rawScenes = text.components(separatedBy: "\n\n")
         var markers: [SceneMarker] = []
+        var lastLocation: String?
         for (idx, raw) in rawScenes.enumerated() {
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
             let tone = sentimentEngine.analyzeSentiment(trimmed)
-            markers.append(SceneMarker(index: idx, text: trimmed, sentiment: tone))
+            var shifts: [SceneShift] = []
+            if idx > 0 {
+                if Self.containsTimeCue(trimmed) { shifts.append(.timeJump) }
+            }
+            if let loc = Self.detectLocation(trimmed) {
+                if let last = lastLocation, last != loc { shifts.append(.locationChange) }
+                lastLocation = loc
+            }
+            markers.append(SceneMarker(index: idx, text: trimmed, sentiment: tone, shifts: shifts))
         }
         return SceneMap(scenes: markers)
+    }
+
+    private static func containsTimeCue(_ text: String) -> Bool {
+        let cues = ["next day", "next morning", "the following day", "later", "years later", "months later", "previously", "earlier", "after"]
+        let lower = text.lowercased()
+        return cues.contains { lower.contains($0) }
+    }
+
+    private static func detectLocation(_ text: String) -> String? {
+        let pattern = #"\b(in|at|to|into|visited)\s+([A-Z][a-zA-Z]+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        guard let match = regex.firstMatch(in: text, range: range) else { return nil }
+        if match.numberOfRanges >= 3 {
+            return ns.substring(with: match.range(at: 2)).lowercased()
+        }
+        return nil
     }
 }

--- a/Tests/CreatorCoreForgeTests/SceneDetectorTests.swift
+++ b/Tests/CreatorCoreForgeTests/SceneDetectorTests.swift
@@ -10,4 +10,15 @@ final class SceneDetectorTests: XCTestCase {
         XCTAssertEqual(map.scenes[0].sentiment, .positive)
         XCTAssertEqual(map.scenes[1].sentiment, .negative)
     }
+
+    func testDetectsTimeAndLocationShifts() {
+        let text = "It was sunny.\n\nThe next day they were in Paris.\n\nA week later they visited London." 
+        let detector = SceneDetector()
+        let map = detector.analyze(text: text)
+        XCTAssertEqual(map.scenes.count, 3)
+        XCTAssertTrue(map.scenes[1].shifts.contains(.timeJump))
+        XCTAssertFalse(map.scenes[1].shifts.contains(.locationChange))
+        XCTAssertTrue(map.scenes[2].shifts.contains(.timeJump))
+        XCTAssertTrue(map.scenes[2].shifts.contains(.locationChange))
+    }
 }


### PR DESCRIPTION
## Summary
- enhance `SceneDetector` to detect time jumps and location changes
- test scene shift detection logic

## Testing
- `swift test`
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab` *(fails: Experimental loader not supported)*

------
https://chatgpt.com/codex/tasks/task_e_685ac1be8aac8321988a52afd0801848