### PR TITLE
Add NSFWMode manager

### DIFF
--- a/Sources/CreatorCoreForge/NSFWMode.swift
+++ b/Sources/CreatorCoreForge/NSFWMode.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Manages global NSFW mode with age verification using `AgeIDVerifier` and persistent
+/// storage via `AppSettings`. When enabled, NSFW features become accessible
+/// across the app.
+public final class NSFWMode {
+    private let settings: AppSettings
+    private let verifier: AgeIDVerifier
+
+    public init(settings: AppSettings = .shared,
+                verifier: AgeIDVerifier = AgeIDVerifier()) {
+        self.settings = settings
+        self.verifier = verifier
+    }
+
+    /// Indicates whether NSFW mode is currently active and verified.
+    public var isEnabled: Bool {
+        settings.allowNSFW && verifier.isVerified
+    }
+
+    /// Attempts to enable NSFW mode by validating the provided birthdate
+    /// and ID number. Returns `true` on success.
+    @discardableResult
+    public func enable(birthdate: Date, idNumber: String) -> Bool {
+        guard verifier.verify(birthdate: birthdate, idNumber: idNumber) else {
+            return false
+        }
+        settings.allowNSFW = true
+        settings.save()
+        return true
+    }
+
+    /// Disables NSFW mode and persists the updated setting.
+    public func disable() {
+        settings.allowNSFW = false
+        settings.save()
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWModeTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWModeTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWModeTests: XCTestCase {
+    func testEnableAndDisableFlow() {
+        let suite = UserDefaults(suiteName: "NSFWModeTests")!
+        suite.removePersistentDomain(forName: "NSFWModeTests")
+        let settings = AppSettings(defaults: suite)
+        let verifier = AgeIDVerifier(store: suite)
+        let mode = NSFWMode(settings: settings, verifier: verifier)
+
+        XCTAssertFalse(mode.isEnabled)
+        XCTAssertTrue(mode.enable(birthdate: Date(timeIntervalSince1970: 0), idNumber: "123456"))
+        XCTAssertTrue(mode.isEnabled)
+
+        mode.disable()
+        XCTAssertFalse(mode.isEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
- add `NSFWMode` class for age-gated NSFW toggle
- add unit test verifying enable/disable behavior

## Testing
- `swift test -q` *(fails: NarrationSchedulerTests.testScheduleExecutes)*

------
https://chatgpt.com/codex/tasks/task_e_685b3fce13248321bee7c0203011eaa3