### PR TITLE
Implement NSFW task stubs

### DIFF
--- a/generated/CoreForgeVisual/Allow_creator_notes_to_guide_scene_rendering_boundaries.py
+++ b/generated/CoreForgeVisual/Allow_creator_notes_to_guide_scene_rendering_boundaries.py
@@ -1,4 +1,26 @@
 # Auto-generated for Allow creator notes to guide scene rendering boundaries
-def allow_creator_notes():
-    """Allow creator notes to guide scene rendering boundaries"""
-    pass
+from typing import Dict, List, Tuple
+
+
+def allow_creator_notes(notes: Dict[str, str]) -> List[Tuple[str, str]]:
+    """Parse creator notes into scene boundary tuples.
+
+    Args:
+        notes: Mapping of scene identifier to note text. Notes can include
+            "start" and "end" markers in the form "start=00:00 end=00:10".
+
+    Returns:
+        List of ``(scene_id, range_string)`` describing the boundaries.
+    """
+
+    boundaries: List[Tuple[str, str]] = []
+    for scene_id, text in notes.items():
+        start, end = "0:00", ""
+        for part in text.split():
+            if part.startswith("start="):
+                start = part.split("=", 1)[1]
+            elif part.startswith("end="):
+                end = part.split("=", 1)[1]
+        if end:
+            boundaries.append((scene_id, f"{start}-{end}"))
+    return boundaries

--- a/generated/CoreForgeVisual/Apply_scene_tone_validator_to_suggest_safe_NSFW_rating_per_visual_sequence.py
+++ b/generated/CoreForgeVisual/Apply_scene_tone_validator_to_suggest_safe_NSFW_rating_per_visual_sequence.py
@@ -1,4 +1,14 @@
 # Auto-generated for Apply scene tone validator to suggest safe/NSFW rating per visual sequence
-def apply_scene_tone():
-    """Apply scene tone validator to suggest safe/NSFW rating per visual sequence"""
-    pass
+from typing import Iterable, List
+
+
+SAFE_WORDS = {"happy", "calm", "wholesome"}
+
+
+def apply_scene_tone(tokens: Iterable[str]) -> str:
+    """Return 'safe' if no NSFW tone detected else 'nsfw'."""
+
+    for tok in tokens:
+        if tok.lower() not in SAFE_WORDS:
+            return "nsfw"
+    return "safe"

--- a/generated/CoreForgeVisual/Embed_NSFW_warning_overlays_for_early_scene_detection.py
+++ b/generated/CoreForgeVisual/Embed_NSFW_warning_overlays_for_early_scene_detection.py
@@ -1,4 +1,12 @@
 # Auto-generated for Embed NSFW warning overlays for early scene detection
-def embed_nsfw_warning():
-    """Embed NSFW warning overlays for early scene detection"""
-    pass
+from typing import List
+
+
+def embed_nsfw_warning(frames: List[str]) -> List[str]:
+    """Embed a simple NSFW overlay onto video frames.
+
+    Each returned frame is suffixed with ``-nsfw-warning`` to indicate the
+    overlay has been applied.
+    """
+
+    return [f"{frame}-nsfw-warning" for frame in frames]

--- a/generated/CoreForgeVisual/Filter_NSFW_content_in_search_preview_and_trailer_modes.py
+++ b/generated/CoreForgeVisual/Filter_NSFW_content_in_search_preview_and_trailer_modes.py
@@ -1,4 +1,11 @@
 # Auto-generated for Filter NSFW content in search, preview, and trailer modes
-def filter_nsfw_content():
-    """Filter NSFW content in search, preview, and trailer modes"""
-    pass
+from typing import Iterable, List
+
+
+def filter_nsfw_content(items: Iterable[dict]) -> List[dict]:
+    """Remove items flagged as NSFW.
+
+    Each item is expected to be a mapping with a boolean ``nsfw`` key.
+    """
+
+    return [item for item in items if not item.get("nsfw")]

--- a/generated/CoreForgeVisual/Generate_parallel_safe_for_stream_scenes_with_auto_adaptation.py
+++ b/generated/CoreForgeVisual/Generate_parallel_safe_for_stream_scenes_with_auto_adaptation.py
@@ -1,4 +1,13 @@
 # Auto-generated for Generate parallel safe-for-stream scenes with auto-adaptation
-def generate_parallel_safe():
-    """Generate parallel safe-for-stream scenes with auto-adaptation"""
-    pass
+from typing import Iterable, Tuple
+
+
+def generate_parallel_safe(scenes: Iterable[str]) -> Tuple[list, list]:
+    """Return a tuple of (nsfw_safe, original) scene lists.
+
+    The safe version appends ``-safe`` to each scene identifier.
+    """
+
+    scenes = list(scenes)
+    safe_scenes = [f"{s}-safe" for s in scenes]
+    return safe_scenes, scenes

--- a/generated/CoreForgeVisual/Hide_NSFW_rendering_options_in_shared_public_projects.py
+++ b/generated/CoreForgeVisual/Hide_NSFW_rendering_options_in_shared_public_projects.py
@@ -1,4 +1,5 @@
 # Auto-generated for Hide NSFW rendering options in shared/public projects
-def hide_nsfw_rendering():
-    """Hide NSFW rendering options in shared/public projects"""
-    pass
+def hide_nsfw_rendering(user_is_owner: bool) -> bool:
+    """Return True if NSFW controls should be visible."""
+
+    return user_is_owner

--- a/generated/CoreForgeVisual/Offer_Creator_dashboard_to_review_flagged_or_reported_NSFW_content.py
+++ b/generated/CoreForgeVisual/Offer_Creator_dashboard_to_review_flagged_or_reported_NSFW_content.py
@@ -1,4 +1,18 @@
 # Auto-generated for Offer Creator dashboard to review flagged or reported NSFW content
-def offer_creator_dashboard():
-    """Offer Creator dashboard to review flagged or reported NSFW content"""
-    pass
+class CreatorDashboard:
+    """Simple tracker for flagged NSFW content."""
+
+    def __init__(self) -> None:
+        self.flagged = []
+
+    def report(self, scene_id: str) -> None:
+        self.flagged.append(scene_id)
+
+    def list_reports(self) -> list:
+        return list(self.flagged)
+
+
+def offer_creator_dashboard() -> CreatorDashboard:
+    """Return a dashboard instance for managing NSFW reports."""
+
+    return CreatorDashboard()

--- a/generated/CoreForgeVisual/Provide_customizable_NSFW_cover_and_thumbnail_censor_options.py
+++ b/generated/CoreForgeVisual/Provide_customizable_NSFW_cover_and_thumbnail_censor_options.py
@@ -1,4 +1,7 @@
 # Auto-generated for Provide customizable NSFW cover and thumbnail censor options
-def provide_customizable_nsfw():
-    """Provide customizable NSFW cover and thumbnail censor options"""
-    pass
+def provide_customizable_nsfw(cover: str, level: int = 1) -> str:
+    """Return a censored cover string based on level."""
+
+    if level <= 0:
+        return cover
+    return f"{cover}-censored{level}"

--- a/generated/CoreForgeVisual/Store_NSFW_render_settings_as_presets_for_series_genre.py
+++ b/generated/CoreForgeVisual/Store_NSFW_render_settings_as_presets_for_series_genre.py
@@ -1,4 +1,11 @@
 # Auto-generated for Store NSFW render settings as presets for series/genre
-def store_nsfw_render():
-    """Store NSFW render settings as presets for series/genre"""
-    pass
+from typing import Dict
+
+
+_NSFW_PRESETS: Dict[str, Dict[str, str]] = {}
+
+
+def store_nsfw_render(series: str, preset: Dict[str, str]) -> None:
+    """Store render settings for a series or genre."""
+
+    _NSFW_PRESETS[series] = preset

--- a/generated/CoreForgeVisual/Tag_NSFW_export_files_with_proper_disclaimers_and_auto_locks.py
+++ b/generated/CoreForgeVisual/Tag_NSFW_export_files_with_proper_disclaimers_and_auto_locks.py
@@ -1,4 +1,5 @@
 # Auto-generated for Tag NSFW export files with proper disclaimers and auto-locks
-def tag_nsfw_export():
-    """Tag NSFW export files with proper disclaimers and auto-locks"""
-    pass
+def tag_nsfw_export(filename: str) -> str:
+    """Return filename with NSFW disclaimer tag."""
+
+    return f"NSFW_{filename}"


### PR DESCRIPTION
## Summary
- flesh out NSFW utilities in generated/CoreForgeVisual
- add helpers for creator notes and NSFW processing

## Testing
- `npm test` in `VisualLab`
- `npm test` in `VoiceLab`
- `swift test` *(fails: exited with signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685bdaf3f5b88321ad33447f722d7926