### PR TITLE
Fix cross-platform fallbacks

### DIFF
--- a/Sources/CreatorCoreForge/SoundEffectManager.swift
+++ b/Sources/CreatorCoreForge/SoundEffectManager.swift
@@ -201,7 +201,10 @@ public final class SoundEffectManager {
         return reverb
     }
 #else
-    public func triggerReverbPreset(preset: ReverbStyle) {}
+    public func triggerReverbPreset(preset: ReverbStyle) -> StubReverb {
+        print("[SoundEffectManager] Reverb preset \(preset.rawValue) not supported on this platform")
+        return StubReverb()
+    }
 #endif
 }
 
@@ -221,6 +224,12 @@ public enum ReverbStyle: String, CaseIterable, Codable {
 #else
 public enum ReverbStyle: String, CaseIterable, Codable {
     case cathedral, cave, underwater, hall, dreamlike
+}
+
+/// Minimal stand-in for `AVAudioUnitReverb` when AVFoundation is unavailable.
+public struct StubReverb {
+    public var wetDryMix: Float = 0.0
+    public init() {}
 }
 #endif
 

--- a/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/UI/SchedulerDashboard.swift
+++ b/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/UI/SchedulerDashboard.swift
@@ -48,8 +48,16 @@ final class ScheduleModel: ObservableObject {
 #else
 final class ScheduleModel {
     static let shared = ScheduleModel()
-    func schedule(url: URL, platform: UploadScheduler.Platform, date: Date) {}
-    var items: [ScheduleItem] { [] }
+    private var internalItems: [ScheduleItem] = []
+    private let scheduler = UploadScheduler()
+
+    func schedule(url: URL, platform: UploadScheduler.Platform, date: Date) {
+        internalItems.append(ScheduleItem(url: url, platform: platform, date: date))
+        internalItems.sort { $0.date < $1.date }
+        scheduler.scheduleUpload(url: url, platform: platform, at: date)
+    }
+
+    var items: [ScheduleItem] { internalItems }
     struct ScheduleItem { let id = UUID(); let url: URL; let platform: UploadScheduler.Platform; let date: Date }
 }
 #endif


### PR DESCRIPTION
## Summary
- handle reverb presets when AVFoundation is unavailable
- add internal storage for SchedulerModel fallback implementation

## Testing
- `bash scripts/run_all_tests.sh` *(fails: TSError in coreforge-build)*

------
https://chatgpt.com/codex/tasks/task_e_685ad28217148321a57502823937e58c