### PR TITLE
Implement basic settings and playback controller

### DIFF
--- a/Sources/CreatorCoreForge/AppSettings.swift
+++ b/Sources/CreatorCoreForge/AppSettings.swift
@@ -1,0 +1,63 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+
+/// Stores global settings including NSFW access, offline mode, and performance quality.
+public final class AppSettings: ObservableObject {
+    public static let shared = AppSettings()
+
+    @Published public var allowNSFW: Bool
+    @Published public var offlineMode: Bool
+    @Published public var performance: PerformanceMode
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.allowNSFW = defaults.bool(forKey: "CF_allowNSFW")
+        self.offlineMode = defaults.bool(forKey: "CF_offlineMode")
+        if let raw = defaults.string(forKey: "CF_performanceMode"),
+           let mode = PerformanceMode(rawValue: raw) {
+            self.performance = mode
+        } else {
+            self.performance = .standard
+        }
+    }
+
+    /// Persist the current settings to user defaults.
+    public func save() {
+        defaults.set(allowNSFW, forKey: "CF_allowNSFW")
+        defaults.set(offlineMode, forKey: "CF_offlineMode")
+        defaults.set(performance.rawValue, forKey: "CF_performanceMode")
+    }
+}
+#else
+/// Stores global settings including NSFW access, offline mode, and performance quality.
+public final class AppSettings {
+    public static let shared = AppSettings()
+
+    public var allowNSFW: Bool
+    public var offlineMode: Bool
+    public var performance: PerformanceMode
+
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.allowNSFW = defaults.bool(forKey: "CF_allowNSFW")
+        self.offlineMode = defaults.bool(forKey: "CF_offlineMode")
+        if let raw = defaults.string(forKey: "CF_performanceMode"),
+           let mode = PerformanceMode(rawValue: raw) {
+            self.performance = mode
+        } else {
+            self.performance = .standard
+        }
+    }
+
+    public func save() {
+        defaults.set(allowNSFW, forKey: "CF_allowNSFW")
+        defaults.set(offlineMode, forKey: "CF_offlineMode")
+        defaults.set(performance.rawValue, forKey: "CF_performanceMode")
+    }
+}
+#endif

--- a/Sources/CreatorCoreForge/AudioPlaybackController.swift
+++ b/Sources/CreatorCoreForge/AudioPlaybackController.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Coordinates playback engine and UI updates for streaming audio.
+public final class AudioPlaybackController {
+    private let engine: AudioPlaybackEngine
+    private let ui: PlaybackUIController
+
+    public init(engine: AudioPlaybackEngine = .init(),
+                ui: PlaybackUIController = .init()) {
+        self.engine = engine
+        self.ui = ui
+    }
+
+    /// Load an audio file and begin playback with basic UI updates.
+    public func loadAndPlay(url: URL) {
+        engine.load(url: url)
+        ui.displayChapterTitle(url.deletingPathExtension().lastPathComponent)
+        engine.play()
+        ui.showPlayButton()
+    }
+
+    public func pause() {
+        engine.pause()
+        ui.showPauseButton()
+    }
+
+    public func resume() {
+        engine.play()
+        ui.showPlayButton()
+    }
+
+    public func stop() {
+        engine.stop()
+        ui.enableControls(false)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AppSettingsTests.swift
+++ b/Tests/CreatorCoreForgeTests/AppSettingsTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AppSettingsTests: XCTestCase {
+    func testSaveAndLoad() {
+        let suite = UserDefaults(suiteName: "AppSettingsTests")!
+        suite.removePersistentDomain(forName: "AppSettingsTests")
+        var settings = AppSettings(defaults: suite)
+        XCTAssertFalse(settings.allowNSFW)
+        settings.allowNSFW = true
+        settings.offlineMode = true
+        settings.performance = .cinematic
+        settings.save()
+        settings = AppSettings(defaults: suite)
+        XCTAssertTrue(settings.allowNSFW)
+        XCTAssertTrue(settings.offlineMode)
+        XCTAssertEqual(settings.performance, .cinematic)
+        suite.removePersistentDomain(forName: "AppSettingsTests")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AudioPlaybackControllerTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioPlaybackControllerTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AudioPlaybackControllerTests: XCTestCase {
+    func testPlaybackFlow() {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("sample.wav")
+        try? Data().write(to: tmp)
+        let controller = AudioPlaybackController()
+        controller.loadAndPlay(url: tmp)
+        controller.pause()
+        controller.resume()
+        controller.stop()
+    }
+}


### PR DESCRIPTION
## Summary
- add `AppSettings` model with NSFW, offline, and performance toggles
- add `AudioPlaybackController` to coordinate audio engine and UI
- test settings persistence and playback controller flow

## Testing
- `npm test --silent` in `VoiceLab`
- `npm test --silent` in `VisualLab`
- `swift test` *(fails: unexpected signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d7fc2dc83219727354b87c5ba6d