### PR TITLE
Improve voice memory persistence

### DIFF
--- a/Tests/CreatorCoreForgeTests/VoiceMemoryManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceMemoryManagerTests.swift
@@ -20,4 +20,15 @@ final class VoiceMemoryManagerTests: XCTestCase {
         XCTAssertEqual(manager.voiceID(for: "Hero", in: "TestSeries"), "Voice1")
         XCTAssertEqual(manager.voiceID(for: "Villain", in: "TestSeries"), "Voice2")
     }
+
+    func testDiskPersistence() {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        var manager = VoiceMemoryManager(userDefaults: defaults, directory: tempDir)
+        manager.assign(voiceID: "V1", to: "Alice", in: "Saga")
+
+        // Recreate manager to load from disk
+        manager = VoiceMemoryManager(userDefaults: UserDefaults(suiteName: UUID().uuidString)!, directory: tempDir)
+        XCTAssertEqual(manager.voiceID(for: "Alice", in: "Saga"), "V1")
+    }
 }


### PR DESCRIPTION
## Summary
- persist `VoiceMemoryManager` assignments to a shared JSON file
- test new disk persistence capability

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685dd6c7001c832184d8e6990a36e5f1