### PR TITLE
Add basic library model and TTS playback

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Displays details for a selected book with chapter list and voice casting.
 struct BookDetailView: View {
     @State private var showVoiceCast = false
+    @EnvironmentObject var library: LibraryModel
     var book: Book
 
     var body: some View {
@@ -28,11 +29,18 @@ struct BookDetailView: View {
                             Image(systemName: "waveform")
                         }
                     }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        library.select(book: book, chapter: chapter)
+                    }
                 }
             }
         }
         .toolbar {
             Button("Voices") { showVoiceCast = true }
+            Button("Play") {
+                library.select(book: book, chapter: book.chapters.first)
+            }
         }
         .sheet(isPresented: $showVoiceCast) {
             VoiceCastView(characters: extractCharacters(from: book))

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -3,11 +3,13 @@ import SwiftUI
 
 struct ContentView: View {
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
+    @StateObject private var library = LibraryModel()
 
     var body: some View {
         Group {
             if hasSeenOnboarding {
                 MainTabView()
+                    .environmentObject(library)
                     .transition(.opacity)
             } else {
                 OnboardingView(hasSeenOnboarding: $hasSeenOnboarding)
@@ -19,17 +21,22 @@ struct ContentView: View {
 }
 
 struct MainTabView: View {
+    @EnvironmentObject var library: LibraryModel
+
     var body: some View {
         TabView {
             LibraryView()
+                .environmentObject(library)
                 .tabItem {
                     Label("Library", systemImage: "books.vertical")
                 }
             ImportView()
+                .environmentObject(library)
                 .tabItem {
                     Label("Import", systemImage: "square.and.arrow.down")
                 }
             PlayerView()
+                .environmentObject(library)
                 .tabItem {
                     Label("Player", systemImage: "play.circle")
                 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
@@ -4,14 +4,14 @@ import SwiftUI
 /// Placeholder import screen for eBook files.
 struct ImportView: View {
     @State private var showingImporter = false
-    @State private var importedBooks: [Book] = []
+    @EnvironmentObject var library: LibraryModel
 
     var body: some View {
         VStack(spacing: 20) {
             Button("Import Book") { showingImporter = true }
                 .buttonStyle(.borderedProminent)
-            if !importedBooks.isEmpty {
-                List(importedBooks) { book in
+            if !library.books.isEmpty {
+                List(library.books) { book in
                     Text(book.title)
                 }
             }
@@ -24,7 +24,7 @@ struct ImportView: View {
                 if let url = urls.first {
                     let chapters = EbookImporter().importEbook(from: url.path).map { Chapter(title: "Chapter", text: $0) }
                     let book = Book(title: url.lastPathComponent, author: "", chapters: chapters)
-                    importedBooks.append(book)
+                    library.addBook(book)
                 }
             case .failure:
                 break

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+import SwiftUI
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
+
+/// Shared library model storing user's books and current playback selection.
+final class LibraryModel: ObservableObject {
+    @Published var books: [Book]
+    @Published var currentBook: Book?
+    @Published var currentChapter: Chapter?
+
+    init() {
+        // Basic demo book used when the library is empty
+        self.books = [
+            Book(title: "Sample Adventure", author: "A. Author", chapters: [
+                Chapter(title: "Intro", text: "@Hero begins the journey."),
+                Chapter(title: "Conflict", text: "@Villain appears in town.")
+            ])
+        ]
+    }
+
+    func addBook(_ book: Book) {
+        books.append(book)
+    }
+
+    func select(book: Book, chapter: Chapter? = nil) {
+        currentBook = book
+        currentChapter = chapter
+    }
+}

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryView.swift
@@ -2,16 +2,11 @@
 import SwiftUI
 
 struct LibraryView: View {
-    @State private var books: [Book] = [
-        Book(title: "Sample Adventure", author: "A. Author", coverImage: nil, chapters: [
-            Chapter(title: "Intro", text: "@Hero begins the journey."),
-            Chapter(title: "Conflict", text: "@Villain appears in town.")
-        ])
-    ]
+    @EnvironmentObject var library: LibraryModel
 
     var body: some View {
         NavigationView {
-            List(books) { book in
+            List(library.books) { book in
                 NavigationLink(destination: BookDetailView(book: book)) {
                     VStack(alignment: .leading) {
                         Text(book.title)

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
@@ -1,11 +1,52 @@
 #if canImport(SwiftUI)
 import SwiftUI
+#if canImport(AVFoundation)
+import AVFoundation
+#endif
 
 struct PlayerView: View {
+    @EnvironmentObject var library: LibraryModel
+#if canImport(AVFoundation)
+    @State private var synthesizer = AVSpeechSynthesizer()
+#endif
+    @State private var isSpeaking = false
+
     var body: some View {
-        Text("Player")
-            .font(.largeTitle)
-            .padding()
+        Group {
+            if let chapter = library.currentChapter {
+                VStack(spacing: 20) {
+                    Text(chapter.title)
+                        .font(.title)
+                    ScrollView {
+                        Text(chapter.text)
+                            .padding()
+                    }
+                    Button(isSpeaking ? "Pause" : "Play") {
+                        toggleSpeech(text: chapter.text)
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            } else {
+                Text("Select a chapter from the Library")
+                    .font(.headline)
+            }
+        }
     }
+
+#if canImport(AVFoundation)
+    private func toggleSpeech(text: String) {
+        if synthesizer.isSpeaking {
+            synthesizer.pauseSpeaking(at: .immediate)
+            isSpeaking = false
+        } else {
+            let utterance = AVSpeechUtterance(string: text)
+            synthesizer.speak(utterance)
+            isSpeaking = true
+        }
+    }
+#else
+    private func toggleSpeech(text: String) {}
+#endif
 }
 #endif


### PR DESCRIPTION
## Summary
- implement `LibraryModel` to store books and selected chapter
- inject `LibraryModel` into `ContentView` and tab views
- allow selecting chapters in `BookDetailView` and new Play button
- update `ImportView` and `LibraryView` to use shared model
- add text-to-speech playback in `PlayerView`

## Testing
- `swift test list` *(fails: undefined symbol 'LibraryDemoApp_main')*

------
https://chatgpt.com/codex/tasks/task_e_685c5b4062a48321984775356a529930