### PR TITLE
Update ebook connectors

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
@@ -4,22 +4,51 @@ struct AppleBook: Identifiable {
     let id: UUID = UUID()
     let title: String
     let author: String
+    let description: String
 }
 
-/// Placeholder service simulating Apple Books integration.
+/// Service that queries the iTunes Search API for eBooks and builds `Book`
+/// models from the provided metadata.
 final class AppleBooksService {
-    func fetchAvailableBooks() -> [AppleBook] {
-        return [
-            AppleBook(title: "Apple Sample 1", author: "Author C"),
-            AppleBook(title: "Apple Sample 2", author: "Author D")
-        ]
+    private struct SearchResponse: Decodable {
+        struct Result: Decodable {
+            let trackName: String
+            let artistName: String
+            let description: String
+        }
+        let results: [Result]
     }
 
+    /// Fetch a list of available eBooks from iTunes.
+    func fetchAvailableBooks() -> [AppleBook] {
+        guard let url = URL(string: "https://itunes.apple.com/search?media=ebook&term=fiction&limit=10") else {
+            return []
+        }
+        var books: [AppleBook] = []
+        let semaphore = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            defer { semaphore.signal() }
+            guard let data = data,
+                  let response = try? JSONDecoder().decode(SearchResponse.self, from: data) else { return }
+            books = response.results.map {
+                AppleBook(title: $0.trackName,
+                          author: $0.artistName,
+                          description: $0.description)
+            }
+        }.resume()
+        _ = semaphore.wait(timeout: .now() + 10)
+        return books
+    }
+
+    /// Convert the selected book description into placeholder chapters.
     func download(book: AppleBook) -> Book {
-        let chapters = [
-            Chapter(title: "Chapter 1", text: "Sample text 1"),
-            Chapter(title: "Chapter 2", text: "Sample text 2")
-        ]
+        let paragraphs = book.description
+            .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .components(separatedBy: ". ")
+            .prefix(10)
+        let chapters = paragraphs.enumerated().map { idx, str in
+            Chapter(title: "Part \(idx + 1)", text: str.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
         return Book(title: book.title, author: book.author, chapters: chapters)
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ConnectView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ConnectView.swift
@@ -1,7 +1,7 @@
 #if canImport(SwiftUI)
 import SwiftUI
 
-/// ConnectView lists available ebook services such as Kindle or Apple Books.
+/// ConnectView lists available ebook services powered by public APIs.
 struct ConnectView: View {
     var body: some View {
         NavigationView {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
@@ -7,18 +7,43 @@ struct KindleBook: Identifiable {
     let downloadURL: URL?
 }
 
-/// Simple service that lists sample Kindle books and creates demo `Book` models
-/// when downloaded. In a real app this would connect to the Kindle API.
+/// Service that fetches public domain books from Project Gutenberg via the
+/// Gutendex API and converts them into `Book` models.
 final class KindleService {
-    func fetchAvailableBooks() -> [KindleBook] {
-        return [
-            KindleBook(title: "Alice in Wonderland", author: "Lewis Carroll",
-                       downloadURL: URL(string: "https://www.gutenberg.org/cache/epub/11/pg11.txt")),
-            KindleBook(title: "Pride and Prejudice", author: "Jane Austen",
-                       downloadURL: URL(string: "https://www.gutenberg.org/files/1342/1342-0.txt"))
-        ]
+    private struct GutenbergResponse: Decodable {
+        struct Result: Decodable {
+            struct Author: Decodable { let name: String }
+            let title: String
+            let authors: [Author]
+            let formats: [String: String]
+        }
+        let results: [Result]
     }
 
+    /// Fetch a list of available public domain books.
+    func fetchAvailableBooks() -> [KindleBook] {
+        guard let url = URL(string: "https://gutendex.com/books/?mime_type=text/plain&languages=en&copyright=false") else {
+            return []
+        }
+        var books: [KindleBook] = []
+        let semaphore = DispatchSemaphore(value: 0)
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            defer { semaphore.signal() }
+            guard let data = data,
+                  let response = try? JSONDecoder().decode(GutenbergResponse.self, from: data) else { return }
+            books = response.results.prefix(10).compactMap { result in
+                let author = result.authors.first?.name ?? "Unknown"
+                let urlString = result.formats["text/plain; charset=utf-8"] ?? result.formats["text/plain"]
+                return KindleBook(title: result.title,
+                                  author: author,
+                                  downloadURL: urlString.flatMap(URL.init))
+            }
+        }.resume()
+        _ = semaphore.wait(timeout: .now() + 10)
+        return books
+    }
+
+    /// Download the selected book text and split it into simple chapters.
     func download(book: KindleBook) -> Book {
         if let url = book.downloadURL,
            let text = try? String(contentsOf: url) {
@@ -28,10 +53,8 @@ final class KindleService {
             }
             return Book(title: book.title, author: book.author, chapters: chapters)
         }
-        let chapters = [
-            Chapter(title: "Chapter 1", text: "Sample text 1"),
-            Chapter(title: "Chapter 2", text: "Sample text 2")
-        ]
-        return Book(title: book.title, author: book.author, chapters: chapters)
+        return Book(title: book.title,
+                    author: book.author,
+                    chapters: [Chapter(title: "Chapter 1", text: "Unable to download")])
     }
 }


### PR DESCRIPTION
## Summary
- implement real data fetching from Gutendex and iTunes Search
- update ConnectView docs for new public API usage

## Testing
- `npm install && npm test` in `VoiceLab`
- `npm install && npm test` in `VisualLab`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685c91d606948321968a048afc810d88