### PR TITLE
Add CoreForgeAudioIntegrator bridging module

### DIFF
--- a/Sources/CreatorCoreForge/CoreForgeAudioIntegrator.swift
+++ b/Sources/CreatorCoreForge/CoreForgeAudioIntegrator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Provides unified access to core audio modules for the app UI and services.
+public struct CoreForgeAudioIntegrator {
+    public let voiceManager: VoiceManager
+    public let ambientMixer: AmbientMixer
+    public let exportSystem: ExportSystem
+    public let segmentEngine: SegmentEngine
+    public let nsfwMode: NSFWMode
+    public let offlineQueue: OfflineQueue
+    public let settings: AppSettings
+    public let memoryEngine: MemoryEngine
+    public let playbackController: AudioPlaybackController
+
+    public init(settings: AppSettings = .shared) {
+        self.voiceManager = VoiceManager()
+        self.ambientMixer = AmbientMixer()
+        self.exportSystem = ExportSystem()
+        self.segmentEngine = SegmentEngine()
+        self.nsfwMode = NSFWMode(settings: settings)
+        self.offlineQueue = OfflineQueue()
+        self.settings = settings
+        self.memoryEngine = MemoryEngine()
+        self.playbackController = AudioPlaybackController()
+    }
+}


### PR DESCRIPTION
## Summary
- add `CoreForgeAudioIntegrator` for unified access to all core audio modules

## Testing
- `swift build`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b434216a88321a8ee5aae690a16fa