### PR TITLE
Add shared dashboard theme

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     targets: [
         .target(name: "CreatorCoreForge", path: "Sources/CreatorCoreForge"),
         .executableTarget(name: "LibraryDemoApp",
+                          dependencies: ["CreatorCoreForge"],
                           path: "apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo",
                           exclude: ["Info.plist"]),
         .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")

--- a/Sources/CreatorCoreForge/AppTheme.swift
+++ b/Sources/CreatorCoreForge/AppTheme.swift
@@ -11,6 +11,11 @@ public enum AppTheme {
             endPoint: .bottomTrailing
         )
     }
+
+    /// Accent color used for icons and interactive elements.
+    public static var accentColor: Color {
+        Color.purple
+    }
 }
 #endif
 

--- a/Sources/CreatorCoreForge/DashboardTabView.swift
+++ b/Sources/CreatorCoreForge/DashboardTabView.swift
@@ -1,0 +1,39 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Represents a single tab configuration for DashboardTabView.
+public struct DashboardTab {
+    public var title: String
+    public var systemImage: String
+    public var view: AnyView
+
+    public init<Content: View>(title: String, systemImage: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.systemImage = systemImage
+        self.view = AnyView(content())
+    }
+}
+
+/// Shared TabView styled with the CoreForge Audio theme.
+public struct DashboardTabView: View {
+    private var tabs: [DashboardTab]
+
+    public init(tabs: [DashboardTab]) {
+        self.tabs = tabs
+    }
+
+    public var body: some View {
+        ZStack {
+            AppTheme.primaryGradient.ignoresSafeArea()
+            TabView {
+                ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+                    tab.view
+                        .tabItem { Label(tab.title, systemImage: tab.systemImage) }
+                        .tag(index)
+                }
+            }
+            .accentColor(AppTheme.accentColor)
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/ContentView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/ContentView.swift
@@ -1,15 +1,17 @@
 import Foundation
 #if canImport(SwiftUI)
 import SwiftUI
+import CreatorCoreForge
 struct ContentView: View {
     @State private var loggedInUser: String?
     @State private var showSignUp = false
+    @StateObject private var usage = UsageStats()
 
     var body: some View {
         NavigationView {
-            if let user = loggedInUser {
-                LibraryView()
-                    .navigationTitle("Library")
+            if let _ = loggedInUser {
+                MainTabView()
+                    .environmentObject(usage)
             } else if showSignUp {
                 SignUpView { email, password in
                     // Mock auth success
@@ -26,6 +28,21 @@ struct ContentView: View {
                 .toolbar { Button("Sign Up") { showSignUp = true } }
             }
         }
+    }
+}
+
+struct MainTabView: View {
+    @EnvironmentObject var usage: UsageStats
+
+    var body: some View {
+        DashboardTabView(tabs: [
+            DashboardTab(title: "Dashboard", systemImage: "chart.bar") {
+                DashboardView().environmentObject(usage)
+            },
+            DashboardTab(title: "Library", systemImage: "books.vertical") {
+                LibraryView()
+            }
+        ])
     }
 }
 

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/DashboardView.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/DashboardView.swift
@@ -1,0 +1,40 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Displays basic usage statistics.
+struct DashboardView: View {
+    @EnvironmentObject var usage: UsageStats
+
+    private func timeString(_ time: TimeInterval) -> String {
+        let h = Int(time) / 3600
+        let m = Int(time.truncatingRemainder(dividingBy: 3600)) / 60
+        return "\(h)h \(m)m"
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section(header: Text("Activity")) {
+                    HStack {
+                        Text("Books Read")
+                        Spacer()
+                        Text("\(usage.booksRead)")
+                    }
+                    HStack {
+                        Text("Listening Time")
+                        Spacer()
+                        Text(timeString(usage.hoursListened))
+                    }
+                    HStack {
+                        Text("Favorites")
+                        Spacer()
+                        Text("\(usage.favorites)")
+                    }
+                }
+            }
+            .navigationTitle("Dashboard")
+        }
+    }
+}
+#endif

--- a/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/UsageStats.swift
+++ b/apps/CoreForgeLibrary/LibraryDemoFull/LibraryDemo/UsageStats.swift
@@ -1,0 +1,9 @@
+import Foundation
+import Combine
+
+/// Tracks library usage metrics for the dashboard.
+final class UsageStats: ObservableObject {
+    @Published var booksRead: Int = 0
+    @Published var hoursListened: TimeInterval = 0
+    @Published var favorites: Int = 0
+}


### PR DESCRIPTION
## Summary
- define `accentColor` in `AppTheme` and use across apps
- add `DashboardTabView` for consistent themed tabs
- integrate dashboard in Library demo with new `UsageStats`
- update Library demo package to depend on `CreatorCoreForge`

## Testing
- `./scripts/run_all_tests.sh` *(fails: audioProcessor.test.ts, newFeatures.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_685c87e4d4f083218452446cdf152d68