### PR TITLE
Add shared signup form with DOB

### DIFF
--- a/Sources/CreatorCoreForge/BasicAuthService.swift
+++ b/Sources/CreatorCoreForge/BasicAuthService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Simple in-memory auth for demo and testing purposes.
+public final class BasicAuthService {
+    public static let shared = BasicAuthService()
+
+    public struct User {
+        public let email: String
+        public let dob: Date
+    }
+
+    private(set) public var currentUser: User?
+
+    private init() {}
+
+    /// Register a user and automatically sign them in.
+    public func register(email: String, password: String, dob: Date) {
+        currentUser = User(email: email, dob: dob)
+    }
+
+    /// Sign in if credentials match the registered user.
+    @discardableResult
+    public func signIn(email: String, password: String) -> Bool {
+        guard let user = currentUser, user.email == email else { return false }
+        return true
+    }
+}

--- a/Sources/CreatorCoreForge/FormGenerator.swift
+++ b/Sources/CreatorCoreForge/FormGenerator.swift
@@ -16,7 +16,8 @@ public struct FormGenerator {
             return FormTemplate(name: "register", fields: [
                 FormField(name: "email", type: .email, required: true),
                 FormField(name: "password", type: .password, required: true),
-                FormField(name: "confirm", type: .password, required: true)
+                FormField(name: "confirm", type: .password, required: true),
+                FormField(name: "dob", type: .date, required: true)
             ])
         } else if lower.contains("checkout") {
             return FormTemplate(name: "checkout", fields: [

--- a/Sources/CreatorCoreForge/FormTemplate.swift
+++ b/Sources/CreatorCoreForge/FormTemplate.swift
@@ -7,6 +7,7 @@ public struct FormField: Codable, Equatable {
         case password
         case email
         case number
+        case date
     }
     public var name: String
     public var type: FieldType

--- a/Sources/CreatorCoreForge/SignUpView.swift
+++ b/Sources/CreatorCoreForge/SignUpView.swift
@@ -1,0 +1,33 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Basic sign up form requesting email, password, and date of birth.
+/// On submit, the user is automatically signed in via `BasicAuthService`.
+public struct SignUpView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var dob = Date()
+    @State private var signedIn = false
+
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 20) {
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            DatePicker("Date of Birth", selection: $dob, displayedComponents: .date)
+            Button("Register") {
+                BasicAuthService.shared.register(email: email, password: password, dob: dob)
+                signedIn = BasicAuthService.shared.signIn(email: email, password: password)
+            }
+            .buttonStyle(.borderedProminent)
+            if signedIn {
+                Text("Signed in as \(email)")
+            }
+        }
+        .padding()
+    }
+}
+#endif

--- a/Tests/CreatorCoreForgeTests/BasicAuthServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/BasicAuthServiceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class BasicAuthServiceTests: XCTestCase {
+    func testRegisterAutoSignsIn() {
+        let service = BasicAuthService.shared
+        service.register(email: "test@example.com", password: "pw", dob: Date())
+        XCTAssertEqual(service.currentUser?.email, "test@example.com")
+        XCTAssertTrue(service.signIn(email: "test@example.com", password: "pw"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FormGeneratorTests.swift
+++ b/Tests/CreatorCoreForgeTests/FormGeneratorTests.swift
@@ -9,6 +9,14 @@ final class FormGeneratorTests: XCTestCase {
         XCTAssertEqual(form?.fields.count, 2)
     }
 
+    func testGeneratesRegisterFormWithDOB() {
+        let gen = FormGenerator()
+        let form = gen.generateForm(from: "register")
+        XCTAssertEqual(form?.name, "register")
+        XCTAssertEqual(form?.fields.count, 4)
+        XCTAssertTrue(form!.fields.contains(where: { $0.name == "dob" && $0.type == .date }))
+    }
+
     func testValidation() {
         let gen = FormGenerator()
         let form = gen.generateForm(from: "login")!


### PR DESCRIPTION
## Summary
- extend `FormField.FieldType` to include a `date` option
- add DOB field to generated registration forms
- provide a reusable SwiftUI `SignUpView` that registers and auto-signs in users
- include an in-memory `BasicAuthService` for demo/testing
- test signup flow and registration form generation

## Testing
- `npm test`
- `swift test` *(fails: fatalError during build)*

------
https://chatgpt.com/codex/tasks/task_e_685d210830848321bd4c92b16fda1cb0