### PR TITLE
Add Library Demo with login and signup views

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,11 +8,15 @@ let package = Package(
         .macOS(.v10_15)
     ],
     products: [
-        .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"])
+        .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"]),
+        .executable(name: "LibraryDemoApp", targets: ["LibraryDemoApp"])
     ],
     dependencies: [],
     targets: [
         .target(name: "CreatorCoreForge", path: "Sources/CreatorCoreForge"),
+        .executableTarget(name: "LibraryDemoApp",
+                          path: "apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo",
+                          exclude: ["Info.plist"]),
         .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")
     ]
 )

--- a/apps/CoreForgeLibrary/AGENTS.md
+++ b/apps/CoreForgeLibrary/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent: Library Demo App
+
+## App: CoreForge Library
+Platform: iOS, macOS
+Purpose: Demonstrates library sync with login and sign up screens.
+
+### Tasks
+- [x] Provide basic SwiftUI views for login, sign up, and library browsing.
+- [x] Include example `LibraryDemoApp` for testing.
+
+### Phase Features Summary
+- Refer to README for full platform overview.

--- a/apps/CoreForgeLibrary/Desktop/index.html
+++ b/apps/CoreForgeLibrary/Desktop/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>CoreForge Library Desktop</title>
+  <script>
+    function launch() {
+      document.getElementById('status').textContent = 'Launcher active.';
+    }
+  </script>
+</head>
+<body>
+  <h1>CoreForge Library</h1>
+  <p id="status">Desktop launcher ready.</p>
+  <button onclick="launch()">Launch</button>
+</body>
+</html>

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/ContentView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/ContentView.swift
@@ -1,0 +1,37 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+struct ContentView: View {
+    @State private var loggedInUser: String?
+    @State private var showSignUp = false
+
+    var body: some View {
+        NavigationView {
+            if let user = loggedInUser {
+                LibraryView(userID: user)
+                    .navigationTitle("Library")
+            } else if showSignUp {
+                SignUpView { email, password in
+                    // Mock auth success
+                    loggedInUser = email
+                }
+                .navigationTitle("Sign Up")
+                .toolbar { Button("Login") { showSignUp = false } }
+            } else {
+                LoginView { email, password in
+                    // Mock auth success
+                    loggedInUser = email
+                }
+                .navigationTitle("Login")
+                .toolbar { Button("Sign Up") { showSignUp = true } }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/Info.plist
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.creatorcoreforge.library</string>
+    <key>CFBundleName</key>
+    <string>CoreForge Library</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+</dict>
+</plist>

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LibraryDemoApp.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LibraryDemoApp.swift
@@ -1,0 +1,13 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+
+@main
+struct LibraryDemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LibraryView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LibraryView.swift
@@ -1,0 +1,30 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+struct LibraryView: View {
+    @State private var books: [String] = []
+    let userID: String
+    private let sync = LibrarySync()
+
+    var body: some View {
+        List(books, id: \.self) { book in
+            Text(book)
+        }
+        .onAppear {
+            sync.fetch(userID: userID) { progress in
+                DispatchQueue.main.async {
+                    books = progress?.map { $0.key } ?? []
+                }
+            }
+        }
+    }
+}
+
+struct LibraryView_Previews: PreviewProvider {
+    static var previews: some View {
+        LibraryView(userID: "1")
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LoginView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/LoginView.swift
@@ -1,0 +1,31 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+
+
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+    var onLogin: ((String, String) -> Void)?
+
+    var body: some View {
+        Form {
+            Section(header: Text("Login")) {
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                SecureField("Password", text: $password)
+            }
+            Button("Login") {
+                onLogin?(email, password)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/SignUpView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/SignUpView.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct SignUpView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirm = ""
+    var onSignUp: ((String, String) -> Void)?
+
+    var body: some View {
+        Form {
+            Section(header: Text("Sign Up")) {
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                SecureField("Password", text: $password)
+                SecureField("Confirm Password", text: $confirm)
+            }
+            Button("Create Account") {
+                guard password == confirm else { return }
+                onSignUp?(email, password)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}
+
+struct SignUpView_Previews: PreviewProvider {
+    static var previews: some View {
+        SignUpView()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `LibraryDemoApp` with login, signup, and library screens
- update Swift Package manifest to include new executable target
- provide simple desktop launcher and agent checklist for the new app

## Testing
- `npm test --workspaces` *(fails: dynamicRangeCompressor.ts compile errors)*
- `swift test` *(fails: compile errors in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_685c4181a2808321af087a75370c0549