### PR TITLE
Fix BuildImprovementEngine tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,29 +1,53 @@
 // swift-tools-version:5.7
 import PackageDescription
 
+var products: [Product] = [
+    .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"])
+]
+
+#if !os(Linux)
+products += [
+    .executable(name: "CoreForgeLibraryApp", targets: ["CoreForgeLibraryApp"]),
+    .executable(name: "CoreForgeAudioApp", targets: ["CoreForgeAudioApp"])
+]
+#endif
+
+var targets: [Target] = [
+    .target(name: "CreatorCoreForge", path: "Sources/CreatorCoreForge"),
+    .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")
+]
+
+#if !os(Linux)
+targets += [
+    .executableTarget(
+        name: "CoreForgeLibraryApp",
+        dependencies: ["CreatorCoreForge"],
+        path: "apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp",
+        exclude: ["Info.plist"]
+    ),
+    .target(name: "CoreForgeAudioModels", path: "apps/CoreForgeAudio/models"),
+    .executableTarget(
+        name: "CoreForgeAudioApp",
+        dependencies: ["CreatorCoreForge", "CoreForgeAudioModels"],
+        path: "apps/CoreForgeAudio/VocalVerseFull/VocalVerse",
+        exclude: [
+            "Info.plist",
+            "Assets.xcassets",
+            "LaunchScreen.storyboard",
+            "prompts.json"
+        ]
+    ),
+    .testTarget(name: "CoreForgeAudioAppTests", dependencies: ["CoreForgeAudioApp"], path: "Tests/CoreForgeAudioAppTests")
+]
+#endif
+
 let package = Package(
     name: "CreatorCoreForge",
     platforms: [
         .iOS(.v14),
         .macOS(.v10_15)
     ],
-    products: [
-        .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"]),
-        .executable(name: "CoreForgeLibraryApp", targets: ["CoreForgeLibraryApp"]),
-        .executable(name: "CoreForgeAudioApp", targets: ["CoreForgeAudioApp"])
-    ],
+    products: products,
     dependencies: [],
-    targets: [
-        .target(name: "CreatorCoreForge", path: "Sources/CreatorCoreForge"),
-        .executableTarget(name: "CoreForgeLibraryApp",
-                          dependencies: ["CreatorCoreForge"],
-                          path: "apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp",
-                          exclude: ["Info.plist"]),
-        .executableTarget(name: "CoreForgeAudioApp",
-                          dependencies: ["CreatorCoreForge"],
-                          path: "apps/CoreForgeAudio/VocalVerseFull/VocalVerse",
-                          exclude: ["Info.plist"]),
-        .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests"),
-        .testTarget(name: "CoreForgeAudioAppTests", dependencies: ["CoreForgeAudioApp"], path: "Tests/CoreForgeAudioAppTests")
-    ]
+    targets: targets
 )

--- a/apps/CoreForgeAudio/models/UsageStats.swift
+++ b/apps/CoreForgeAudio/models/UsageStats.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if canImport(Combine)
 import Combine
 
 /// Tracks basic usage analytics for the dashboard.
@@ -17,3 +18,21 @@ final class UsageStats: ObservableObject {
         importedBooks += 1
     }
 }
+#else
+/// Basic placeholder when Combine isn't available.
+final class UsageStats {
+    var totalListeningTime: TimeInterval = 0
+    var importedBooks: Int = 0
+    var creditsUsed: Int = 0
+    var subscriptionTier: String = "Free"
+    var achievements: [String] = []
+
+    func addListeningTime(_ time: TimeInterval) {
+        totalListeningTime += time
+    }
+
+    func recordImport() {
+        importedBooks += 1
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add Linux guards in `Package.swift`
- include separate CoreForgeAudioModels target
- make UsageStats build on non-Apple platforms

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test --filter BuildImprovementEngineTests`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685dd43a729c8321b0143d1c4d81271f