### PR TITLE
Enhance Audio dashboard navigation

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -6,11 +6,12 @@ struct ContentView: View {
     @StateObject private var library = LibraryModel()
     @StateObject private var usage = UsageStats()
     @Namespace private var ns
+    @State private var selectedTab = 0
 
     var body: some View {
         Group {
             if hasSeenOnboarding {
-                MainTabView(namespace: ns)
+                MainTabView(namespace: ns, selection: $selectedTab)
                     .environmentObject(library)
                     .environmentObject(usage)
                     .transition(.scale)
@@ -25,48 +26,56 @@ struct ContentView: View {
 
 struct MainTabView: View {
     var namespace: Namespace.ID
+    @Binding var selection: Int
     @EnvironmentObject var library: LibraryModel
     @EnvironmentObject var usage: UsageStats
 
     var body: some View {
-        TabView {
-            DashboardView()
+        TabView(selection: $selection) {
+            DashboardView(tabSelection: $selection)
                 .environmentObject(usage)
                 .tabItem {
                     Label("Dashboard", systemImage: "chart.bar")
                 }
+                .tag(0)
             LibraryView(namespace: namespace)
                 .environmentObject(library)
                 .tabItem {
                     Label("Library", systemImage: "books.vertical")
                 }
+                .tag(1)
             ConnectView()
                 .environmentObject(library)
                 .environmentObject(usage)
                 .tabItem {
                     Label("Connect", systemImage: "link")
                 }
+                .tag(2)
             ImportView()
                 .environmentObject(library)
                 .environmentObject(usage)
                 .tabItem {
                     Label("Import", systemImage: "square.and.arrow.down")
                 }
+                .tag(3)
             PlayerView()
                 .environmentObject(library)
                 .environmentObject(usage)
                 .tabItem {
                     Label("Player", systemImage: "play.circle")
                 }
+                .tag(4)
             FavoritesView()
                 .tabItem {
                     Label("Favorites", systemImage: "star")
                 }
+                .tag(5)
             SettingsView()
                 .environmentObject(usage)
                 .tabItem {
                     Label("Settings", systemImage: "gearshape")
                 }
+                .tag(6)
         }
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/DashboardView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/DashboardView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Displays usage metrics, subscription status, and achievements.
 struct DashboardView: View {
     @EnvironmentObject var usage: UsageStats
+    @Binding var tabSelection: Int
 
     var body: some View {
         NavigationView {
@@ -43,6 +44,18 @@ struct DashboardView: View {
                 }
             }
             .navigationTitle("Dashboard")
+            .toolbar {
+                Menu {
+                    Button("Library") { tabSelection = 1 }
+                    Button("Connect") { tabSelection = 2 }
+                    Button("Import") { tabSelection = 3 }
+                    Button("Player") { tabSelection = 4 }
+                    Button("Favorites") { tabSelection = 5 }
+                    Button("Settings") { tabSelection = 6 }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add tab index binding to MainTabView in CoreForge Audio
- provide dashboard menu for quick navigation

## Testing
- `swift test -l` *(fails: build takes too long)*
- `swift build` *(fails: build cancelled due to time)*

------
https://chatgpt.com/codex/tasks/task_e_685c8f138ccc8321b49b767f1fbfb8a1