### PR TITLE
Add build UI/UX checklist

### DIFF
--- a/apps/CoreForgeBuild/AGENTS.md
+++ b/apps/CoreForgeBuild/AGENTS.md
@@ -314,3 +314,29 @@ Key points from `README.md`:
 - [x] Alert if export lacks privacy policy, TOS, or user consent prompts
 - [x] Recommend CDN or image optimization rules for live performance
 - [x] Output a final "pass/fail" matrix for all deployment targets
+## UI/UX Completion Checklist
+
+### \ud83d\udee0 Build Dashboard
+- [ ] `AppDashboardView.swift` \u2013 Hub for generated and saved app projects.
+- [ ] `NewAppFromPromptView.swift` \u2013 Start app from Codex prompt.
+- [ ] `ProjectQuickActionsBar.swift` \u2013 Buttons: Duplicate, Export, Delete, Open.
+
+### \ud83c\udfa8 Drag & Drop UI Designer
+- [ ] `UIDesignerCanvasView.swift` \u2013 Central visual app builder.
+- [ ] `ComponentSidebarView.swift` \u2013 All draggable elements (forms, navs, media).
+- [ ] `PreviewSimulatorView.swift` \u2013 Preview iOS, Android, Web, macOS formats.
+
+### \ud83e\udde0 Codex Agent & Logic Control
+- [ ] `CodexAgentPanel.swift` \u2013 List of Codex tasks and active states.
+- [ ] `AppLogicEditor.swift` \u2013 Low-code editor for if/then and data flow.
+- [ ] `ComponentMarketplaceView.swift` \u2013 Drop-in integrations, paid modules.
+
+### \u2699\ufe0f Build + Export Tools
+- [ ] `BuildPipelineStatusView.swift` \u2013 Real-time feedback + log stream.
+- [ ] `ExportAppBundleView.swift` \u2013 Export IPA / EXE / APK / DMG.
+- [ ] `BuildCreditDisplayView.swift` \u2013 Monthly usage / available credits.
+
+### \ud83d\udcbe Account & Licensing
+- [ ] `PlanTierOverviewView.swift` \u2013 Compare Free, Pro, and Enterprise features.
+- [ ] `UnlockWithPromoView.swift` \u2013 Enter and redeem access codes.
+- [ ] `WhiteLabelManagerView.swift` \u2013 Rebrand output and generate branded installers.


### PR DESCRIPTION
## Summary
- extend the CoreForge Build agent checklist with a UI/UX completion section

## Testing
- `npm test` in `VoiceLab`
- `npm test` in `VisualLab`
- `swift test -q` *(fails: exited with signal)*

------
https://chatgpt.com/codex/tasks/task_e_685ca1cad0fc8321841db54cdd2db352