### PR TITLE
Fix leftover merge marker

### DIFF
--- a/VoiceLab/src/dynamicRangeCompressor.ts
+++ b/VoiceLab/src/dynamicRangeCompressor.ts
@@ -49,15 +49,13 @@ export class AudioProcessor {
     if (attack < 0 || release < 0) throw new Error('attack/release must be >= 0');
     if (sampleRate <= 0) throw new Error('sampleRate must be > 0');
 
-    const buffer = Buffer.from(await input.arrayBuffer());
+  const buffer = Buffer.from(await input.arrayBuffer());
 
-    const samples = new Float32Array(
-      buffer.buffer,
-      buffer.byteOffset,
-      Math.floor(buffer.byteLength / 4)
-    );
-=======
-    const samples = new Float32Array(buffer.buffer, buffer.byteOffset, Math.floor(buffer.byteLength / 4));
+  const samples = new Float32Array(
+    buffer.buffer,
+    buffer.byteOffset,
+    Math.floor(buffer.byteLength / 4)
+  );
 
 
     const attackCoef = attack > 0 ? Math.exp(-1 / (attack * sampleRate)) : 0;


### PR DESCRIPTION
## Summary
- remove conflict marker from `dynamicRangeCompressor.ts`

## Testing
- `npm test`
- `swift test` *(fails: cannot find `viewerFilterEnabled`)*

------
https://chatgpt.com/codex/tasks/task_e_685d3ac8ced08321b4f4dcd2b05f18ea