### PR TITLE
Fix OfflineQueue async tasks

### DIFF
--- a/Sources/CreatorCoreForge/OfflineQueue.swift
+++ b/Sources/CreatorCoreForge/OfflineQueue.swift
@@ -2,13 +2,14 @@ import Foundation
 
 /// File-safe async task queue used for offline TTS processing.
 public final class OfflineQueue {
-    private var tasks: [() -> Void] = []
+    private var tasks: [() async -> Void] = []
     private var isProcessing = false
+    private var currentTask: Task<Void, Never>?
 
     public init() {}
 
     /// Add a task to the queue and start processing if needed.
-    public func add(_ task: @escaping () -> Void) {
+    public func add(_ task: @escaping () async -> Void) {
         tasks.append(task)
         process()
     }
@@ -16,16 +17,20 @@ public final class OfflineQueue {
     /// Cancel all pending tasks without executing them.
     public func cancelAll() {
         tasks.removeAll()
+        currentTask?.cancel()
+        currentTask = nil
+        isProcessing = false
     }
 
     private func process() {
         guard !isProcessing, !tasks.isEmpty else { return }
         isProcessing = true
         let task = tasks.removeFirst()
-        DispatchQueue.global().async {
-            task()
-            DispatchQueue.main.async {
+        currentTask = Task {
+            await task()
+            await MainActor.run {
                 self.isProcessing = false
+                self.currentTask = nil
                 self.process()
             }
         }


### PR DESCRIPTION
## Summary
- fix OfflineQueue so tasks can be async and cancellation stops running task

## Testing
- `swift build` *(fails: long build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_685d954045948321aea50eb3803a375e