### PR TITLE
Add Kindle tab for ebook downloads

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -38,6 +38,12 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Library", systemImage: "books.vertical")
                 }
+            KindleView()
+                .environmentObject(library)
+                .environmentObject(usage)
+                .tabItem {
+                    Label("Kindle", systemImage: "book.fill")
+                }
             ImportView()
                 .environmentObject(library)
                 .environmentObject(usage)

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct KindleBook: Identifiable {
+    let id: UUID = UUID()
+    let title: String
+    let author: String
+}
+
+/// Simple service that lists sample Kindle books and creates demo `Book` models
+/// when downloaded. In a real app this would connect to the Kindle API.
+final class KindleService {
+    func fetchAvailableBooks() -> [KindleBook] {
+        return [
+            KindleBook(title: "Kindle Sample 1", author: "Author A"),
+            KindleBook(title: "Kindle Sample 2", author: "Author B")
+        ]
+    }
+
+    func download(book: KindleBook) -> Book {
+        // Simulate download by generating placeholder chapters
+        let chapters = [
+            Chapter(title: "Chapter 1", text: "Sample text 1"),
+            Chapter(title: "Chapter 2", text: "Sample text 2")
+        ]
+        return Book(title: book.title, author: book.author, chapters: chapters)
+    }
+}

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleView.swift
@@ -1,0 +1,36 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays a list of sample Kindle books and allows downloading them
+/// into the local library.
+struct KindleView: View {
+    @EnvironmentObject var library: LibraryModel
+    @EnvironmentObject var usage: UsageStats
+    private let service = KindleService()
+    @State private var books: [KindleBook] = []
+
+    var body: some View {
+        NavigationView {
+            List(books) { book in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(book.title)
+                        Text(book.author).font(.caption)
+                    }
+                    Spacer()
+                    Button("Download") {
+                        let newBook = service.download(book: book)
+                        library.addBook(newBook)
+                        usage.recordImport()
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .navigationTitle("Kindle")
+            .onAppear {
+                books = service.fetchAvailableBooks()
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add simple Kindle service and view for downloading sample ebooks
- update main dashboard TabView with new Kindle tab

## Testing
- `npm test` *(fails: VoiceLab)*
- `npm test` in `VisualLab`
- `npm test` in `apps/CoreForgeBuild`
- `swift test` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685c6d667a588321b4a3b8304ab3a6e3