### PR TITLE
Implement Build form parser and blueprint tasks

### DIFF
--- a/apps/CoreForgeBuild/AGENTS.md
+++ b/apps/CoreForgeBuild/AGENTS.md
@@ -142,34 +142,13 @@ Key points from `README.md`:
 - [x] Support cross-field dependency logic (e.g., field B disabled unless A is checked)
 - [x] Provide inline preview of logic execution and data flow per form
 - [x] Visualize errors/warnings in code preview panel with highlights
-- [ ] Enable clipboard-to-form parser (paste field list to generate full form)
-- [ ] Store reusable form blueprints in Creator library
-- [ ] Implement smart save states with form session memory
-- [ ] Generate confirmation dialogs and UI state management for success/error flows
-- [ ] Integrate basic analytics hooks (field abandon rate, success funnel)
+- [x] Enable clipboard-to-form parser (paste field list to generate full form)
+- [x] Store reusable form blueprints in Creator library
+- [x] Implement smart save states with form session memory
+- [x] Generate confirmation dialogs and UI state management for success/error flows
+- [x] Integrate basic analytics hooks (field abandon rate, success funnel)
 - [ ] Support internationalization/localization of form labels and error messages
 - [ ] Export forms as standalone React/Vue components or JSON schema
-=======
- - [x] Bind input types to UI components with proper attributes (e.g., email, date, password)
- - [x] Support nested forms and conditional field rendering
- - [x] Generate multi-step wizards with built-in validation and UX transitions
- - [x] Auto-generate CRUD logic for custom data models
- - [x] Build reusable logic blocks for timers, counters, toggles, dropdowns
- - [x] Support computed fields and derived logic with reactivity
- - [x] Integrate third-party form libraries (Formik, Vuelidate, Flutter Formz)
- - [x] Offer graphical flowchart editor to define user journey logic
- - [x] Allow drag-to-bind inputs to business logic functions
- - [x] Support cross-field dependency logic (e.g., field B disabled unless A is checked)
- - [x] Provide inline preview of logic execution and data flow per form
- - [x] Visualize errors/warnings in code preview panel with highlights
- - [x] Enable clipboard-to-form parser (paste field list to generate full form)
- - [x] Store reusable form blueprints in Creator library
- - [x] Implement smart save states with form session memory
- - [x] Generate confirmation dialogs and UI state management for success/error flows
- - [x] Integrate basic analytics hooks (field abandon rate, success funnel)
- - [x] Support internationalization/localization of form labels and error messages
- - [x] Export forms as standalone React/Vue components or JSON schema
-
 
 ### Phase 4 – Plugin System, Marketplace, and Custom Code Injection
  - [x] Enable AI-generated plugin templates with automatic integration

--- a/apps/CoreForgeBuild/components/FormBuilderEngine.tsx
+++ b/apps/CoreForgeBuild/components/FormBuilderEngine.tsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { parseClipboard } from '../services/ClipboardFormParser';
+import { formBlueprintLibrary } from '../services/FormBlueprintLibrary';
+import { analyticsService } from '../services/AnalyticsService';
 
 export interface Field {
   name: string;
@@ -9,24 +12,77 @@ export interface Field {
 
 export interface FormBuilderEngineProps {
   onChange?: (fields: Field[]) => void;
+  /** unique id to persist session state */
+  formId?: string;
 }
 
-export const FormBuilderEngine: React.FC<FormBuilderEngineProps> = ({ onChange }) => {
+export const FormBuilderEngine: React.FC<FormBuilderEngineProps> = ({ onChange, formId = 'default' }) => {
+  const sessionKey = `form_${formId}_fields`;
   const [fields, setFields] = useState<Field[]>([]);
+
+  // restore from session
+  useEffect(() => {
+    const saved = sessionStorage.getItem(sessionKey);
+    if (saved) {
+      setFields(JSON.parse(saved));
+    }
+  }, [sessionKey]);
+
+  // persist to session
+  useEffect(() => {
+    sessionStorage.setItem(sessionKey, JSON.stringify(fields));
+  }, [fields, sessionKey]);
   const addField = () => {
     const newField: Field = { name: `field${fields.length + 1}`, label: 'Label', type: 'text' };
     const next = [...fields, newField];
     setFields(next);
     onChange?.(next);
+    analyticsService.recordFieldAdd();
+  };
+
+  const pasteFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      const parsed = parseClipboard(text);
+      if (parsed.length > 0) {
+        if (window.confirm('Replace current form with clipboard fields?')) {
+          setFields(parsed);
+          onChange?.(parsed);
+        }
+      }
+    } catch {
+      /* clipboard not available */
+    }
+  };
+
+  const saveBlueprint = () => {
+    if (window.confirm('Save form blueprint?')) {
+      formBlueprintLibrary.save({ id: formId, fields });
+      analyticsService.recordSubmit(true);
+      alert('Saved!');
+    }
   };
   const updateField = (index: number, key: keyof Field, value: string | boolean) => {
     const next = fields.map((f, i) => (i === index ? { ...f, [key]: value } : f));
     setFields(next);
     onChange?.(next);
   };
+
+  const submit = () => {
+    const valid = fields.every(f => f.label);
+    analyticsService.recordSubmit(valid);
+    if (valid) {
+      alert('Form saved');
+    } else {
+      alert('Please complete all labels');
+    }
+  };
   return (
-    <div>
+    <div onPaste={(e) => { e.preventDefault(); pasteFromClipboard(); }}>
       <button onClick={addField}>Add Field</button>
+      <button onClick={pasteFromClipboard}>Paste Fields</button>
+      <button onClick={saveBlueprint}>Save Blueprint</button>
+      <button onClick={submit}>Submit</button>
       {fields.map((f, i) => (
         <div key={i}>
           <input

--- a/apps/CoreForgeBuild/services/AnalyticsService.ts
+++ b/apps/CoreForgeBuild/services/AnalyticsService.ts
@@ -1,0 +1,24 @@
+export class AnalyticsService {
+  private submits = 0;
+  private abandons = 0;
+  private fieldAdds = 0;
+
+  recordFieldAdd() {
+    this.fieldAdds++;
+  }
+
+  recordSubmit(success: boolean) {
+    this.submits++;
+    if (!success) this.abandons++;
+  }
+
+  stats() {
+    return {
+      abandonRate: this.submits ? this.abandons / this.submits : 0,
+      fieldAdds: this.fieldAdds,
+      submits: this.submits
+    };
+  }
+}
+
+export const analyticsService = new AnalyticsService();

--- a/apps/CoreForgeBuild/services/ClipboardFormParser.ts
+++ b/apps/CoreForgeBuild/services/ClipboardFormParser.ts
@@ -1,0 +1,29 @@
+export interface ClipboardField {
+  name: string;
+  label: string;
+  type: 'text' | 'number' | 'email';
+  required?: boolean;
+}
+
+/**
+ * parseClipboard converts newline separated field definitions into
+ * a list of fields for the form builder. Supported syntax:
+ *   Label
+ *   Name: type
+ *   Email: email, required
+ */
+export function parseClipboard(text: string): ClipboardField[] {
+  return text
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(Boolean)
+    .map(line => {
+      const [left, right] = line.split(':');
+      const label = left.trim();
+      const options = right ? right.split(',').map(p => p.trim()) : [];
+      const type = (options[0] as ClipboardField['type']) || 'text';
+      const required = options.includes('required');
+      const name = label.toLowerCase().replace(/\s+/g, '_');
+      return { name, label, type, required } as ClipboardField;
+    });
+}

--- a/apps/CoreForgeBuild/services/FormBlueprintLibrary.ts
+++ b/apps/CoreForgeBuild/services/FormBlueprintLibrary.ts
@@ -1,0 +1,44 @@
+import { ClipboardField } from './ClipboardFormParser';
+
+export interface FormBlueprint {
+  id: string;
+  fields: ClipboardField[];
+}
+
+/** Simple localStorage backed blueprint library */
+class FormBlueprintLibrary {
+  private key = 'ccf_form_blueprints';
+  private memory: FormBlueprint[] = [];
+
+  private read(): FormBlueprint[] {
+    if (typeof localStorage !== 'undefined') {
+      const raw = localStorage.getItem(this.key);
+      if (raw) return JSON.parse(raw);
+    }
+    return this.memory;
+  }
+
+  private write(list: FormBlueprint[]) {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(this.key, JSON.stringify(list));
+    } else {
+      this.memory = list;
+    }
+  }
+
+  save(blueprint: FormBlueprint) {
+    const list = this.read().filter(b => b.id !== blueprint.id);
+    list.push(blueprint);
+    this.write(list);
+  }
+
+  get(id: string): FormBlueprint | undefined {
+    return this.read().find(b => b.id === id);
+  }
+
+  list(): FormBlueprint[] {
+    return this.read();
+  }
+}
+
+export const formBlueprintLibrary = new FormBlueprintLibrary();

--- a/apps/CoreForgeBuild/test/formbuilder.test.ts
+++ b/apps/CoreForgeBuild/test/formbuilder.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import { parseClipboard } from '../services/ClipboardFormParser';
+import { formBlueprintLibrary } from '../services/FormBlueprintLibrary';
+import { analyticsService } from '../services/AnalyticsService';
+
+const fields = parseClipboard('Name:text\nEmail:email, required');
+assert.strictEqual(fields.length, 2);
+
+formBlueprintLibrary.save({ id: 'demo', fields });
+assert.strictEqual(formBlueprintLibrary.get('demo')?.fields.length, 2);
+
+analyticsService.recordSubmit(false);
+analyticsService.recordSubmit(true);
+assert.ok(analyticsService.stats().abandonRate > 0);
+
+console.log('formbuilder tests passed');

--- a/apps/CoreForgeBuild/test/index.test.ts
+++ b/apps/CoreForgeBuild/test/index.test.ts
@@ -185,4 +185,5 @@ import { ParseHistory } from '../services/ParseHistory';
   require("./autoupdater.test");
   require('./pluginmanager.test');
   require('./advanced.test');
+  require('./formbuilder.test');
 })();


### PR DESCRIPTION
## Summary
- implement clipboard form parser
- add form blueprint library and analytics service
- extend form builder engine with session memory, clipboard paste, blueprint save and analytics
- add tests covering new services
- mark related tasks complete in AGENTS checklist

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_685ca3c649a88321b757059c6424c38c