### PR TITLE
Improve TTS rendering and add multitrack suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Ran `scripts/full_app_scan.py` and updated readiness checklist. Verified test suites via `run_all_tests.sh`.
 - Measured `full_app_scan.py` runtime (0.11s, ~14.7 MB) via new `measure_performance.py` and confirmed tests pass.
 - Added developer console toggle to `BuildPreviewEngine`.
+- Enhanced `TTSRenderer` with buffered queue processing, jittered backoff, and latency monitoring callbacks.
+- Added `MultiTrackProductionSuite` for simple audio/video track orchestration with unit tests.
 - Added `UnifiedAudioEngine` shared module and updated all app feature lists.
 - Added `UnifiedVideoEngine` and `AdaptiveLearningEngine` modules for cross-platform video rendering and adaptive learning.
 - Enhanced `AdaptiveLearningEngine` to track lesson completion timestamps.

--- a/Sources/CreatorCoreForge/MultiTrackProductionSuite.swift
+++ b/Sources/CreatorCoreForge/MultiTrackProductionSuite.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Represents an audio track used for mixing.
+public struct ProductionTrack {
+    public let name: String
+    public let samples: [Int]
+    public init(name: String, samples: [Int]) {
+        self.name = name
+        self.samples = samples
+    }
+}
+
+/// Holds the result of a combined audio/video render.
+public struct ProductionResult {
+    public let audioMix: [Int]
+    public let frames: [String]
+}
+
+/// Simple orchestrator for multitrack audio and video production.
+public final class MultiTrackProductionSuite {
+    private let editor: MultiTrackEditor
+    private let exporter: ExportProduction
+
+    public init(editor: MultiTrackEditor = MultiTrackEditor(),
+                exporter: ExportProduction = ExportProduction()) {
+        self.editor = editor
+        self.exporter = exporter
+    }
+
+    /// Mix audio tracks and export frames with an optional watermark.
+    public func produce(tracks: [ProductionTrack],
+                        frames: [String],
+                        watermark: String? = nil) -> ProductionResult {
+        let mix = editor.mix(tracks: tracks.map { $0.samples })
+        let exported = exporter.export(frames: frames, watermark: watermark)
+        return ProductionResult(audioMix: mix, frames: exported)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/MultiTrackProductionSuiteTests.swift
+++ b/Tests/CreatorCoreForgeTests/MultiTrackProductionSuiteTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class MultiTrackProductionSuiteTests: XCTestCase {
+    func testProduce() {
+        let suite = MultiTrackProductionSuite()
+        let tracks = [
+            ProductionTrack(name: "v1", samples: [1,2]),
+            ProductionTrack(name: "v2", samples: [1])
+        ]
+        let result = suite.produce(tracks: tracks, frames: ["f1", "f2"], watermark: "wm")
+        XCTAssertEqual(result.audioMix[0], 2)
+        XCTAssertEqual(result.frames.first, "f1-wm(wm)")
+    }
+}

--- a/VoiceLab/src/dynamicRangeCompressor.ts
+++ b/VoiceLab/src/dynamicRangeCompressor.ts
@@ -50,21 +50,8 @@ export class AudioProcessor {
     if (attack < 0 || release < 0) throw new Error('attack/release must be >= 0');
     if (sampleRate <= 0) throw new Error('sampleRate must be > 0');
 
-=======
-export class AudioProcessor {
-  async compress(
-    input: AudioBlob,
-    threshold = 0.6,
-    ratio = 4
-  ): Promise<AudioBlob> {
-
     const buffer = Buffer.from(await input.arrayBuffer());
-    const samples = new Float32Array(
-      buffer.buffer,
-      buffer.byteOffset,
-      Math.floor(buffer.byteLength / 4)
-    );
-
+    const samples = new Float32Array(buffer.buffer, buffer.byteOffset, Math.floor(buffer.byteLength / 4));
 
     const attackCoef = attack > 0 ? Math.exp(-1 / (attack * sampleRate)) : 0;
     const releaseCoef = release > 0 ? Math.exp(-1 / (release * sampleRate)) : 0;
@@ -85,17 +72,6 @@ export class AudioProcessor {
         gain = desiredGain + diff * releaseCoef;
       }
       samples[i] *= gain * makeupGain;
-    }
-
-=======
-    for (let i = 0; i < samples.length; i++) {
-      const s = samples[i];
-      const abs = Math.abs(s);
-      if (abs > threshold) {
-        const sign = Math.sign(s);
-        const excess = abs - threshold;
-        samples[i] = sign * (threshold + excess / ratio);
-      }
     }
 
     return new Blob([samples.buffer], { type: input.type || 'application/octet-stream' });

--- a/VoiceLab/test/audioProcessor.test.ts
+++ b/VoiceLab/test/audioProcessor.test.ts
@@ -41,11 +41,4 @@ test('attack smoothing delays full compression', async () => {
   const imm = new Float32Array(await immediate.arrayBuffer());
   const slw = new Float32Array(await slow.arrayBuffer());
   expect(slw[0]).toBeGreaterThan(imm[0]);
-=======
-  const out = await processor.compress(input, 0.5, 2);
-  const data = new Float32Array(await out.arrayBuffer());
-  expect(data[0]).toBeCloseTo(0.2);
-  expect(data[1]).toBeCloseTo(0.5 + (0.8 - 0.5) / 2);
-  expect(data[2]).toBeCloseTo(-(0.5 + (0.9 - 0.5) / 2));
-
 });

--- a/VoiceLab/test/ttsRenderer.test.ts
+++ b/VoiceLab/test/ttsRenderer.test.ts
@@ -7,3 +7,19 @@ test('TTSRenderer processes queued segments', async () => {
   await new Promise((res) => setTimeout(res, 50));
   expect(renderer.isIdle()).toBe(true);
 });
+
+test('latency spike callback fires', async () => {
+  const { renderSegment } = await import('../src/ttsService');
+  (renderSegment as jest.Mock).mockImplementationOnce(async () => {
+    await new Promise((r) => setTimeout(r, 60));
+    return new Blob(['a']);
+  });
+  const spikes: number[] = [];
+  const renderer = new TTSRenderer({
+    onLatencySpike: (latency) => spikes.push(latency),
+    latencyThreshold: 50,
+  });
+  renderer.enqueue({ id: 'slow', text: 'test' });
+  await new Promise((r) => setTimeout(r, 80));
+  expect(spikes.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- enhance TTSRenderer with buffered queue, backoff tweaks and latency callbacks
- fix merge conflicts in audio processor tests and compressor
- add MultiTrackProductionSuite for multi-track audio/video
- test latency spike handling and new suite
- document updates in CHANGELOG

## Testing
- `npm test --workspaces`
- `swift test` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_e_685c884d96cc832186ca298009ab4c0e