### PR TITLE
Add simple MiniPlayerView

### DIFF
--- a/apps/CoreForgeAudio/views/MiniPlayerView.swift
+++ b/apps/CoreForgeAudio/views/MiniPlayerView.swift
@@ -9,30 +9,42 @@ struct MiniPlayerView: View {
     var namespace: Namespace.ID
     @Binding var isExpanded: Bool
     @State private var isPlaying = false
-    @State private var speed: Double = 1.0
-    @State private var voice: String = VoiceConfig.voices.first?.name ?? "Default"
 
     var body: some View {
-        HStack {
-            VStack(alignment: .leading) {
-                Text(book.title)
+        Theme.card {
+            HStack {
+                Text(chapter.title.isEmpty ? book.title : chapter.title)
                     .font(.subheadline)
-                Text(chapter.title)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                Spacer()
+                Button(action: { isPlaying.toggle() }) {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .imageScale(.medium)
+                        .foregroundColor(.primary)
+                }
             }
-            Spacer()
-            Button(action: { isPlaying.toggle() }) {
-                Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-            }
-            PlaybackSpeedControlView(speed: $speed, voice: $voice)
+            .frame(maxWidth: .infinity)
         }
-        .padding()
         .background(AppTheme.primaryGradient)
-        .cornerRadius(12)
-        .shadow(radius: 4)
         .matchedGeometryEffect(id: "player", in: namespace)
         .onTapGesture { isExpanded = true }
     }
+}
+
+#Preview {
+    struct PreviewWrapper: View {
+        @Namespace var ns
+        @State var expanded = false
+
+        var body: some View {
+            MiniPlayerView(
+                book: Book(title: "Sample Book", author: "Author"),
+                chapter: Chapter(title: "Chapter 1", text: "Sample"),
+                namespace: ns,
+                isExpanded: $expanded
+            )
+        }
+    }
+    return PreviewWrapper()
 }
 #endif


### PR DESCRIPTION
## Summary
- simplify the MiniPlayerView to just show track title and play/pause button
- add preview block to MiniPlayerView

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685d74818cd88321b5a90b8f4c729f57