### PR TITLE
Add audiobookshelf fetch utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,12 @@ For iOS builds in Xcode Cloud, see [docs/XcodeCloud.md](docs/XcodeCloud.md) and 
 
 
 ## Fetching n8n Workflow Engine
-
 Use `./scripts/fetch_n8n.sh` to clone or update the [n8n](https://github.com/n8n-io/n8n) automation engine under `external/n8n`. Review the license printed at the end of the script before integrating it into your projects.
+
+## Fetching Audiobookshelf Tools
+Use `./scripts/fetch_audiobookshelf.sh` to clone or update the [audiobookshelf](https://github.com/advplyr/audiobookshelf) server under `external/audiobookshelf`. Review the license printed at the end of the script before experimenting locally.
+
+
 
 
 After fetching the repository, you can leverage VoiceLab's `runN8nAssistant` helper to experiment with n8n-inspired AI workflows locally.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,8 @@ Utility shell and Python scripts used for building projects and auditing feature
 
 - `chatterbox_bridge.py` – convert a simple `SPEAKER: line` script into a single audio file using a Chatterbox API. Requires `pydub`, `tqdm`, `requests`, and a `CHATTERBOX_API_URL` environment variable.
 - `fetch_plugins.sh` – download plugin repositories listed in `plugin_list.txt` using `pull_plugins.py`.
+- `fetch_n8n.sh` – clone the n8n automation engine into `external/n8n`.
+- `fetch_audiobookshelf.sh` – clone the audiobookshelf server into `external/audiobookshelf`.
 
 - `pull_plugins.py` – download a GitHub repository; automatically falls back to the `main` branch if `master` is missing.
   The list now points to publicly accessible GitHub repositories so the script

--- a/scripts/fetch_audiobookshelf.sh
+++ b/scripts/fetch_audiobookshelf.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clone or update the audiobookshelf server for local library management.
+# The repository is placed under external/audiobookshelf.
+
+TARGET_DIR="external/audiobookshelf"
+REPO_URL="https://github.com/advplyr/audiobookshelf.git"
+
+if [ -d "$TARGET_DIR" ]; then
+  echo "Updating existing audiobookshelf repository..."
+  git -C "$TARGET_DIR" pull --ff-only
+else
+  echo "Cloning audiobookshelf repository..."
+  mkdir -p external
+  git clone --depth=1 "$REPO_URL" "$TARGET_DIR"
+fi
+
+# Display the first few lines of the license for reference.
+cat "$TARGET_DIR"/LICENSE | head -n 5


### PR DESCRIPTION
## Summary
- add `fetch_audiobookshelf.sh` for optional audiobookshelf integration
- document new fetch script in `README` and scripts overview

## Testing
- `npm test --workspaces`
- `swift test` *(fails: exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685dddbc218483218831a67f8c75aa70