### PR TITLE
Improve NetworkInfoProvider error handling

### DIFF
--- a/Sources/CreatorCoreForge/NetworkInfoProvider.swift
+++ b/Sources/CreatorCoreForge/NetworkInfoProvider.swift
@@ -4,6 +4,12 @@ import FoundationNetworking
 #endif
 
 /// Provides simple JSON dictionary fetches from remote endpoints.
+public enum NetworkInfoError: Error, Equatable {
+    case network(String)
+    case invalidResponse
+    case decoding(String)
+}
+
 public final class NetworkInfoProvider {
     private let session: URLSession
 
@@ -12,16 +18,37 @@ public final class NetworkInfoProvider {
     }
 
     /// Retrieve a `[String: String]` dictionary from the given URL.
-    /// Returns `nil` if decoding fails or the status code isn't 200.
-    public func fetchInfo(from url: URL, completion: @escaping ([String: String]?) -> Void) {
-        session.dataTask(with: url) { data, response, _ in
-            guard let data = data,
-                  let dict = try? JSONDecoder().decode([String: String].self, from: data),
-                  (response as? HTTPURLResponse)?.statusCode == 200 else {
-                completion(nil)
-                return
-            }
-            completion(dict)
-        }.resume()
+    /// Handles network errors, non-200 responses, and JSON decoding issues.
+    /// - Parameters:
+    ///   - url: Endpoint returning a JSON dictionary.
+    ///   - retryCount: Number of retry attempts on transient failures.
+    ///   - completion: Result containing dictionary or `NetworkInfoError`.
+    public func fetchInfo(from url: URL,
+                          retryCount: Int = 0,
+                          completion: @escaping (Result<[String: String], NetworkInfoError>) -> Void) {
+        func attempt(_ count: Int) {
+            session.dataTask(with: url) { data, response, error in
+                if let error = error {
+                    if count > 0 {
+                        attempt(count - 1)
+                        return
+                    }
+                    completion(.failure(.network(error.localizedDescription)))
+                    return
+                }
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+                      let data = data else {
+                    completion(.failure(.invalidResponse))
+                    return
+                }
+                do {
+                    let dict = try JSONDecoder().decode([String: String].self, from: data)
+                    completion(.success(dict))
+                } catch {
+                    completion(.failure(.decoding(error.localizedDescription)))
+                }
+            }.resume()
+        }
+        attempt(retryCount)
     }
 }

--- a/Tests/CreatorCoreForgeTests/NetworkInfoProviderTests.swift
+++ b/Tests/CreatorCoreForgeTests/NetworkInfoProviderTests.swift
@@ -32,8 +32,13 @@ final class NetworkInfoProviderTests: XCTestCase {
         let session = URLSession(configuration: config)
         let provider = NetworkInfoProvider(session: session)
         let exp = expectation(description: "info")
-        provider.fetchInfo(from: URL(string: "https://example.com/info")!) { info in
-            XCTAssertEqual(info?["key"], "value")
+        provider.fetchInfo(from: URL(string: "https://example.com/info")!) { result in
+            switch result {
+            case .success(let info):
+                XCTAssertEqual(info["key"], "value")
+            case .failure(let error):
+                XCTFail("Unexpected failure: \(error)")
+            }
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)
@@ -47,8 +52,13 @@ final class NetworkInfoProviderTests: XCTestCase {
         let session = URLSession(configuration: config)
         let provider = NetworkInfoProvider(session: session)
         let exp = expectation(description: "info")
-        provider.fetchInfo(from: URL(string: "https://example.com/info")!) { info in
-            XCTAssertNil(info)
+        provider.fetchInfo(from: URL(string: "https://example.com/info")!) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertEqual(error, .invalidResponse)
+            }
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)


### PR DESCRIPTION
## Summary
- enhance `NetworkInfoProvider` with explicit error enum and retry logic
- update unit tests for the new result type

## Testing
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`
- `swift test` *(failed: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b42ea0b388321975bbe95bffefd08