### PR TITLE
Implement NSFW age verification

### DIFF
--- a/Sources/CreatorCoreForge/NSFWContentManager.swift
+++ b/Sources/CreatorCoreForge/NSFWContentManager.swift
@@ -18,6 +18,7 @@ public final class NSFWContentManager: ObservableObject {
     ]
 
     @Published public var unlocked: Bool = false
+    @Published public var ageVerified: Bool = false
     @Published public var nsfwSceneLog: [NSFWScene] = []
     @Published public var contentIntensity: NSFWIntensity = .softcore
     @Published public var contentMode: NSFWContentMode = .slow
@@ -39,10 +40,16 @@ public final class NSFWContentManager: ObservableObject {
     }
 
     public func unlock(with promoCode: String) {
+        guard ageVerified else { return }
         if promoCode.lowercased() == "creatoraccess" {
             unlocked = true
             consentTracker.logConsent(userID: "local", consent: true)
         }
+    }
+
+    /// Verify user age for NSFW access.
+    public func verifyAge(_ age: Int) {
+        ageVerified = age >= ContentPolicyManager.ageLimit
     }
 
     public func logConsent(userID: String, consent: Bool) {
@@ -116,6 +123,7 @@ public final class NSFWContentManager {
     ]
 
     public var unlocked: Bool = false
+    public var ageVerified: Bool = false
     public var nsfwSceneLog: [NSFWScene] = []
     public var contentIntensity: NSFWIntensity = .softcore
     public var contentMode: NSFWContentMode = .slow
@@ -137,10 +145,16 @@ public final class NSFWContentManager {
     }
 
     public func unlock(with promoCode: String) {
+        guard ageVerified else { return }
         if promoCode.lowercased() == "creatoraccess" {
             unlocked = true
             consentTracker.logConsent(userID: "local", consent: true)
         }
+    }
+
+    /// Verify user age for NSFW access.
+    public func verifyAge(_ age: Int) {
+        ageVerified = age >= ContentPolicyManager.ageLimit
     }
 
     public func logConsent(userID: String, consent: Bool) {

--- a/Sources/CreatorCoreForge/NSFWSceneToggle.swift
+++ b/Sources/CreatorCoreForge/NSFWSceneToggle.swift
@@ -14,8 +14,10 @@ public struct NSFWSceneToggle {
     }
 
     /// Toggle global NSFW mode using the standard unlock code.
-    public func setEnabled(_ enabled: Bool) {
+    /// Age must meet `ContentPolicyManager.ageLimit`.
+    public func setEnabled(_ enabled: Bool, age: Int = 0) {
         if enabled {
+            manager.verifyAge(age)
             manager.unlock(with: "creatoraccess")
         } else {
             manager.unlocked = false

--- a/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWContentManagerTests.swift
@@ -5,6 +5,7 @@ final class NSFWContentManagerTests: XCTestCase {
     func testUnlockWithPromoCode() {
         let manager = NSFWContentManager.shared
         manager.unlocked = false
+        manager.verifyAge(20)
         manager.unlock(with: "creatoraccess")
         XCTAssertTrue(manager.unlocked)
     }
@@ -47,5 +48,13 @@ final class NSFWContentManagerTests: XCTestCase {
         let second = manager.nextAftercarePrompt()
         XCTAssertNotEqual(first, "")
         XCTAssertNotEqual(second, "")
+    }
+
+    func testAgeVerification() {
+        let manager = NSFWContentManager.shared
+        manager.verifyAge(16)
+        XCTAssertFalse(manager.ageVerified)
+        manager.verifyAge(18)
+        XCTAssertTrue(manager.ageVerified)
     }
 }

--- a/Tests/CreatorCoreForgeTests/NSFWSceneToggleTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWSceneToggleTests.swift
@@ -4,9 +4,17 @@ import XCTest
 final class NSFWSceneToggleTests: XCTestCase {
     func testAllowScene() {
         let toggle = NSFWSceneToggle(manager: NSFWContentManager())
-        toggle.setEnabled(true)
+        toggle.setEnabled(true, age: 20)
         XCTAssertTrue(toggle.allow(intensity: .softcore))
         toggle.setEnabled(false)
         XCTAssertFalse(toggle.allow(intensity: .softcore))
+    }
+
+    func testAgeVerification() {
+        let toggle = NSFWSceneToggle(manager: NSFWContentManager())
+        toggle.setEnabled(true, age: 15)
+        XCTAssertFalse(toggle.allow(intensity: .softcore))
+        toggle.setEnabled(true, age: 19)
+        XCTAssertTrue(toggle.allow(intensity: .softcore))
     }
 }


### PR DESCRIPTION
## Summary
- add `ageVerified` flag and verification method
- gate NSFW unlocking behind age verification
- extend NSFW toggle to require an age parameter
- update tests for new age gating logic

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685b5855cfbc83219f550c43fcc1831d