### PR TITLE
Fix audio module missing files

### DIFF
--- a/apps/CoreForgeAudio/Desktop/package-lock.json
+++ b/apps/CoreForgeAudio/Desktop/package-lock.json
@@ -1411,7 +1411,7 @@
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
+        "minipass": "^7.1.3",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
@@ -1439,8 +1439,8 @@
       }
     },
     "node_modules/config-file-ts/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true,
       "license": "ISC",

--- a/apps/CoreForgeAudio/audio_utils.py
+++ b/apps/CoreForgeAudio/audio_utils.py
@@ -1,0 +1,8 @@
+from pydub import AudioSegment
+
+
+def normalize_volume(path: str, target_dbfs: float = -20.0) -> AudioSegment:
+    """Return audio normalized to a target volume."""
+    audio = AudioSegment.from_file(path)
+    change = target_dbfs - audio.dBFS
+    return audio.apply_gain(change)

--- a/apps/CoreForgeAudio/components/NowPlayingBadge.tsx
+++ b/apps/CoreForgeAudio/components/NowPlayingBadge.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export interface NowPlayingBadgeProps {
+  title: string;
+}
+
+export const NowPlayingBadge: React.FC<NowPlayingBadgeProps> = ({ title }) => (
+  <div className="now-playing-badge">Now Playing: {title}</div>
+);

--- a/apps/CoreForgeAudio/services/AudioDeviceManager.ts
+++ b/apps/CoreForgeAudio/services/AudioDeviceManager.ts
@@ -1,0 +1,16 @@
+export interface AudioDevice {
+  id: string;
+  name: string;
+}
+
+export class AudioDeviceManager {
+  private devices: AudioDevice[] = [];
+
+  register(device: AudioDevice): void {
+    this.devices.push(device);
+  }
+
+  list(): AudioDevice[] {
+    return [...this.devices];
+  }
+}


### PR DESCRIPTION
## Summary
- implement simple AudioDeviceManager service in TypeScript
- add NowPlayingBadge React component
- provide Python audio_utils helper
- bump minipass entry in CoreForgeAudio package-lock

## Testing
- `bash scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dc269988483219e9febe926b3d658