### PR TITLE
Add robust vault handler

### DIFF
--- a/apps/CoreForgeBloom/PrivateVault.swift
+++ b/apps/CoreForgeBloom/PrivateVault.swift
@@ -5,13 +5,34 @@ import Foundation
 /// XOR operation based on the provided password so the examples
 /// remain self contained.
 public final class PrivateVault {
+    /// Password required for unlocking the vault.
     private let password: String
+    /// Timestamp when each entry was added. Parallel array to `entries`.
     private var logs: [Date] = []
+    /// Encrypted note payloads.
     private var entries: [Data] = []
 
     /// Create a new vault secured by `password`.
     public init(password: String) {
         self.password = password
+    }
+
+    // MARK: - Types
+
+    /// Supported actions for the unified `handle` API.
+    public enum Action {
+        case add(String)
+        case addBatch([String])
+        case remove(index: Int)
+        case retrieve(password: String)
+        case readmeSummary(url: URL?)
+    }
+
+    /// Errors that can be thrown or returned during vault operations.
+    public enum VaultError: Error {
+        case invalidPassword
+        case indexOutOfBounds
+        case ioFailure
     }
 
     // MARK: - Private helpers
@@ -41,9 +62,23 @@ public final class PrivateVault {
         logs.append(Date())
     }
 
+    /// Adds multiple entries at once.
+    public func addEntries(_ texts: [String]) {
+        for text in texts { addEntry(text) }
+    }
+
+    /// Remove the entry at `index`.
+    public func removeEntry(at index: Int) throws {
+        guard entries.indices.contains(index) else {
+            throw VaultError.indexOutOfBounds
+        }
+        entries.remove(at: index)
+        logs.remove(at: index)
+    }
+
     /// Retrieve all entries if the password matches.
-    public func retrieveEntries(password: String) -> [String]? {
-        guard password == self.password else { return nil }
+    public func retrieveEntries(password: String) throws -> [String] {
+        guard password == self.password else { throw VaultError.invalidPassword }
         return entries.map { decrypt($0) }
     }
 
@@ -52,4 +87,47 @@ public final class PrivateVault {
 
     /// Returns the number of stored entries.
     public var count: Int { entries.count }
+
+    /// Provide a short summary of the README at `url` or in the current directory.
+    public func readmeSummary(url: URL? = nil) throws -> String {
+        let manager = FileManager.default
+        let path: String
+        if let url = url { path = url.path } else {
+            path = "README.md"
+        }
+        guard let data = manager.contents(atPath: path),
+              let text = String(data: data, encoding: .utf8) else {
+            throw VaultError.ioFailure
+        }
+        let lines = text.split(separator: "\n").map(String.init)
+        return lines.prefix(3).joined(separator: " ")
+    }
+
+    /// Unified handler that performs various actions and returns human-readable output.
+    @discardableResult
+    public func handle(_ action: Action) -> Result<[String], VaultError> {
+        do {
+            switch action {
+            case .add(let text):
+                addEntry(text)
+                return .success([])
+            case .addBatch(let texts):
+                addEntries(texts)
+                return .success([])
+            case .remove(let index):
+                try removeEntry(at: index)
+                return .success([])
+            case .retrieve(let pw):
+                let items = try retrieveEntries(password: pw)
+                return .success(items)
+            case .readmeSummary(let url):
+                let summary = try readmeSummary(url: url)
+                return .success([summary])
+            }
+        } catch let error as VaultError {
+            return .failure(error)
+        } catch {
+            return .failure(.ioFailure)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend `PrivateVault` to support batch operations
- add vault error types and README summarization
- provide unified `handle` API for add/remove/retrieve actions

## Testing
- `swift test` *(fails: exited with signal 4, 0 tests run)*
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_685b586a7fcc8321aaeda084d0153378