### PR TITLE
Add clean install script to resolve npm ENOTEMPTY errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,15 +390,20 @@ Run `scripts/generate_app_completion_report.py` to update `app_completion_report
 See `docs/progress_bot.md` for usage details.
 ## Running Tests
 
-Install Node dependencies for the labs before running the test suites:
+Install Node dependencies for the labs before running the test suites.
+Use the helper script to perform a clean install across all workspaces:
 
 ```bash
-cd VoiceLab && npm install && npm test
-cd ../VisualLab && npm install && npm test
+./scripts/clean_install.sh
+cd VoiceLab && npm test
+cd ../VisualLab && npm test
 cd .. && swift test
 ```
 
-This ensures `jest`, `ts-node`, and other dev tools are available.
+If you encounter an `ENOTEMPTY` rename error during installation, the script
+removes any leftover `node_modules` directories and runs `npm ci` to ensure a
+fresh workspace. This guarantees `jest`, `ts-node`, and other dev tools are
+available.
 
 
 ## CI/CD

--- a/scripts/clean_install.sh
+++ b/scripts/clean_install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+# Clean install Node dependencies for all workspaces
+cd "$(dirname "$0")/.."
+rm -rf node_modules
+npm ci
+for dir in VoiceLab VisualLab apps/CoreForgeBuild; do
+    rm -rf "$dir/node_modules"
+    (cd "$dir" && npm ci)
+done


### PR DESCRIPTION
## Summary
- add `scripts/clean_install.sh` for wiping node_modules and performing `npm ci`
- update README test instructions to use the clean install script and explain how it fixes `ENOTEMPTY` rename errors

## Testing
- `npm test`
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dacbf6aa8832199bd13f18f6a7752