### PR TITLE
Add minimal build helper modules

### DIFF
--- a/Sources/CreatorCoreForge/BuildQueueController.swift
+++ b/Sources/CreatorCoreForge/BuildQueueController.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Controls a queue of build tasks across multiple platforms.
+public final class BuildQueueController {
+    private var queue: [() -> String] = []
+    private let lock = DispatchQueue(label: "BuildQueueController")
+
+    public init() {}
+
+    /// Add a build step returning a build path.
+    public func enqueue(_ block: @escaping () -> String) {
+        lock.async { self.queue.append(block) }
+    }
+
+    /// Run the next build step if any and return its output.
+    @discardableResult
+    public func runNext() -> String? {
+        var task: (() -> String)?
+        lock.sync {
+            if !self.queue.isEmpty { task = self.queue.removeFirst() }
+        }
+        return task?()
+    }
+
+    /// Cancel all pending tasks.
+    public func cancelAll() {
+        lock.async { self.queue.removeAll() }
+    }
+
+    /// Number of pending build steps.
+    public var pending: Int { lock.sync { queue.count } }
+}

--- a/Sources/CreatorCoreForge/ExportManager.swift
+++ b/Sources/CreatorCoreForge/ExportManager.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Simplified export handler for CoreForge Build projects.
+public struct ExportManager {
+    public init() {}
+
+    /// Export an app bundle for the given platform into the output directory.
+    public func export(platform: String, output: String) -> String {
+        let path = URL(fileURLWithPath: output).appendingPathComponent("\(platform).bundle").path
+        FileManager.default.createFile(atPath: path, contents: Data(), attributes: nil)
+        return path
+    }
+
+    /// Validate exported file exists.
+    public func validate(path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}

--- a/Sources/CreatorCoreForge/LivePreviewPane.swift
+++ b/Sources/CreatorCoreForge/LivePreviewPane.swift
@@ -1,0 +1,45 @@
+#if canImport(SwiftUI) && canImport(WebKit)
+import SwiftUI
+import WebKit
+
+/// SwiftUI view that renders a preview URL in a simple device frame.
+public struct LivePreviewPane: View {
+    public enum Device {
+        case iOS, android, web
+    }
+
+    public var url: URL
+    public var device: Device = .web
+
+    public init(url: URL, device: Device = .web) {
+        self.url = url
+        self.device = device
+    }
+
+    public var body: some View {
+        WebView(url: url)
+            .frame(width: frameSize.width, height: frameSize.height)
+            .border(Color.gray)
+    }
+
+    private var frameSize: CGSize {
+        switch device {
+        case .iOS: return CGSize(width: 375, height: 667)
+        case .android: return CGSize(width: 360, height: 640)
+        case .web: return CGSize(width: 800, height: 600)
+        }
+    }
+}
+
+private struct WebView: NSViewRepresentable {
+    let url: URL
+
+    func makeNSView(context: Context) -> WKWebView {
+        return WKWebView()
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        webView.load(URLRequest(url: url))
+    }
+}
+#endif

--- a/Sources/CreatorCoreForge/PromptParserEngine.swift
+++ b/Sources/CreatorCoreForge/PromptParserEngine.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Simple engine converting natural input to a very basic schema and logic flow.
+public struct PromptParserEngine {
+    private let parser: PromptParser
+
+    public init(parser: PromptParser = PromptParser()) {
+        self.parser = parser
+    }
+
+    /// Parse text and return normalized text with flows separated by arrows.
+    public func parseSchema(from text: String) -> (normalized: String, flows: [[String]]) {
+        let result = parser.parse(text)
+        let flows = text
+            .split(separator: "\n")
+            .filter { $0.contains("->") }
+            .map { $0.split(separator: "->").map { $0.trimmingCharacters(in: .whitespaces) } }
+        return (result.text, flows)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/BuildQueueControllerTests.swift
+++ b/Tests/CreatorCoreForgeTests/BuildQueueControllerTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class BuildQueueControllerTests: XCTestCase {
+    func testEnqueueAndRun() {
+        let controller = BuildQueueController()
+        controller.enqueue { "out" }
+        XCTAssertEqual(controller.pending, 1)
+        XCTAssertEqual(controller.runNext(), "out")
+        XCTAssertEqual(controller.pending, 0)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/ExportManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ExportManagerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ExportManagerTests: XCTestCase {
+    func testExportAndValidate() {
+        let manager = ExportManager()
+        let path = manager.export(platform: "ios", output: "/tmp")
+        XCTAssertTrue(manager.validate(path: path))
+    }
+}

--- a/apps/CoreForgeBuild/components/AICopilot.tsx
+++ b/apps/CoreForgeBuild/components/AICopilot.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+
+export interface AICopilotProps {
+  onAsk?: (question: string) => Promise<string>;
+}
+
+export const AICopilot: React.FC<AICopilotProps> = ({ onAsk }) => {
+  const [text, setText] = useState('');
+  const [reply, setReply] = useState('');
+  const ask = async () => {
+    const r = (await onAsk?.(text)) || 'No response';
+    setReply(r);
+  };
+  return (
+    <div>
+      <input value={text} onChange={e => setText(e.target.value)} />
+      <button onClick={ask}>Ask</button>
+      <pre>{reply}</pre>
+    </div>
+  );
+};

--- a/apps/CoreForgeBuild/components/FormBuilderEngine.tsx
+++ b/apps/CoreForgeBuild/components/FormBuilderEngine.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+export interface Field {
+  name: string;
+  label: string;
+  type: 'text' | 'number' | 'email';
+  required?: boolean;
+}
+
+export interface FormBuilderEngineProps {
+  onChange?: (fields: Field[]) => void;
+}
+
+export const FormBuilderEngine: React.FC<FormBuilderEngineProps> = ({ onChange }) => {
+  const [fields, setFields] = useState<Field[]>([]);
+  const addField = () => {
+    const newField: Field = { name: `field${fields.length + 1}`, label: 'Label', type: 'text' };
+    const next = [...fields, newField];
+    setFields(next);
+    onChange?.(next);
+  };
+  const updateField = (index: number, key: keyof Field, value: string | boolean) => {
+    const next = fields.map((f, i) => (i === index ? { ...f, [key]: value } : f));
+    setFields(next);
+    onChange?.(next);
+  };
+  return (
+    <div>
+      <button onClick={addField}>Add Field</button>
+      {fields.map((f, i) => (
+        <div key={i}>
+          <input
+            value={f.label}
+            onChange={e => updateField(i, 'label', e.target.value)}
+          />
+          <select value={f.type} onChange={e => updateField(i, 'type', e.target.value as Field['type'])}>
+            <option value="text">Text</option>
+            <option value="number">Number</option>
+            <option value="email">Email</option>
+          </select>
+          <label>
+            Required
+            <input
+              type="checkbox"
+              checked={f.required}
+              onChange={e => updateField(i, 'required', e.target.checked)}
+            />
+          </label>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/apps/CoreForgeBuild/services/TeamSyncManager.ts
+++ b/apps/CoreForgeBuild/services/TeamSyncManager.ts
@@ -1,0 +1,20 @@
+export interface Collaborator {
+  id: string;
+  role: string;
+}
+
+export class TeamSyncManager {
+  private members = new Map<string, Collaborator>();
+
+  addMember(user: Collaborator) {
+    this.members.set(user.id, user);
+  }
+
+  removeMember(id: string) {
+    this.members.delete(id);
+  }
+
+  list(): Collaborator[] {
+    return Array.from(this.members.values());
+  }
+}

--- a/apps/CoreForgeBuild/services/TestingSuite.ts
+++ b/apps/CoreForgeBuild/services/TestingSuite.ts
@@ -1,0 +1,18 @@
+import { execSync } from 'child_process';
+
+export class TestingSuite {
+  /** Generate a dummy test case */
+  generate(module: string): string[] {
+    return [`should test ${module}`, `should validate ${module}`];
+  }
+
+  /** Run npm test and return whether it succeeded */
+  run(): boolean {
+    try {
+      execSync('npm test --workspaces', { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/CoreForgeBuild/test/teamsync.test.ts
+++ b/apps/CoreForgeBuild/test/teamsync.test.ts
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import { TeamSyncManager } from '../services/TeamSyncManager';
+
+const mgr = new TeamSyncManager();
+mgr.addMember({ id: 'u1', role: 'Owner' });
+assert.strictEqual(mgr.list().length, 1);
+mgr.removeMember('u1');
+assert.strictEqual(mgr.list().length, 0);
+console.log('TeamSyncManager tests passed');

--- a/apps/CoreForgeBuild/test/testingsuite.test.ts
+++ b/apps/CoreForgeBuild/test/testingsuite.test.ts
@@ -1,0 +1,6 @@
+import assert from 'node:assert';
+import { TestingSuite } from '../services/TestingSuite';
+
+const suite = new TestingSuite();
+assert.strictEqual(suite.generate('module').length, 2);
+console.log('TestingSuite generate test passed');


### PR DESCRIPTION
## Summary
- stub out PromptParserEngine and BuildQueueController
- add LivePreviewPane with conditional SwiftUI usage
- include ExportManager for packaging
- implement FormBuilderEngine, AI Copilot component, and supporting services
- add simple Swift and TypeScript tests

## Testing
- `npm test --silent`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b409623248321a0676892ed451b64