### PR TITLE
Improve test functionality

### DIFF
--- a/Tests/CreatorCoreForgeTests/AIVocalProductionEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/AIVocalProductionEngineTests.swift
@@ -7,4 +7,16 @@ final class AIVocalProductionEngineTests: XCTestCase {
         let processed = engine.process(track: [0.5, 1.0, 0.25])
         XCTAssertEqual(processed.max(), 1.0)
     }
+
+    func testProcessHandlesNegativeValues() {
+        let engine = AIVocalProductionEngine()
+        let processed = engine.process(track: [-2, 2])
+        XCTAssertEqual(processed, [-1, 1])
+    }
+
+    func testProcessHandlesZeroTrack() {
+        let engine = AIVocalProductionEngine()
+        let processed = engine.process(track: [0, 0])
+        XCTAssertEqual(processed, [0, 0])
+    }
 }

--- a/Tests/CreatorCoreForgeTests/CMSampleBufferExtensionsTests.swift
+++ b/Tests/CreatorCoreForgeTests/CMSampleBufferExtensionsTests.swift
@@ -29,8 +29,8 @@ final class CMSampleBufferExtensionsTests: XCTestCase {
         XCTAssertEqual(output, pixel)
     }
     #else
-    func testToPixelBuffer() {
-        XCTAssertTrue(true)
+    func testToPixelBuffer() throws {
+        throw XCTSkip("AVFoundation not available on this platform")
     }
     #endif
 }


### PR DESCRIPTION
## Summary
- refine CMSampleBuffer extension tests to properly skip when AVFoundation is missing
- expand coverage for `AIVocalProductionEngine` normalization logic

## Testing
- `swift test --skip-build --filter CMSampleBufferExtensionsTests`
- `swift test --skip-build --filter AIVocalProductionEngineTests`


------
https://chatgpt.com/codex/tasks/task_e_685b549eb3e48321b4e242a5f34bdd58