### PR TITLE
Fix workflow names and cleanup

### DIFF
--- a/.github/workflows/fastlane-testflight.yml
+++ b/.github/workflows/fastlane-testflight.yml
@@ -9,7 +9,6 @@ jobs:
   build-and-upload:
     runs-on: macos-latest
 
-=======
     strategy:
       matrix:
         app:

--- a/.github/workflows/upload-appstore.yml
+++ b/.github/workflows/upload-appstore.yml
@@ -7,7 +7,6 @@ jobs:
   build-and-upload:
     runs-on: macos-latest
 
-=======
     strategy:
       matrix:
         app:

--- a/.github/workflows/upload-coreforgevisual-testflight.yml
+++ b/.github/workflows/upload-coreforgevisual-testflight.yml
@@ -1,4 +1,4 @@
-name: Upload LoreForgeAI to TestFlight
+name: Upload CoreForge Visual to TestFlight
 
 on:
   workflow_dispatch:

--- a/.github/workflows/upload-testflight.yml
+++ b/.github/workflows/upload-testflight.yml
@@ -7,7 +7,6 @@ jobs:
   build-and-upload:
     runs-on: macos-latest
 
-=======
     strategy:
       matrix:
         app:


### PR DESCRIPTION
## Summary
- clean up stray separator lines in GitHub Actions
- rename visual deployment workflow

## Testing
- `npm test` *(fails: merge conflict markers in TypeScript files)*
- `swift test` *(fails: compile errors in Swift sources)*

------
https://chatgpt.com/codex/tasks/task_e_685b0df7ccd08321b26775290f42a711