### PR TITLE
Add Connect tab for external ebook services

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct AppleBook: Identifiable {
+    let id: UUID = UUID()
+    let title: String
+    let author: String
+}
+
+/// Placeholder service simulating Apple Books integration.
+final class AppleBooksService {
+    func fetchAvailableBooks() -> [AppleBook] {
+        return [
+            AppleBook(title: "Apple Sample 1", author: "Author C"),
+            AppleBook(title: "Apple Sample 2", author: "Author D")
+        ]
+    }
+
+    func download(book: AppleBook) -> Book {
+        let chapters = [
+            Chapter(title: "Chapter 1", text: "Sample text 1"),
+            Chapter(title: "Chapter 2", text: "Sample text 2")
+        ]
+        return Book(title: book.title, author: book.author, chapters: chapters)
+    }
+}

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksView.swift
@@ -1,0 +1,34 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays a list of sample Apple Books and allows downloading them
+/// into the local library.
+struct AppleBooksView: View {
+    @EnvironmentObject var library: LibraryModel
+    @EnvironmentObject var usage: UsageStats
+    private let service = AppleBooksService()
+    @State private var books: [AppleBook] = []
+
+    var body: some View {
+        List(books) { book in
+            HStack {
+                VStack(alignment: .leading) {
+                    Text(book.title)
+                    Text(book.author).font(.caption)
+                }
+                Spacer()
+                Button("Download") {
+                    let newBook = service.download(book: book)
+                    library.addBook(newBook)
+                    usage.recordImport()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+        .navigationTitle("Apple Books")
+        .onAppear {
+            books = service.fetchAvailableBooks()
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ConnectView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ConnectView.swift
@@ -1,0 +1,20 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// ConnectView lists available ebook services such as Kindle or Apple Books.
+struct ConnectView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                NavigationLink(destination: KindleView()) {
+                    Label("Kindle", systemImage: "book.fill")
+                }
+                NavigationLink(destination: AppleBooksView()) {
+                    Label("Apple Books", systemImage: "book.circle")
+                }
+            }
+            .navigationTitle("Connect")
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -38,11 +38,11 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Library", systemImage: "books.vertical")
                 }
-            KindleView()
+            ConnectView()
                 .environmentObject(library)
                 .environmentObject(usage)
                 .tabItem {
-                    Label("Kindle", systemImage: "book.fill")
+                    Label("Connect", systemImage: "link")
                 }
             ImportView()
                 .environmentObject(library)


### PR DESCRIPTION
## Summary
- add `ConnectView` to access Kindle and Apple Books
- support Apple Books with placeholder service and view
- update main tab view to show new Connect tab

## Testing
- `swift build --target CreatorCoreForge`
- `npm install` & `npm test` in `VoiceLab` *(fails: Test suite failed to run)*
- `npm install` & `npm test` in `VisualLab`
- `swift test` *(fails: fatalError during tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c7227b1a88321b084aa4fc58e698d