### PR TITLE
Integrate auto updater with CoreForge Build

### DIFF
--- a/apps/CoreForgeBuild/services/AutoUpdaterService.ts
+++ b/apps/CoreForgeBuild/services/AutoUpdaterService.ts
@@ -1,0 +1,24 @@
+export class AutoUpdaterService {
+  constructor(private updateUrl: string = 'https://example.com/latest.json') {}
+
+  async checkForUpdate(currentVersion: string): Promise<string | null> {
+    const res = await fetch(this.updateUrl);
+    const json = await res.json().catch(() => null);
+    const latest = json?.version as string | undefined;
+    if (!latest) return null;
+    return this.compare(latest, currentVersion) > 0 ? latest : null;
+  }
+
+  private compare(a: string, b: string): number {
+    const pa = a.split('.').map(n => parseInt(n));
+    const pb = b.split('.').map(n => parseInt(n));
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+      const va = pa[i] || 0;
+      const vb = pb[i] || 0;
+      if (va > vb) return 1;
+      if (va < vb) return -1;
+    }
+    return 0;
+  }
+}

--- a/apps/CoreForgeBuild/test/autoupdater.test.ts
+++ b/apps/CoreForgeBuild/test/autoupdater.test.ts
@@ -1,0 +1,16 @@
+import http from 'node:http';
+import assert from 'node:assert';
+import { AutoUpdaterService } from '../services/AutoUpdaterService';
+
+const server = http.createServer((_, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ version: '2.0' }));
+});
+
+server.listen(0, async () => {
+  const { port } = server.address() as any;
+  const svc = new AutoUpdaterService(`http://localhost:${port}`);
+  const latest = await svc.checkForUpdate('1.0');
+  assert.strictEqual(latest, '2.0');
+  server.close(() => console.log('AutoUpdaterService tests passed'));
+});

--- a/apps/CoreForgeBuild/test/index.test.ts
+++ b/apps/CoreForgeBuild/test/index.test.ts
@@ -182,6 +182,7 @@ import { ParseHistory } from '../services/ParseHistory';
 
   console.log('CoreForgeBuild tests passed');
   require('./collaboration.test');
+  require("./autoupdater.test");
   require('./pluginmanager.test');
   require('./advanced.test');
 })();

--- a/generated/CoreForgeBuild/Integrate_shared_autoUpdater_swift.swift
+++ b/generated/CoreForgeBuild/Integrate_shared_autoUpdater_swift.swift
@@ -1,4 +1,11 @@
-# Auto-generated for Integrate shared `autoUpdater.swift`
-func integrate_shared_autoupdater() {
-    // Integrate shared `autoUpdater.swift`
+import Foundation
+import CreatorCoreForge
+
+public func integrate_shared_autoupdater(version: String = "1.0",
+                                         url: URL = URL(string: "https://example.com/latest.json")!,
+                                         completion: @escaping (String?) -> Void) {
+    let updater = AutoUpdater(updateURL: url)
+    updater.checkForUpdate(currentVersion: version) { newVersion in
+        completion(newVersion)
+    }
 }


### PR DESCRIPTION
## Summary
- implement `AutoUpdaterService` for the Build app
- hook new auto updater tests into existing test suite
- wire Swift helper to shared `AutoUpdater`

## Testing
- `npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b3bc419ec8321b677941a405fd0f2