### PR TITLE
Add basic audio app views

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
@@ -1,0 +1,55 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays details for a selected book with chapter list and voice casting.
+struct BookDetailView: View {
+    @State private var showVoiceCast = false
+    var book: Book
+
+    var body: some View {
+        List {
+            if let cover = book.coverImage {
+                Image(cover)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 200)
+            }
+            Text(book.title)
+                .font(.title)
+            Text("by \(book.author)")
+                .foregroundColor(.secondary)
+            ProgressView(value: book.progress)
+            Section(header: Text("Chapters")) {
+                ForEach(book.chapters) { chapter in
+                    HStack {
+                        Text(chapter.title)
+                        Spacer()
+                        if chapter.audioURL != nil {
+                            Image(systemName: "waveform")
+                        }
+                    }
+                }
+            }
+        }
+        .toolbar {
+            Button("Voices") { showVoiceCast = true }
+        }
+        .sheet(isPresented: $showVoiceCast) {
+            VoiceCastView(characters: extractCharacters(from: book))
+        }
+    }
+
+    private func extractCharacters(from book: Book) -> [String] {
+        // Very naive character detection placeholder
+        var set = Set<String>()
+        for chapter in book.chapters {
+            chapter.text.split(separator: " ").forEach { word in
+                if word.hasPrefix("@") {
+                    set.insert(String(word.dropFirst()))
+                }
+            }
+        }
+        return Array(set)
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -25,6 +25,10 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Library", systemImage: "books.vertical")
                 }
+            ImportView()
+                .tabItem {
+                    Label("Import", systemImage: "square.and.arrow.down")
+                }
             PlayerView()
                 .tabItem {
                     Label("Player", systemImage: "play.circle")

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
@@ -1,0 +1,35 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Placeholder import screen for eBook files.
+struct ImportView: View {
+    @State private var showingImporter = false
+    @State private var importedBooks: [Book] = []
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Button("Import Book") { showingImporter = true }
+                .buttonStyle(.borderedProminent)
+            if !importedBooks.isEmpty {
+                List(importedBooks) { book in
+                    Text(book.title)
+                }
+            }
+        }
+        .fileImporter(isPresented: $showingImporter,
+                      allowedContentTypes: [.pdf, .epub, .plainText],
+                      allowsMultipleSelection: false) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    let chapters = EbookImporter().importEbook(from: url.path).map { Chapter(title: "Chapter", text: $0) }
+                    let book = Book(title: url.lastPathComponent, author: "", chapters: chapters)
+                    importedBooks.append(book)
+                }
+            case .failure:
+                break
+            }
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryView.swift
@@ -2,12 +2,24 @@
 import SwiftUI
 
 struct LibraryView: View {
+    @State private var books: [Book] = [
+        Book(title: "Sample Adventure", author: "A. Author", coverImage: nil, chapters: [
+            Chapter(title: "Intro", text: "@Hero begins the journey."),
+            Chapter(title: "Conflict", text: "@Villain appears in town.")
+        ])
+    ]
+
     var body: some View {
         NavigationView {
-            Text("Library")
-                .font(.largeTitle)
-                .padding()
-                .navigationTitle("Library")
+            List(books) { book in
+                NavigationLink(destination: BookDetailView(book: book)) {
+                    VStack(alignment: .leading) {
+                        Text(book.title)
+                        Text(book.author).font(.caption)
+                    }
+                }
+            }
+            .navigationTitle("Library")
         }
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
@@ -1,0 +1,40 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Simple interface to assign voices to characters.
+struct VoiceCastView: View {
+    @Environment(\.dismiss) private var dismiss
+    let characters: [String]
+    @State private var selections: [String: String] = [:]
+
+    private let voices = VoiceConfig.voices
+
+    var body: some View {
+        NavigationView {
+            Form {
+                ForEach(characters, id: \.self) { name in
+                    Picker(name, selection: Binding(
+                        get: { selections[name] ?? CharacterVoiceMemory.shared.voiceForCharacter(name)?.id ?? voices.first?.id ?? "" },
+                        set: { selections[name] = $0 }
+                    )) {
+                        ForEach(voices, id: \.id) { voice in
+                            Text(voice.name).tag(voice.id)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Voice Cast")
+            .toolbar {
+                Button("Done") {
+                    for (char, id) in selections {
+                        if let voice = voices.first(where: { $0.id == id }) {
+                            CharacterVoiceMemory.shared.assignVoice(voice, to: char)
+                        }
+                    }
+                    dismiss()
+                }
+            }
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/models/Book.swift
+++ b/apps/CoreForgeAudio/models/Book.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Represents an audiobook with chapters and progress tracking.
+struct Book: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var author: String
+    var coverImage: String?
+    var chapters: [Chapter]
+    var progress: Double
+    var lastOpened: Date?
+
+    init(id: UUID = UUID(),
+         title: String,
+         author: String,
+         coverImage: String? = nil,
+         chapters: [Chapter] = [],
+         progress: Double = 0,
+         lastOpened: Date? = nil) {
+        self.id = id
+        self.title = title
+        self.author = author
+        self.coverImage = coverImage
+        self.chapters = chapters
+        self.progress = progress
+        self.lastOpened = lastOpened
+    }
+}
+
+/// Basic chapter model used by `Book`.
+struct Chapter: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var text: String
+    var audioURL: URL?
+
+    init(id: UUID = UUID(),
+         title: String,
+         text: String,
+         audioURL: URL? = nil) {
+        self.id = id
+        self.title = title
+        self.text = text
+        self.audioURL = audioURL
+    }
+}


### PR DESCRIPTION
## Summary
- add basic `Book` and `Chapter` models
- create `BookDetailView`, `VoiceCastView`, and `ImportView`
- update `LibraryView` to list example books
- add Import tab in `MainTabView`

## Testing
- `swift test` *(fails: undefined symbol LibraryDemoApp_main)*

------
https://chatgpt.com/codex/tasks/task_e_685c4a7466bc83219f0882838dfe23dc