### PR TITLE
Fix placeholder logic in preload and loaders

### DIFF
--- a/apps/CoreForgeAudio/Desktop/preload.js
+++ b/apps/CoreForgeAudio/Desktop/preload.js
@@ -1,3 +1,8 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('api', {});
+// Expose a very small API surface to the renderer process. Additional
+// channels can be added as needed by the desktop app.
+contextBridge.exposeInMainWorld('api', {
+  openFileDialog: () => ipcRenderer.invoke('open-file'),
+  getAppVersion: () => ipcRenderer.invoke('get-version')
+});

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CharacterVoiceMemory.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CharacterVoiceMemory.swift
@@ -17,9 +17,15 @@ final class CharacterVoiceMemory {
         persist()
     }
 
-    func voiceForCharacter(_ character: String) -> Voice? {
-        guard let id = assignments[character.lowercased()] else { return nil }
-        return VoiceConfig.voices.first { $0.id == id }
+    /// Return the assigned voice for a given character. If no explicit
+    /// assignment exists, fall back to the default voice so callers never
+    /// receive `nil`.
+    func voiceForCharacter(_ character: String) -> Voice {
+        if let id = assignments[character.lowercased()],
+           let voice = VoiceConfig.voices.first(where: { $0.id == id }) {
+            return voice
+        }
+        return VoiceConfig.voices.first ?? Voice(id: "default", name: "Default")
     }
 
     func clearAll() {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PromptTemplateLoader.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
@@ -14,7 +14,7 @@ struct VoiceCastView: View {
             Form {
                 ForEach(characters, id: \.self) { name in
                     Picker(name, selection: Binding(
-                        get: { selections[name] ?? CharacterVoiceMemory.shared.voiceForCharacter(name)?.id ?? voices.first?.id ?? "" },
+                        get: { selections[name] ?? CharacterVoiceMemory.shared.voiceForCharacter(name).id ?? voices.first?.id ?? "" },
                         set: { selections[name] = $0 }
                     )) {
                         ForEach(voices, id: \.id) { voice in

--- a/apps/CoreForgeLeads/DataForgeAIFull/Sources/DataForgeAI/PromptTemplateLoader.swift
+++ b/apps/CoreForgeLeads/DataForgeAIFull/Sources/DataForgeAI/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/PromptTemplateLoader.swift
+++ b/apps/CoreForgeMarket/TradeMindAIFull/Sources/TradeMindAI/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeMusic/VerseForgeAIFull/Sources/VerseForgeAI/PromptTemplateLoader.swift
+++ b/apps/CoreForgeMusic/VerseForgeAIFull/Sources/VerseForgeAI/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeStudio/VocalVisionFull/Sources/VocalVision/PromptTemplateLoader.swift
+++ b/apps/CoreForgeStudio/VocalVisionFull/Sources/VocalVision/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/PromptTemplateLoader.swift
+++ b/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }

--- a/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/PromptTemplateLoader.swift
+++ b/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/PromptTemplateLoader.swift
@@ -7,17 +7,18 @@ struct PromptTemplateLoader {
         self.bundle = bundle
     }
 
+    /// Load all available prompt templates from the bundled `prompts.json` file.
+    /// Any malformed entries are skipped rather than causing the load to fail.
     func loadTemplates() -> [PromptTemplate] {
         guard let url = bundle.url(forResource: "prompts", withExtension: "json"),
               let data = try? Data(contentsOf: url),
               let array = try? JSONSerialization.jsonObject(with: data) as? [[String: String]] else {
             return []
         }
-        return array.compactMap { dict in
+        return array.reduce(into: [PromptTemplate]()) { result, dict in
             if let name = dict["name"], let text = dict["text"] {
-                return PromptTemplate(name: name, text: text)
+                result.append(PromptTemplate(name: name, text: text))
             }
-            return nil
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement preload bridge functions for Electron desktop app
- remove optional returns for character voice lookup
- skip malformed prompt entries when loading templates
- update view to use new voice API

## Testing
- `npm test`
- `swift test` *(fails: no such module 'FirebaseAuth')*

------
https://chatgpt.com/codex/tasks/task_e_685dc91f1b4c83219f9eec0022b3a554