### PR TITLE
Fix fastlane build script for all Xcode projects

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,10 +58,10 @@ platform :ios do
 
   desc "Build and upload all iOS apps"
   lane :build_all do
-    Dir["../apps/*"].each do |app_path|
-      scheme = File.basename(app_path)
-      next if %w[AGENTS.md README.md].include?(scheme)
-      sh("bundle exec fastlane build_and_upload PROJECT_PATH=#{app_path}/#{scheme}.xcodeproj SCHEME=#{scheme}")
+    Dir["../apps/**/*.xcodeproj"].each do |project|
+      next if project.include?("openai-swift")
+      scheme = File.basename(project, ".xcodeproj")
+      sh("bundle exec fastlane build_and_upload PROJECT_PATH=#{project} SCHEME=#{scheme}")
     end
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -19,4 +19,4 @@ SCHEME=CoreForgeWriter bundle exec fastlane build_and_upload
 bundle exec fastlane build_all
 ```
 
-`build_all` iterates over each directory in `../apps` (excluding `AGENTS.md` and `README.md`) and runs `build_and_upload` with the matching scheme name.
+`build_all` searches for every `.xcodeproj` under `../apps` and runs `build_and_upload` with the matching scheme. Projects under `openai-swift` are skipped.


### PR DESCRIPTION
## Summary
- update `fastlane` build_all lane to locate every `.xcodeproj`
- document new build_all behaviour in README

## Testing
- `npm ci`/`npm run lint`/`npm run build`/`npm test` in VoiceLab
- `npm ci`/`npm test` in VisualLab
- `swift test --enable-code-coverage` *(fails: exited with signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685af8fe86c08321861bfb568c0d52a8