### PR TITLE
Add ebook2audiobook feature links

### DIFF
--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -340,6 +340,9 @@ Key points from `README.md`:
 - **Dark mode** and theme toggles via `ThemeManager`
 - **Offline audio storage** with stealth vault option
 - **Offline download queue management**
+- **ebook2audiobook** integration for advanced chapter conversion
+- See [`../ebook2audiobook/FEATURES-CODEX-COMPLETE.md`](../ebook2audiobook/FEATU
+RES-CODEX-COMPLETE.md) for the full list of Python pipeline features.
 
 
 ## Full Phase Checklist (Phases 1–9)

--- a/apps/CoreForgeAudio/DeveloperSetup.md
+++ b/apps/CoreForgeAudio/DeveloperSetup.md
@@ -3,3 +3,5 @@
 - Install Xcode and open `CoreForgeAudio.xcodeproj`
 - Run `swift package resolve` to fetch dependencies
 - Provide `OPENAI_API_KEY` and `ELEVEN_API_KEY` in your scheme
+- Optional: `pip install -r ../ebook2audiobook/requirements.txt` to enable
+  the ebook2audiobook pipeline used by `scripts/ebook2audiobook_bridge.py`

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -41,6 +41,11 @@ queue and an eBook–to–audio converter that complement the app's own classes.
 For advanced conversions using the Python pipeline, run `../../scripts/ebook2audiobook_bridge.py MyBook.epub`.
 You can also turn a dialogue script into audio using `../../scripts/chatterbox_bridge.py script.txt` once your Chatterbox API endpoint is configured.
 
+Full details on the Python-based feature set live in
+[`../ebook2audiobook/FEATURES-CODEX-COMPLETE.md`](../ebook2audiobook/FEATURES-CODEX-COMPLETE.md).
+Install the optional pipeline as described in `DeveloperSetup.md` to unlock
+these advanced converters.
+
 
 ## Building (iOS)
 1. Open `CoreForgeAudio.xcodeproj` in Xcode.

--- a/apps/CoreForgeAudio/baseline_requirements.md
+++ b/apps/CoreForgeAudio/baseline_requirements.md
@@ -16,5 +16,7 @@ This document outlines the minimal setup required to build and run **CoreForge A
 1. Run `swift package resolve` to fetch dependencies.
 2. Open `CoreForgeAudio.xcodeproj` and build the **CoreForgeAudio** scheme.
 3. Execute `npm test` from the repo root to ensure shared packages pass.
+4. (Optional) run `pip install -r ../ebook2audiobook/requirements.txt` to use
+   the Python ebook2audiobook features.
 
 These requirements align with the repo-wide AGENTS checklist and provide a baseline for all contributors.


### PR DESCRIPTION
## Summary
- reference `ebook2audiobook` feature list from CoreForge Audio docs
- mention optional Python pipeline install steps

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(failed: Exited with unexpected signal code 4)*
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685ddb5c91ec832184b5cf5e0e875d98