### PR TITLE
Add CoreForge Audio SPM target and basic tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     ],
     products: [
         .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"]),
-        .executable(name: "CoreForgeLibraryApp", targets: ["CoreForgeLibraryApp"])
+        .executable(name: "CoreForgeLibraryApp", targets: ["CoreForgeLibraryApp"]),
+        .executable(name: "CoreForgeAudioApp", targets: ["CoreForgeAudioApp"])
     ],
     dependencies: [],
     targets: [
@@ -18,6 +19,11 @@ let package = Package(
                           dependencies: ["CreatorCoreForge"],
                           path: "apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp",
                           exclude: ["Info.plist"]),
-        .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")
+        .executableTarget(name: "CoreForgeAudioApp",
+                          dependencies: ["CreatorCoreForge"],
+                          path: "apps/CoreForgeAudio/VocalVerseFull/VocalVerse",
+                          exclude: ["Info.plist"]),
+        .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests"),
+        .testTarget(name: "CoreForgeAudioAppTests", dependencies: ["CoreForgeAudioApp"], path: "Tests/CoreForgeAudioAppTests")
     ]
 )

--- a/Tests/CoreForgeAudioAppTests/AppLaunchTests.swift
+++ b/Tests/CoreForgeAudioAppTests/AppLaunchTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import CoreForgeAudioApp
+
+final class AppLaunchTests: XCTestCase {
+    func testAppInitialization() {
+        #if canImport(SwiftUI)
+        let app = CoreForgeAudioApp()
+        _ = app.body // ensure body can be accessed
+        XCTAssertTrue(true)
+        #else
+        XCTAssertTrue(true)
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- add CoreForgeAudioApp product in `Package.swift`
- create executable target for CoreForgeAudioApp
- add unit test target `CoreForgeAudioAppTests` with basic launch test

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685db751d85483218567b6b798ae9fa5