### PR TITLE
Add sign-up forms across desktop apps

### DIFF
--- a/Sources/CreatorCoreForge/BasicAuthService.swift
+++ b/Sources/CreatorCoreForge/BasicAuthService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Simple in-memory auth for demo and testing purposes.
+public final class BasicAuthService {
+    public static let shared = BasicAuthService()
+
+    public struct User {
+        public let email: String
+        public let dob: Date
+    }
+
+    private(set) public var currentUser: User?
+
+    private init() {}
+
+    /// Register a user and automatically sign them in.
+    public func register(email: String, password: String, dob: Date) {
+        currentUser = User(email: email, dob: dob)
+    }
+
+    /// Sign in if credentials match the registered user.
+    @discardableResult
+    public func signIn(email: String, password: String) -> Bool {
+        guard let user = currentUser, user.email == email else { return false }
+        return true
+    }
+}

--- a/Sources/CreatorCoreForge/FormGenerator.swift
+++ b/Sources/CreatorCoreForge/FormGenerator.swift
@@ -16,7 +16,8 @@ public struct FormGenerator {
             return FormTemplate(name: "register", fields: [
                 FormField(name: "email", type: .email, required: true),
                 FormField(name: "password", type: .password, required: true),
-                FormField(name: "confirm", type: .password, required: true)
+                FormField(name: "confirm", type: .password, required: true),
+                FormField(name: "dob", type: .date, required: true)
             ])
         } else if lower.contains("checkout") {
             return FormTemplate(name: "checkout", fields: [

--- a/Sources/CreatorCoreForge/FormTemplate.swift
+++ b/Sources/CreatorCoreForge/FormTemplate.swift
@@ -7,6 +7,7 @@ public struct FormField: Codable, Equatable {
         case password
         case email
         case number
+        case date
     }
     public var name: String
     public var type: FieldType

--- a/Sources/CreatorCoreForge/SignUpView.swift
+++ b/Sources/CreatorCoreForge/SignUpView.swift
@@ -1,0 +1,33 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Basic sign up form requesting email, password, and date of birth.
+/// On submit, the user is automatically signed in via `BasicAuthService`.
+public struct SignUpView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var dob = Date()
+    @State private var signedIn = false
+
+    public init() {}
+
+    public var body: some View {
+        VStack(spacing: 20) {
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            DatePicker("Date of Birth", selection: $dob, displayedComponents: .date)
+            Button("Register") {
+                BasicAuthService.shared.register(email: email, password: password, dob: dob)
+                signedIn = BasicAuthService.shared.signIn(email: email, password: password)
+            }
+            .buttonStyle(.borderedProminent)
+            if signedIn {
+                Text("Signed in as \(email)")
+            }
+        }
+        .padding()
+    }
+}
+#endif

--- a/Tests/CreatorCoreForgeTests/BasicAuthServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/BasicAuthServiceTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class BasicAuthServiceTests: XCTestCase {
+    func testRegisterAutoSignsIn() {
+        let service = BasicAuthService.shared
+        service.register(email: "test@example.com", password: "pw", dob: Date())
+        XCTAssertEqual(service.currentUser?.email, "test@example.com")
+        XCTAssertTrue(service.signIn(email: "test@example.com", password: "pw"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FormGeneratorTests.swift
+++ b/Tests/CreatorCoreForgeTests/FormGeneratorTests.swift
@@ -9,6 +9,14 @@ final class FormGeneratorTests: XCTestCase {
         XCTAssertEqual(form?.fields.count, 2)
     }
 
+    func testGeneratesRegisterFormWithDOB() {
+        let gen = FormGenerator()
+        let form = gen.generateForm(from: "register")
+        XCTAssertEqual(form?.name, "register")
+        XCTAssertEqual(form?.fields.count, 4)
+        XCTAssertTrue(form!.fields.contains(where: { $0.name == "dob" && $0.type == .date }))
+    }
+
     func testValidation() {
         let gen = FormGenerator()
         let form = gen.generateForm(from: "login")!

--- a/apps/CoreForgeAudio/Desktop/index.html
+++ b/apps/CoreForgeAudio/Desktop/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-
   <head>
     <meta charset="UTF-8" />
     <title>CoreForge Audio Desktop</title>
@@ -8,11 +7,41 @@
       function launch() {
         document.getElementById('status').textContent = 'Launcher active.';
       }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
     </script>
   </head>
   <body>
     <h1>CoreForge Audio Desktop</h1>
     <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
     <button onclick="launch()">Launch</button>
   </body>
 </html>

--- a/apps/CoreForgeBloom/Desktop/index.html
+++ b/apps/CoreForgeBloom/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Bloom Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Bloom</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Bloom Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Bloom</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeBuild/Desktop/index.html
+++ b/apps/CoreForgeBuild/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Build Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Build</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Build Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Build</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeDNA/Desktop/index.html
+++ b/apps/CoreForgeDNA/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge DNA Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge DNA</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge DNA Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge DNA</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeLeads/Desktop/index.html
+++ b/apps/CoreForgeLeads/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Leads Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Leads</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Leads Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Leads</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeLearn/Desktop/index.html
+++ b/apps/CoreForgeLearn/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Learn Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Learn</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Learn Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Learn</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeLibrary/Desktop/index.html
+++ b/apps/CoreForgeLibrary/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Library Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Library</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Library Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Library</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeMarket/Desktop/index.html
+++ b/apps/CoreForgeMarket/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Market Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Market</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Market Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Market</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeMind/Desktop/index.html
+++ b/apps/CoreForgeMind/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Mind Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Mind</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Mind Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Mind</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeMusic/Desktop/index.html
+++ b/apps/CoreForgeMusic/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Music Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Music</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Music Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Music</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeQuest/Desktop/index.html
+++ b/apps/CoreForgeQuest/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Quest Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Quest</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Quest Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Quest</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeStudio/Desktop/index.html
+++ b/apps/CoreForgeStudio/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Studio Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Studio</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Studio Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Studio</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeVisual/Desktop/index.html
+++ b/apps/CoreForgeVisual/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Visual Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Visual</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Visual Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Visual</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeVoiceLab/Desktop/index.html
+++ b/apps/CoreForgeVoiceLab/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Voice Lab Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Voice Lab</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Voice Lab Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Voice Lab</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>

--- a/apps/CoreForgeWriter/Desktop/index.html
+++ b/apps/CoreForgeWriter/Desktop/index.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="UTF-8">
-  <title>CoreForge Writer Desktop</title>
-  <script>
-    function launch() {
-      document.getElementById('status').textContent = 'Launcher active.';
-    }
-  </script>
-</head>
-<body>
-  <h1>CoreForge Writer</h1>
-  <p id="status">Desktop launcher ready.</p>
-  <button onclick="launch()">Launch</button>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CoreForge Writer Desktop</title>
+    <script>
+      function launch() {
+        document.getElementById('status').textContent = 'Launcher active.';
+      }
+
+      function autoSignIn() {
+        const stored = localStorage.getItem('cf_user');
+        if (stored) {
+          const user = JSON.parse(stored);
+          document.getElementById('welcome').textContent = `Welcome \${user.email}`;
+          document.getElementById('signup').style.display = 'none';
+        }
+      }
+
+      function register(evt) {
+        evt.preventDefault();
+        const email = document.getElementById('email').value;
+        const password = document.getElementById('password').value;
+        const dob = document.getElementById('dob').value;
+        localStorage.setItem('cf_user', JSON.stringify({ email, password, dob }));
+        document.getElementById('welcome').textContent = `Welcome \${email}`;
+        document.getElementById('signup').style.display = 'none';
+      }
+
+      window.addEventListener('DOMContentLoaded', autoSignIn);
+    </script>
+  </head>
+  <body>
+    <h1>CoreForge Writer</h1>
+    <p id="status">Desktop launcher ready.</p>
+    <div id="signup">
+      <form onsubmit="register(event)">
+        <input id="email" placeholder="Email" required />
+        <input id="password" type="password" placeholder="Password" required />
+        <input id="dob" type="date" required />
+        <button type="submit">Sign Up</button>
+      </form>
+    </div>
+    <p id="welcome"></p>
+    <button onclick="launch()">Launch</button>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add sign-up form with DOB and auto sign-in logic to every desktop index.html

## Testing
- `npm test --silent`
- `swift test -v` *(fails to finish building in environment)*

------
https://chatgpt.com/codex/tasks/task_e_685d210830848321bd4c92b16fda1cb0