### PR TITLE
Implement audio sandbox features

### DIFF
--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -263,9 +263,9 @@ This file is a full checklist of every feature required for code completion and 
 - [x] InlineWhisperSupport
 - [x] MidSentenceToneSwitching
 
-- [ ] SceneVolumeDynamics
-- [ ] SpatialPositioning
-- [ ] RoomSimulation
+- [x] SceneVolumeDynamics
+- [x] SpatialPositioning
+- [x] RoomSimulation
 
  - [x] MultiTrackExport
 - [x] EmotionCurveVisualizer
@@ -275,11 +275,11 @@ This file is a full checklist of every feature required for code completion and 
 - [x] MoodColorCoder
  - [x] AICastingDirector
  - [x] VoiceApprovalWorkflow
-- [ ] ScriptSnippetInjector
-- [ ] CreatorSandboxMode
-- [ ] DualNarratorToggle
-- [ ] VoiceDNAForking
-- [ ] FlashbackSceneEngine
+- [x] ScriptSnippetInjector
+- [x] CreatorSandboxMode
+- [x] DualNarratorToggle
+- [x] VoiceDNAForking
+- [x] FlashbackSceneEngine
 - [ ] ContinuityChecker
 - [ ] CrossoverEngine
 ## NSFW Features & Expansion (If Enabled)

--- a/generated/CoreForgeAudio/CreatorSandboxMode.py
+++ b/generated/CoreForgeAudio/CreatorSandboxMode.py
@@ -1,4 +1,26 @@
 # Auto-generated for CreatorSandboxMode
-def creatorsandboxmode():
-    """CreatorSandboxMode"""
-    pass
+"""Context manager for temporary sandbox workspaces."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def creatorsandboxmode(base_dir: str | None = None) -> Path:
+    """Yield a temporary directory for experimentation.
+
+    The directory is removed on exit.
+    """
+
+    path = Path(tempfile.mkdtemp(dir=base_dir))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+__all__ = ["creatorsandboxmode"]

--- a/generated/CoreForgeAudio/DualNarratorToggle.py
+++ b/generated/CoreForgeAudio/DualNarratorToggle.py
@@ -1,4 +1,34 @@
 # Auto-generated for DualNarratorToggle
-def dualnarratortoggle():
-    """DualNarratorToggle"""
-    pass
+"""Toggle overlay of a secondary narrator track."""
+
+from __future__ import annotations
+
+from pydub import AudioSegment
+
+
+def dualnarratortoggle(
+    primary: AudioSegment,
+    secondary: AudioSegment,
+    enabled: bool = False,
+    secondary_db: float = -6.0,
+) -> AudioSegment:
+    """Return combined narration if ``enabled`` else ``primary``.
+
+    Parameters
+    ----------
+    primary:
+        Main narration segment.
+    secondary:
+        Secondary narration segment.
+    enabled:
+        If ``True``, overlay ``secondary`` onto ``primary``.
+    secondary_db:
+        Volume adjustment for ``secondary`` in dB.
+    """
+
+    if not enabled:
+        return primary
+    return primary.overlay(secondary + secondary_db)
+
+
+__all__ = ["dualnarratortoggle"]

--- a/generated/CoreForgeAudio/FlashbackSceneEngine.py
+++ b/generated/CoreForgeAudio/FlashbackSceneEngine.py
@@ -1,4 +1,18 @@
 # Auto-generated for FlashbackSceneEngine
-def flashbacksceneengine():
-    """FlashbackSceneEngine"""
-    pass
+"""Apply a flashback-style audio effect."""
+
+from __future__ import annotations
+
+from pydub import AudioSegment, effects
+
+
+def flashbacksceneengine(segment: AudioSegment, depth: float = 0.5) -> AudioSegment:
+    """Return ``segment`` filtered with a simple "memory" effect."""
+
+    depth = max(0.0, min(depth, 1.0))
+    filtered = effects.low_pass_filter(segment, cutoff=1200)
+    echo = filtered - (depth * 10)
+    return filtered.overlay(echo, position=50)
+
+
+__all__ = ["flashbacksceneengine"]

--- a/generated/CoreForgeAudio/ScriptSnippetInjector.py
+++ b/generated/CoreForgeAudio/ScriptSnippetInjector.py
@@ -1,4 +1,29 @@
 # Auto-generated for ScriptSnippetInjector
-def scriptsnippetinjector():
-    """ScriptSnippetInjector"""
-    pass
+"""Utilities to inject text snippets into a script."""
+
+from __future__ import annotations
+
+
+def scriptsnippetinjector(script: str, snippet: str, line: int | None = None) -> str:
+    """Return ``script`` with ``snippet`` inserted at ``line``.
+
+    Parameters
+    ----------
+    script:
+        Original script text.
+    snippet:
+        Text to insert.
+    line:
+        Line index (0-based) at which to insert ``snippet``. ``None`` appends
+        to the end.
+    """
+
+    lines = script.splitlines()
+    if line is None or line >= len(lines):
+        lines.append(snippet)
+    else:
+        lines.insert(max(line, 0), snippet)
+    return "\n".join(lines)
+
+
+__all__ = ["scriptsnippetinjector"]

--- a/generated/CoreForgeAudio/VoiceDNAForking.py
+++ b/generated/CoreForgeAudio/VoiceDNAForking.py
@@ -1,4 +1,29 @@
 # Auto-generated for VoiceDNAForking
-def voicednaforking():
-    """VoiceDNAForking"""
-    pass
+"""Create derivative voice profiles."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from uuid import uuid4
+
+from .VoicePersonalityProfiles import VoiceProfile
+
+
+def voicednaforking(
+    profile: VoiceProfile,
+    pitch: float | None = None,
+    rate: float | None = None,
+    tone: str | None = None,
+) -> VoiceProfile:
+    """Return a new :class:`VoiceProfile` forked from ``profile``."""
+
+    return replace(
+        profile,
+        name=f"{profile.name}_fork_{uuid4().hex[:8]}",
+        pitch=pitch if pitch is not None else profile.pitch,
+        rate=rate if rate is not None else profile.rate,
+        tone=tone if tone is not None else profile.tone,
+    )
+
+
+__all__ = ["voicednaforking"]

--- a/tests/python/test_audio_enhancements.py
+++ b/tests/python/test_audio_enhancements.py
@@ -14,6 +14,12 @@ from generated.CoreForgeAudio.MidSentenceToneSwitching import midsentencetoneswi
 from generated.CoreForgeAudio.SceneVolumeDynamics import scenevolumedynamics
 from generated.CoreForgeAudio.SpatialPositioning import spatialpositioning
 from generated.CoreForgeAudio.RoomSimulation import roomsimulation
+from generated.CoreForgeAudio.ScriptSnippetInjector import scriptsnippetinjector
+from generated.CoreForgeAudio.CreatorSandboxMode import creatorsandboxmode
+from generated.CoreForgeAudio.DualNarratorToggle import dualnarratortoggle
+from generated.CoreForgeAudio.VoiceDNAForking import voicednaforking
+from generated.CoreForgeAudio.FlashbackSceneEngine import flashbacksceneengine
+from generated.CoreForgeAudio.VoicePersonalityProfiles import VoiceProfile
 
 
 def _tone(duration=200):
@@ -65,4 +71,38 @@ def test_spatial_positioning():
 def test_room_simulation():
     tone = _tone(300)
     out = roomsimulation(tone, delay_ms=50, decay=0.5, repeats=1)
+    assert len(out) >= len(tone)
+
+
+def test_script_snippet_injector():
+    script = "a\nb"
+    out = scriptsnippetinjector(script, "X", 1)
+    assert out.splitlines()[1] == "X"
+
+
+def test_creator_sandbox_mode(tmp_path: Path):
+    with creatorsandboxmode() as path:
+        p = path / "test.txt"
+        p.write_text("hi")
+        assert p.is_file()
+    assert not p.exists()
+
+
+def test_dual_narrator_toggle():
+    primary = _tone(200)
+    secondary = _tone(200)
+    out = dualnarratortoggle(primary, secondary, enabled=True)
+    assert len(out) == len(primary)
+
+
+def test_voice_dna_forking():
+    base = VoiceProfile(name="hero")
+    fork = voicednaforking(base, pitch=1.1)
+    assert fork.name != base.name
+    assert fork.pitch == 1.1
+
+
+def test_flashback_scene_engine():
+    tone = _tone(200)
+    out = flashbacksceneengine(tone)
     assert len(out) >= len(tone)


### PR DESCRIPTION
## Summary
- add ScriptSnippetInjector, CreatorSandboxMode, DualNarratorToggle, VoiceDNAForking, and FlashbackSceneEngine modules
- expand audio tests to cover new modules
- mark first eight open tasks complete in CoreForge Audio AGENTS checklist

## Testing
- `scripts/run_all_tests.sh` *(fails: TSError in apps/CoreForgeBuild)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad29907288321b728625c19d36d7e