### PR TITLE
Fix Audio SwiftUI previews and theme usage

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -33,17 +33,14 @@ struct ContentView: View {
                     .environmentObject(onboarding)
                     .environmentObject(prefs)
                     .transition(.scale)
-}
-
-#if DEBUG
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-            .environmentObject(UserPreferences.shared)
-    }
-}
-#endif
+            }
         }
         .animation(.easeInOut, value: hasSeenOnboarding)
     }
+}
+
+#Preview {
+    ContentView()
+        .environmentObject(UserPreferences.shared)
+}
 #endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
@@ -1,5 +1,7 @@
 import Foundation
-import SwiftUI
+#if canImport(Combine)
+import Combine
+#endif
 #if canImport(AVFoundation)
 import AVFoundation
 #endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/UserPreferences.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/UserPreferences.swift
@@ -1,3 +1,5 @@
+import Foundation
+#if canImport(SwiftUI)
 import SwiftUI
 
 /// Shared user preference storage using `@AppStorage`.
@@ -23,3 +25,4 @@ final class UserPreferences: ObservableObject {
         return Calendar.current.dateComponents([.year], from: date, to: Date()).year ?? 0
     }
 }
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceConfig.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceConfig.swift
@@ -14,7 +14,12 @@ struct VoiceConfig {
         Voice(id: "storyteller", name: "Storyteller"),
         Voice(id: "assistant", name: "Assistant"),
         Voice(id: "morgan", name: "Morgan"),
-        Voice(id: "emma", name: "Emma")
+        Voice(id: "emma", name: "Emma"),
+        Voice(id: "athena", name: "Athena"),
+        Voice(id: "zeus", name: "Zeus"),
+        Voice(id: "ultra", name: "UltraAI"),
+        Voice(id: "aisynth", name: "AiSynth"),
+        Voice(id: "hermes", name: "Hermes")
     ]
 
     /// Cached list of voice display names for UI components.
@@ -28,9 +33,3 @@ struct VoiceConfig {
     }
 }
 
-// Register newly added voice
-VoiceConfig.addVoice(id: "athena", name: "Athena")
-VoiceConfig.addVoice(id: "zeus", name: "Zeus")
-VoiceConfig.addVoice(id: "ultra", name: "UltraAI")
-VoiceConfig.addVoice(id: "aisynth", name: "AiSynth")
-VoiceConfig.addVoice(id: "hermes", name: "Hermes")

--- a/apps/CoreForgeAudio/components/NSFWToggleView.swift
+++ b/apps/CoreForgeAudio/components/NSFWToggleView.swift
@@ -14,13 +14,10 @@ struct NSFWToggleView: View {
     }
 }
 
-#if DEBUG
-struct NSFWToggleView_Previews: PreviewProvider {
-    static var previews: some View {
-        NSFWToggleView()
-            .padding()
-            .previewLayout(.sizeThatFits)
-    }
+#Preview {
+    NSFWToggleView()
+        .padding()
+        .previewLayout(.sizeThatFits)
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/components/PlaybackSpeedControlView.swift
+++ b/apps/CoreForgeAudio/components/PlaybackSpeedControlView.swift
@@ -41,15 +41,17 @@ struct PlaybackSpeedControlView: View {
     }
 }
 
-#if DEBUG
-struct PlaybackSpeedControlView_Previews: PreviewProvider {
-    @State static var speed = PlaybackSpeed.one.rawValue
-    @State static var voice = "Default"
-    static var previews: some View {
-        PlaybackSpeedControlView(speed: $speed, voice: $voice)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var speed = PlaybackSpeed.one.rawValue
+        @State var voice = "Default"
+        var body: some View {
+            PlaybackSpeedControlView(speed: $speed, voice: $voice)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/components/SwipePreviewHandler.swift
+++ b/apps/CoreForgeAudio/components/SwipePreviewHandler.swift
@@ -15,14 +15,11 @@ struct SwipePreviewHandler: ViewModifier {
     }
 }
 
-#if DEBUG
-struct SwipePreviewHandler_Previews: PreviewProvider {
-    static var previews: some View {
-        Text("Preview")
-            .voicePreviewOnHold(audioURL: URL(fileURLWithPath: "/dev/null"))
-            .padding()
-            .previewLayout(.sizeThatFits)
-    }
+#Preview {
+    Text("Preview")
+        .voicePreviewOnHold(audioURL: URL(fileURLWithPath: "/dev/null"))
+        .padding()
+        .previewLayout(.sizeThatFits)
 }
 #endif
 

--- a/apps/CoreForgeAudio/components/VoicePickerView.swift
+++ b/apps/CoreForgeAudio/components/VoicePickerView.swift
@@ -14,14 +14,16 @@ struct VoicePickerView: View {
     }
 }
 
-#if DEBUG
-struct VoicePickerView_Previews: PreviewProvider {
-    @State static var voice = "Default"
-    static var previews: some View {
-        VoicePickerView(voice: $voice)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var voice = "Default"
+        var body: some View {
+            VoicePickerView(voice: $voice)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/AmbientFXMixerView.swift
+++ b/apps/CoreForgeAudio/views/AmbientFXMixerView.swift
@@ -11,19 +11,21 @@ struct AmbientFXMixerView: View {
             Slider(value: $level, in: 0...1)
         }
         .padding()
-        .background(AppTheme.cardMaterial)
-        .cornerRadius(AppTheme.cornerRadius)
+        .background(Theme.cardMaterial)
+        .cornerRadius(Theme.cornerRadius)
     }
 }
 
-#if DEBUG
-struct AmbientFXMixerView_Previews: PreviewProvider {
-    @State static var level = 0.5
-    static var previews: some View {
-        AmbientFXMixerView(level: $level)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var level = 0.5
+        var body: some View {
+            AmbientFXMixerView(level: $level)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/ExportQueueView.swift
+++ b/apps/CoreForgeAudio/views/ExportQueueView.swift
@@ -20,16 +20,12 @@ struct ExportQueueView: View {
     }
 }
 
-#if DEBUG
-struct ExportQueueView_Previews: PreviewProvider {
+#Preview {
     class DummyManager: ExportQueueManager {
         override var pendingCount: Int { 2 }
     }
-
-    static var previews: some View {
-        NavigationView {
-            ExportQueueView(manager: DummyManager())
-        }
+    return NavigationView {
+        ExportQueueView(manager: DummyManager())
     }
 }
 #endif

--- a/apps/CoreForgeAudio/views/FeaturedCarouselView.swift
+++ b/apps/CoreForgeAudio/views/FeaturedCarouselView.swift
@@ -13,7 +13,7 @@ struct FeaturedCarouselView: View {
                 ForEach(books) { book in
                     VStack(alignment: .leading) {
                         Rectangle()
-                            .fill(AppTheme.primaryGradient)
+                            .fill(Theme.primaryGradient)
                             .frame(width: 120, height: 160)
                             .overlay(
                                 VStack(alignment: .leading) {
@@ -37,9 +37,9 @@ struct FeaturedCarouselView: View {
                                 alignment: .bottom
                             )
                     }
-                    .background(AppTheme.cardMaterial)
-                    .cornerRadius(AppTheme.cornerRadius)
-                    .shadow(radius: AppTheme.shadowRadius)
+                    .background(Theme.cardMaterial)
+                    .cornerRadius(Theme.cornerRadius)
+                    .shadow(radius: Theme.shadowRadius)
                 }
             }
             .padding(.horizontal)
@@ -47,15 +47,11 @@ struct FeaturedCarouselView: View {
     }
 }
 
-#if DEBUG
-struct FeaturedCarouselView_Previews: PreviewProvider {
-    static var previews: some View {
-        FeaturedCarouselView(books: [
-            Book(title: "Sample", author: "A"),
-            Book(title: "Sample 2", author: "B")
-        ])
-        .environmentObject(LibraryModel())
-    }
+#Preview {
+    FeaturedCarouselView(books: [
+        Book(title: "Sample", author: "A"),
+        Book(title: "Sample 2", author: "B")
+    ])
+    .environmentObject(LibraryModel())
 }
-#endif
 #endif

--- a/apps/CoreForgeAudio/views/LanguageSelectorView.swift
+++ b/apps/CoreForgeAudio/views/LanguageSelectorView.swift
@@ -14,14 +14,16 @@ struct LanguageSelectorView: View {
     }
 }
 
-#if DEBUG
-struct LanguageSelectorView_Previews: PreviewProvider {
-    @State static var lang = "English"
-    static var previews: some View {
-        LanguageSelectorView(language: $lang)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var lang = "English"
+        var body: some View {
+            LanguageSelectorView(language: $lang)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/LibraryDashboardView.swift
+++ b/apps/CoreForgeAudio/views/LibraryDashboardView.swift
@@ -54,9 +54,9 @@ struct LibraryDashboardView: View {
                         .environmentObject(library)
                         .environmentObject(usage)
                         .transition(.scale)
-                        .background(AppTheme.cardMaterial)
-                        .cornerRadius(AppTheme.cornerRadius)
-                        .shadow(radius: AppTheme.shadowRadius)
+                        .background(Theme.cardMaterial)
+                        .cornerRadius(Theme.cornerRadius)
+                        .shadow(radius: Theme.shadowRadius)
                 } else {
                     MiniPlayerView(book: book, chapter: chapter, namespace: ns, isExpanded: $showPlayer)
                         .padding()
@@ -74,13 +74,9 @@ struct LibraryDashboardView: View {
     }
 }
 
-#if DEBUG
-struct LibraryDashboardView_Previews: PreviewProvider {
-    static var previews: some View {
-        LibraryDashboardView()
-            .environmentObject(LibraryModel())
-            .environmentObject(UsageStats())
-    }
+#Preview {
+    LibraryDashboardView()
+        .environmentObject(LibraryModel())
+        .environmentObject(UsageStats())
 }
-#endif
 #endif

--- a/apps/CoreForgeAudio/views/SearchView.swift
+++ b/apps/CoreForgeAudio/views/SearchView.swift
@@ -25,7 +25,7 @@ struct SearchView: View {
                         let isSelected = filters.contains(option)
                         Text(option)
                             .padding(8)
-                            .background(isSelected ? AppTheme.primaryGradient : Color.secondary.opacity(0.2))
+                            .background(isSelected ? Theme.primaryGradient : Color.secondary.opacity(0.2))
                             .cornerRadius(8)
                             .onTapGesture {
                                 if isSelected { filters.remove(option) } else { filters.insert(option) }
@@ -38,16 +38,18 @@ struct SearchView: View {
     }
 }
 
-#if DEBUG
-struct SearchView_Previews: PreviewProvider {
-    @State static var query = ""
-    @State static var sort = "Title"
-    @State static var filters: Set<String> = []
-    static var previews: some View {
-        SearchView(query: $query, sort: $sort, filters: $filters)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var query = ""
+        @State var sort = "Title"
+        @State var filters: Set<String> = []
+        var body: some View {
+            SearchView(query: $query, sort: $sort, filters: $filters)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/VoiceEmotionControlView.swift
+++ b/apps/CoreForgeAudio/views/VoiceEmotionControlView.swift
@@ -14,20 +14,22 @@ struct VoiceEmotionControlView: View {
         } label: {
             Label(emotion, systemImage: "face.smiling")
                 .padding(8)
-                .background(AppTheme.cardMaterial)
-                .cornerRadius(AppTheme.cornerRadius)
+                .background(Theme.cardMaterial)
+                .cornerRadius(Theme.cornerRadius)
         }
     }
 }
 
-#if DEBUG
-struct VoiceEmotionControlView_Previews: PreviewProvider {
-    @State static var emotion = "Neutral"
-    static var previews: some View {
-        VoiceEmotionControlView(emotion: $emotion)
-            .padding()
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var emotion = "Neutral"
+        var body: some View {
+            VoiceEmotionControlView(emotion: $emotion)
+                .padding()
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/VoiceMemoryView.swift
+++ b/apps/CoreForgeAudio/views/VoiceMemoryView.swift
@@ -26,12 +26,9 @@ struct VoiceMemoryView: View {
     }
 }
 
-#if DEBUG
-struct VoiceMemoryView_Previews: PreviewProvider {
-    static var previews: some View {
-        VoiceMemoryView()
-            .previewLayout(.sizeThatFits)
-    }
+#Preview {
+    VoiceMemoryView()
+        .previewLayout(.sizeThatFits)
 }
 #endif
 #endif

--- a/apps/CoreForgeAudio/views/VoicePreviewPopup.swift
+++ b/apps/CoreForgeAudio/views/VoicePreviewPopup.swift
@@ -27,9 +27,9 @@ struct VoicePreviewPopup: View {
             }
         }
         .padding()
-        .background(AppTheme.cardMaterial)
-        .cornerRadius(AppTheme.cornerRadius)
-        .shadow(radius: AppTheme.shadowRadius)
+        .background(Theme.cardMaterial)
+        .cornerRadius(Theme.cornerRadius)
+        .shadow(radius: Theme.shadowRadius)
     }
 
     private func playPreview() {
@@ -40,13 +40,15 @@ struct VoicePreviewPopup: View {
     }
 }
 
-#if DEBUG
-struct VoicePreviewPopup_Previews: PreviewProvider {
-    @State static var presented = true
-    static var previews: some View {
-        VoicePreviewPopup(audioURL: URL(fileURLWithPath: "/dev/null"), isPresented: $presented)
-            .previewLayout(.sizeThatFits)
+#Preview {
+    struct PreviewWrapper: View {
+        @State var presented = true
+        var body: some View {
+            VoicePreviewPopup(audioURL: URL(fileURLWithPath: "/dev/null"), isPresented: $presented)
+                .previewLayout(.sizeThatFits)
+        }
     }
+    return PreviewWrapper()
 }
 #endif
 #endif


### PR DESCRIPTION
## Summary
- ensure all Audio views use `#Preview`
- switch styling to `Theme` instead of `AppTheme`
- gate `UserPreferences` with `canImport(SwiftUI)`
- fix `ContentView` braces and preview
- include additional voices directly in config

## Testing
- `npm test`
- `swift test` *(fails: cannot find type 'Book' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_685dd189c4cc8321b807ea2322f7c631