### PR TITLE
Enable per-app referral program terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@
 - Creator, Pro, Enterprise, White Label tiers per app
 - In-app credits, NSFW add-ons, voice packs, templates
 - Referral, affiliate, and creator monetization models included
-- Editable referral program with cross-app referral dashboard
+- Referral program customizable per app with cross-app referral dashboard
 
 ---
 

--- a/Sources/CreatorCoreForge/ReferralDashboard.swift
+++ b/Sources/CreatorCoreForge/ReferralDashboard.swift
@@ -4,11 +4,14 @@ import Foundation
 public struct ReferralDashboard {
     public init() {}
 
-    /// Formats referral statistics for display.
-    public func summary(for program: ReferralProgram) -> String {
-        program.allStats()
+    /// Formats referral statistics and current terms for display. If `app` is provided,
+    /// the app-specific terms are included.
+    public func summary(for program: ReferralProgram, app: String? = nil) -> String {
+        let terms = program.currentInfo(forApp: app).terms
+        let stats = program.allStats()
             .map { "\($0.key): \($0.value)" }
             .sorted()
             .joined(separator: "\n")
+        return "Terms: \(terms)\n" + stats
     }
 }

--- a/Sources/CreatorCoreForge/ReferralProgram.swift
+++ b/Sources/CreatorCoreForge/ReferralProgram.swift
@@ -13,6 +13,7 @@ public final class ReferralProgram {
     }
 
     private var info: ProgramInfo
+    private var infoByApp: [String: ProgramInfo] = [:]
     private var stats: [String: Int] = [:]
 
     public init(info: ProgramInfo = .init()) {
@@ -37,14 +38,21 @@ public final class ReferralProgram {
         stats[code] ?? 0
     }
 
-    /// Update program terms.
-    public func updateTerms(_ newTerms: String) {
-        info.terms = newTerms
+    /// Update program terms. When `app` is provided, update terms only for that app.
+    public func updateTerms(_ newTerms: String, forApp app: String? = nil) {
+        if let app = app {
+            infoByApp[app] = ProgramInfo(terms: newTerms)
+        } else {
+            info.terms = newTerms
+        }
     }
 
-    /// Current program info.
-    public func currentInfo() -> ProgramInfo {
-        info
+    /// Current program info. When `app` is provided, returns app-specific terms if set.
+    public func currentInfo(forApp app: String? = nil) -> ProgramInfo {
+        if let app = app, let appInfo = infoByApp[app] {
+            return appInfo
+        }
+        return info
     }
 
     /// All referral statistics.

--- a/Tests/CreatorCoreForgeTests/ReferralDashboardTests.swift
+++ b/Tests/CreatorCoreForgeTests/ReferralDashboardTests.swift
@@ -15,5 +15,6 @@ final class ReferralDashboardTests: XCTestCase {
         XCTAssertTrue(summary.contains("1"))
         XCTAssertTrue(summary.contains(code2))
         XCTAssertTrue(summary.contains("2"))
+        XCTAssertTrue(summary.contains("Terms:"))
     }
 }

--- a/Tests/CreatorCoreForgeTests/ReferralProgramTests.swift
+++ b/Tests/CreatorCoreForgeTests/ReferralProgramTests.swift
@@ -16,4 +16,12 @@ final class ReferralProgramTests: XCTestCase {
         program.updateTerms("New terms")
         XCTAssertEqual(program.currentInfo().terms, "New terms")
     }
+
+    func testPerAppTerms() {
+        let program = ReferralProgram()
+        program.updateTerms("App A terms", forApp: "AppA")
+        XCTAssertEqual(program.currentInfo(forApp: "AppA").terms, "App A terms")
+        // Default terms should remain unchanged
+        XCTAssertEqual(program.currentInfo().terms, "Standard referral rewards apply.")
+    }
 }


### PR DESCRIPTION
## Summary
- allow customizable referral terms per app
- show terms in the referral dashboard
- update README for per-app referral support
- add tests for per-app terms

## Testing
- `swift build --target CreatorCoreForgeTests`
- `swift test` *(fails: LibraryDemoApp_main missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ac9d7908321bf4d3114e851e17a