### PR TITLE
Fix CoreForge audio build errors

### DIFF
--- a/Sources/CreatorCoreForge/MockDataGenerator.swift
+++ b/Sources/CreatorCoreForge/MockDataGenerator.swift
@@ -13,6 +13,9 @@ public struct MockDataGenerator {
                 data[field.name] = "password"
             case .number:
                 data[field.name] = "123"
+            case .date:
+                let formatter = ISO8601DateFormatter()
+                data[field.name] = formatter.string(from: Date())
             case .text:
                 data[field.name] = field.name.capitalized
             }

--- a/Sources/CreatorCoreForge/NSFWContentManager.swift
+++ b/Sources/CreatorCoreForge/NSFWContentManager.swift
@@ -135,6 +135,7 @@ public final class NSFWContentManager {
     public var nsfwSceneLog: [NSFWScene] = []
     public var contentIntensity: NSFWIntensity = .softcore
     public var contentMode: NSFWContentMode = .slow
+    public var viewerFilterEnabled: Bool = false
 
     public enum NSFWIntensity: String, Codable, CaseIterable {
         case off, softcore, sensual, rough, hardcore
@@ -210,6 +211,10 @@ public final class NSFWContentManager {
 
     public func setMode(_ mode: NSFWContentMode) {
         self.contentMode = mode
+    }
+
+    public func setViewerFilter(enabled: Bool) {
+        viewerFilterEnabled = enabled
     }
 
     public func isSceneAllowed(_ intensity: NSFWIntensity) -> Bool {

--- a/Tests/CreatorCoreForgeTests/NSFWPhase7FeatureTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWPhase7FeatureTests.swift
@@ -17,7 +17,7 @@ final class NSFWPhase7FeatureTests: XCTestCase {
         let fxLib = NSFWFXLibraryManager(); fxLib.upload("fx1")
         _ = NSFWTransitionManager()
         _ = NSFWScopeGuard().hasAccess()
-        let history = NSFWUsageHistory(); history.record(scene: "A")
+        let history = NSFWUsageHistory(); history.record(scene: "A", plan: .creator)
         _ = NSFWModerationFlagger().flag("unsafe text")
         _ = NSFWSafetyDetector().isSafe("safe text")
         let dash = NSFWRatingsDashboard(); dash.rate(scene: "A", score: 5)


### PR DESCRIPTION
## Summary
- ensure MockDataGenerator handles all field types
- expose `viewerFilterEnabled` and setter on non-Combine builds
- update NSFWPhase7 tests for API change

## Testing
- `swift build -c release`
- `swift test -c release` *(fails: signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685db1504c1c832192a83fd6d82edb88