### PR TITLE
Add App Store workflow for CoreForge Audio

### DIFF
--- a/.github/workflows/upload-coreforgeaudio-appstore.yml
+++ b/.github/workflows/upload-coreforgeaudio-appstore.yml
@@ -1,0 +1,35 @@
+name: Upload CoreForge Audio to App Store
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_deliver:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.0"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+
+      - name: Install Fastlane
+        run: gem install fastlane
+
+      - name: Build and Deliver CoreForge Audio
+        env:
+          PROJECT_PATH: apps/CoreForgeAudio/CoreForgeAudio.xcodeproj
+          SCHEME: CoreForgeAudio
+          APPSTORECONNECT_KEY_ID: ${{ secrets.APPSTORECONNECT_KEY_ID }}
+          APPSTORECONNECT_ISSUER_ID: ${{ secrets.APPSTORECONNECT_ISSUER_ID }}
+          APPSTORECONNECT_API_KEY: ${{ secrets.APPSTORECONNECT_API_KEY }}
+          APPSTORECONNECT_TEAM_ID: ${{ secrets.APPSTORECONNECT_TEAM_ID }}
+        run: fastlane build_and_deliver


### PR DESCRIPTION
## Summary
- add workflow to deliver CoreForge Audio to App Store

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b1df5e70c8321aa48452caa608124