### PR TITLE
Implement NSFW tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,11 +245,11 @@ This document details all AI agent capabilities, engine modules, and next-genera
 - [x] Allow per-character NSFW permissions and tone preferences
 - [x] Tag and index NSFW scenes for optional inclusion/exclusion in exports
 - [x] Offer NSFW visual FX library (shadows, fog, body simulation overlays)
-- [ ] Blur or censor sensitive body areas based on creator control
-- [ ] Support dual rendering: NSFW and Safe version from same scene
-- [ ] Enable private-only scene generation with encrypted preview keys
-- [ ] Provide intensity control slider for visual eroticism or violence
-- [ ] Sync NSFW tone with voice and ambient FX layers
+- [x] Blur or censor sensitive body areas based on creator control
+- [x] Support dual rendering: NSFW and Safe version from same scene
+- [x] Enable private-only scene generation with encrypted preview keys
+- [x] Provide intensity control slider for visual eroticism or violence
+- [x] Sync NSFW tone with voice and ambient FX layers
 - [ ] Allow creator notes to guide scene rendering boundaries
 - [ ] Embed NSFW warning overlays for early scene detection
 - [ ] Generate parallel safe-for-stream scenes with auto-adaptation

--- a/Sources/CreatorCoreForge/NSFWPhase7.swift
+++ b/Sources/CreatorCoreForge/NSFWPhase7.swift
@@ -86,6 +86,22 @@ public struct NSFWIntensityMeter {
     public init(level: Double = 0.5) {
         self.level = max(0.0, min(1.0, level))
     }
+
+    /// Update the current level using a slider-style value between 0 and 1.
+    public mutating func setLevel(_ value: Double) {
+        self.level = max(0.0, min(1.0, value))
+    }
+
+    /// Map the current level to a discrete intensity used by `NSFWContentManager`.
+    public func scaledIntensity() -> NSFWContentManager.NSFWIntensity {
+        switch level {
+        case ..<0.25: return .off
+        case ..<0.5: return .softcore
+        case ..<0.75: return .sensual
+        case ..<0.9: return .rough
+        default: return .hardcore
+        }
+    }
 }
 
 /// Blend text with a sub-tone tag for genre flexibility.

--- a/Sources/CreatorCoreForge/NSFWToneSyncer.swift
+++ b/Sources/CreatorCoreForge/NSFWToneSyncer.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Synchronizes NSFW tone with voice and ambient FX layers.
+public final class NSFWToneSyncer {
+    private let matcher = NSFWAmbientFXMatcher()
+    public init() {}
+
+    /// Apply a tone to the provided voice string and replace the ambient FX list
+    /// with those best matching the tone.
+    public func sync(tone: NSFWStyle, voice: inout String, ambient: inout [String]) {
+        voice = "[tone:\(tone.rawValue)] " + voice
+        ambient = matcher.fx(for: tone)
+    }
+}

--- a/Sources/CreatorCoreForge/PreviewKeyManager.swift
+++ b/Sources/CreatorCoreForge/PreviewKeyManager.swift
@@ -1,0 +1,26 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+/// Generates and validates encrypted preview keys for private scenes.
+public struct PreviewKeyManager {
+    public init() {}
+
+    /// Create a preview key using SHA256 of the scene identifier and a salt.
+    public func generateKey(for sceneID: String, salt: String = "coreforge") -> String {
+        let input = sceneID + salt
+        #if canImport(CryptoKit)
+        let data = Data(input.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.compactMap { String(format: "%02x", $0) }.joined()
+        #else
+        return String(input.reversed())
+        #endif
+    }
+
+    /// Validate the preview key matches the scene identifier and salt.
+    public func validate(key: String, sceneID: String, salt: String = "coreforge") -> Bool {
+        generateKey(for: sceneID, salt: salt) == key
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWPhase7FeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWPhase7FeatureTests.swift
@@ -24,5 +24,20 @@ final class NSFWPhase7FeatureTests: XCTestCase {
         _ = BodyContactFXSimulator().playRhythm(["thump"])
         _ = NSFWPG13Renderer().renderSafeVersion(of: "naked scene")
         let tracker = NSFWSkipTracker(); tracker.recordSkip(); _ = tracker.skipCount
+
+        // New features
+        var meter = NSFWIntensityMeter()
+        meter.setLevel(0.8)
+        XCTAssertEqual(meter.scaledIntensity(), .rough)
+
+        let keyManager = PreviewKeyManager()
+        let key = keyManager.generateKey(for: "scene1")
+        XCTAssertTrue(keyManager.validate(key: key, sceneID: "scene1"))
+
+        var voice = "Hello"
+        var ambient: [String] = []
+        NSFWToneSyncer().sync(tone: .sensual, voice: &voice, ambient: &ambient)
+        XCTAssertTrue(voice.contains("tone:sensual"))
+        XCTAssertFalse(ambient.isEmpty)
     }
 }

--- a/VisualLab/src/CensorService.ts
+++ b/VisualLab/src/CensorService.ts
@@ -1,3 +1,24 @@
 export function censorLayer(frame: string, level: number): string {
   return level > 0 ? `${frame}-censored-${level}` : frame;
 }
+
+export interface CensorRegionOption {
+  region: string;
+  level: number;
+}
+
+/**
+ * Apply censor blur to specific regions of a frame. The output frame name is
+ * suffixed with region blur information so downstream renderers can pick up
+ * the correct mask overlays.
+ */
+export function censorRegions(
+  frame: string,
+  options: CensorRegionOption[]
+): string {
+  if (options.length === 0) return frame;
+  const suffix = options
+    .map((o) => `${o.region}-blur${Math.round(o.level)}`)
+    .join('_');
+  return `${frame}-${suffix}`;
+}

--- a/VisualLab/src/VisualRenderer.ts
+++ b/VisualLab/src/VisualRenderer.ts
@@ -14,6 +14,7 @@ export interface VideoClip {
 }
 
 import { UnifiedVideoEngine } from './UnifiedVideoEngine.ts';
+import { censorLayer } from './CensorService.ts';
 
 export class VisualRenderer {
   constructor(private engine = UnifiedVideoEngine.shared) {}
@@ -21,12 +22,29 @@ export class VisualRenderer {
   async render(config: RenderConfig): Promise<VideoClip> {
     const { frames, voiceTrack, ambientTracks = [], style = 'default', resolution = { width: 1280, height: 720 } } = config;
     const clip = await this.engine.render(frames, resolution);
+    const processedFrames = (clip.frames as any).map((f: any) => f.frame ?? f) as Buffer[];
     const audio = [voiceTrack, ...ambientTracks].filter((b): b is Buffer => !!b);
     return {
-      frames: clip.frames as Buffer[],
+      frames: processedFrames,
       audio,
       style,
       resolution,
     };
+  }
+
+  /**
+   * Render both an NSFW version and a safe version of a scene. The safe
+   * version uses basic censoring based on the provided level.
+   */
+  async renderDual(
+    config: RenderConfig & { censorLevel?: number }
+  ): Promise<{ nsfw: VideoClip; safe: VideoClip }> {
+    const nsfw = await this.render(config);
+    const level = config.censorLevel ?? 1;
+    const safeFrames = config.frames.map((f) =>
+      Buffer.from(censorLayer(f.toString(), level))
+    );
+    const safe = await this.render({ ...config, frames: safeFrames });
+    return { nsfw, safe };
   }
 }

--- a/VisualLab/test/newFeatures.test.ts
+++ b/VisualLab/test/newFeatures.test.ts
@@ -75,6 +75,8 @@ const rendered = await renderer.render({ frames: [Buffer.from('f')] });
 assert.strictEqual(rendered.frames.length, 1);
 assert.strictEqual(rendered.audio.length, 0);
 assert.strictEqual(rendered.style, 'default');
+const dual = await renderer.renderDual({ frames: [Buffer.from('f')], censorLevel: 2 });
+assert.strictEqual(dual.safe.frames[0].toString(), 'f-censored-2');
 
 
 

--- a/VisualLab/test/openTasks.test.ts
+++ b/VisualLab/test/openTasks.test.ts
@@ -5,6 +5,7 @@ import {
   SceneToggleService,
   ContentFilter,
   censorLayer,
+  censorRegions,
   fuseScenes,
   applyHallucinogenicFilter,
   applySurrealism,
@@ -41,6 +42,10 @@ const filter = new ContentFilter();
 filter.verify('u');
 assert.ok(filter.canPreview('u'));
 assert.strictEqual(censorLayer('frame',1),'frame-censored-1');
+assert.strictEqual(
+  censorRegions('frame', [{ region: 'chest', level: 2 }]),
+  'frame-chest-blur2'
+);
 
 assert.deepStrictEqual(fuseScenes(['a'],['b']), ['a|b']);
 assert.deepStrictEqual(applyHallucinogenicFilter(['f']), ['f-trippy']);


### PR DESCRIPTION
## Summary
- complete NSFW visual tasks in AGENTS checklist
- support regional censoring in `CensorService`
- allow dual rendering with `VisualRenderer.renderDual`
- add preview key generation and tone sync utilities
- expand intensity meter API and add tests

## Testing
- `scripts/run_all_tests.sh`
- `npm test` in VisualLab

------
https://chatgpt.com/codex/tasks/task_e_685bd68928608321af4be1991400e4c8