### PR TITLE
Implement export blockers detection and AI Copilot hotkeys

### DIFF
--- a/Sources/CreatorCoreForge/ExportManager.swift
+++ b/Sources/CreatorCoreForge/ExportManager.swift
@@ -15,4 +15,20 @@ public struct ExportManager {
     public func validate(path: String) -> Bool {
         FileManager.default.fileExists(atPath: path)
     }
+
+    /// Detect common export blockers like missing login screen or icons.
+    public func detectBlockers(projectFiles: [String]) -> [String] {
+        var issues: [String] = []
+        let lowercased = projectFiles.map { $0.lowercased() }
+        if !lowercased.contains(where: { $0.contains("login") }) {
+            issues.append("missing login screen")
+        }
+        if !lowercased.contains(where: { $0.contains("icon") }) {
+            issues.append("missing app icon")
+        }
+        if !lowercased.contains(where: { $0.contains("validation") }) {
+            issues.append("no validation logic found")
+        }
+        return issues
+    }
 }

--- a/Tests/CreatorCoreForgeTests/ExportManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ExportManagerTests.swift
@@ -7,4 +7,14 @@ final class ExportManagerTests: XCTestCase {
         let path = manager.export(platform: "ios", output: "/tmp")
         XCTAssertTrue(manager.validate(path: path))
     }
+
+    func testDetectBlockers() {
+        let manager = ExportManager()
+        let none = manager.detectBlockers(projectFiles: ["LoginScreen", "icon.png", "validation.js"])
+        XCTAssertEqual(none.isEmpty, true)
+        let issues = manager.detectBlockers(projectFiles: ["Main"])
+        XCTAssertTrue(issues.contains("missing login screen"))
+        XCTAssertTrue(issues.contains("missing app icon"))
+        XCTAssertTrue(issues.contains("no validation logic found"))
+    }
 }

--- a/apps/CoreForgeBuild/components/AICopilot.tsx
+++ b/apps/CoreForgeBuild/components/AICopilot.tsx
@@ -2,15 +2,34 @@ import React, { useState } from 'react';
 
 export interface AICopilotProps {
   onAsk?: (question: string) => Promise<string>;
+  hotkeys?: Record<string, string>;
 }
 
-export const AICopilot: React.FC<AICopilotProps> = ({ onAsk }) => {
+export function registerHotkeys(
+  target: { addEventListener(type: string, cb: (e: any) => void): void },
+  hotkeys: Record<string, string>,
+  ask: (q: string) => void
+) {
+  target.addEventListener('keydown', (e: any) => {
+    const key = e.key?.toLowerCase();
+    if (key && hotkeys[key]) {
+      ask(hotkeys[key]);
+    }
+  });
+}
+
+export const AICopilot: React.FC<AICopilotProps> = ({ onAsk, hotkeys }) => {
   const [text, setText] = useState('');
   const [reply, setReply] = useState('');
   const ask = async () => {
     const r = (await onAsk?.(text)) || 'No response';
     setReply(r);
   };
+  React.useEffect(() => {
+    if (hotkeys) {
+      registerHotkeys(window, hotkeys, q => onAsk?.(q).then(r => setReply(r || 'No response')));
+    }
+  }, [hotkeys]);
   return (
     <div>
       <input value={text} onChange={e => setText(e.target.value)} />

--- a/apps/CoreForgeBuild/test/aicopilot.hotkey.test.ts
+++ b/apps/CoreForgeBuild/test/aicopilot.hotkey.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert';
+import { registerHotkeys } from '../components/AICopilot';
+
+const calls: any[] = [];
+const target = {
+  addEventListener: (_: string, cb: (e: any) => void) => {
+    calls.push(cb);
+  }
+};
+let asked: string | null = null;
+registerHotkeys(target as any, { h: 'help' }, q => {
+  asked = q;
+});
+// simulate keydown
+calls[0]({ key: 'h' });
+assert.strictEqual(asked, 'help');
+console.log('AICopilot hotkey test passed');


### PR DESCRIPTION
## Summary
- expand `ExportManager` with export blocker detection
- add corresponding tests for `ExportManager`
- support hotkey triggers in `AICopilot`
- include new `AICopilot` hotkey test

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b452eb92083219c3c2cf64c9c52ae