### PR TITLE
Add favorite voices tab

### DIFF
--- a/Sources/CreatorCoreForge/FavoriteVoiceService.swift
+++ b/Sources/CreatorCoreForge/FavoriteVoiceService.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Stores user-selected favorite voices for quick access.
+public final class FavoriteVoiceService: ObservableObject {
+    public static let shared = FavoriteVoiceService()
+    @Published public private(set) var favorites: Set<String>
+    private let key = "VV_FavoriteVoices"
+    private let store: UserDefaults
+    
+    public init(store: UserDefaults = .standard) {
+        self.store = store
+        if let arr = store.array(forKey: key) as? [String] {
+            favorites = Set(arr)
+        } else {
+            favorites = []
+        }
+    }
+
+    /// Toggle a voice as favorite or remove it if already set.
+    public func toggle(voiceID: String) {
+        if favorites.contains(voiceID) {
+            favorites.remove(voiceID)
+        } else {
+            favorites.insert(voiceID)
+        }
+        persist()
+    }
+
+    /// Check whether a voice ID is marked as favorite.
+    public func isFavorite(_ voiceID: String) -> Bool {
+        favorites.contains(voiceID)
+    }
+
+    private func persist() {
+        store.set(Array(favorites), forKey: key)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FavoriteVoiceServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/FavoriteVoiceServiceTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class FavoriteVoiceServiceTests: XCTestCase {
+    func testToggleAndPersistence() {
+        let suite = UserDefaults(suiteName: "FavoriteVoiceTest")!
+        suite.removePersistentDomain(forName: "FavoriteVoiceTest")
+        var service = FavoriteVoiceService(store: suite)
+        service.toggle(voiceID: "narrator")
+        XCTAssertTrue(service.isFavorite("narrator"))
+        // create new instance to verify persistence
+        service = FavoriteVoiceService(store: suite)
+        XCTAssertTrue(service.isFavorite("narrator"))
+        service.toggle(voiceID: "narrator")
+        XCTAssertFalse(service.isFavorite("narrator"))
+    }
+}

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -24,6 +24,7 @@ vault system. It is written in SwiftUI and will expand to additional platforms.
 - **Multi-cast audiobook generation** via `MultiCastAudiobookGenerator`
 - **Immersive dramatized production** with `DramatizedAudiobookProducer`
 - **Dashboard** tab with usage analytics and achievements
+- **Favorite Voices** tab for quickly selecting preferred voices
 - **Highlighted reading** during playback
 
 

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -56,6 +56,10 @@ struct MainTabView: View {
                 .tabItem {
                     Label("Player", systemImage: "play.circle")
                 }
+            FavoritesView()
+                .tabItem {
+                    Label("Favorites", systemImage: "star")
+                }
             SettingsView()
                 .environmentObject(usage)
                 .tabItem {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/FavoritesView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/FavoritesView.swift
@@ -1,0 +1,27 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Lists available voices with the ability to mark favorites.
+struct FavoritesView: View {
+    @ObservedObject private var favorites = FavoriteVoiceService.shared
+    private let voices = VoiceConfig.voices
+
+    var body: some View {
+        NavigationView {
+            List(voices, id: \.id) { voice in
+                HStack {
+                    Text(voice.name)
+                    Spacer()
+                    Button(action: { favorites.toggle(voiceID: voice.id) }) {
+                        Image(systemName: favorites.isFavorite(voice.id) ? "star.fill" : "star")
+                            .foregroundColor(.yellow)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .navigationTitle("Favorite Voices")
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceAssigner.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceAssigner.swift
@@ -1,9 +1,15 @@
 import Foundation
+import CreatorCoreForge
 
 /// Simple AI-based voice assignment stub.
 /// Assigns a voice ID based on length and mood keywords.
 struct VoiceAssigner {
     static func assignVoice(for text: String) -> Voice {
+        // Prefer user's favorite voice if one exists
+        if let favID = FavoriteVoiceService.shared.favorites.first,
+           let fav = VoiceConfig.voices.first(where: { $0.id == favID }) {
+            return fav
+        }
         // Basic heuristics: choose narrator for long text, celebrity for keywords
         let lowercased = text.lowercased()
         if lowercased.contains("wow") || lowercased.contains("incredible") {


### PR DESCRIPTION
## Summary
- create `FavoriteVoiceService` for storing preferred voice IDs
- add SwiftUI `FavoritesView` for marking voices as favorites
- show the new Favorites tab in `MainTabView`
- prefer favorite voices in `VoiceAssigner`
- document the new feature in CoreForge Audio README
- test `FavoriteVoiceService` persistence

## Testing
- `./scripts/run_all_tests.sh` *(fails: audioProcessor.test.ts, newFeatures.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685c7ba32a448321b245a53578527b61