### PR TITLE
Integrate ebook2audiobook pipeline into CoreForge Audio

### DIFF
--- a/apps/CoreForgeAudio/AGENTS.md
+++ b/apps/CoreForgeAudio/AGENTS.md
@@ -343,6 +343,7 @@ Key points from `README.md`:
 - **ebook2audiobook** integration for advanced chapter conversion
 - See [`../ebook2audiobook/FEATURES-CODEX-COMPLETE.md`](../ebook2audiobook/FEATU
 RES-CODEX-COMPLETE.md) for the full list of Python pipeline features.
+- Use `audio_utils.convert_ebook_to_audio` to trigger the pipeline programmatically.
 
 
 ## Full Phase Checklist (Phases 1–9)

--- a/apps/CoreForgeAudio/DeveloperSetup.md
+++ b/apps/CoreForgeAudio/DeveloperSetup.md
@@ -4,4 +4,5 @@
 - Run `swift package resolve` to fetch dependencies
 - Provide `OPENAI_API_KEY` and `ELEVEN_API_KEY` in your scheme
 - Optional: `pip install -r ../ebook2audiobook/requirements.txt` to enable
-  the ebook2audiobook pipeline used by `scripts/ebook2audiobook_bridge.py`
+  the ebook2audiobook pipeline used by `scripts/ebook2audiobook_bridge.py` or
+  the `convert_ebook_to_audio` helper in `audio_utils.py`.

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -38,7 +38,9 @@ you notice missing playback or export features, ensure the package is linked in
 Xcode and reference `Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift`
 for additional helper functions. These utilities provide an offline download
 queue and an eBook–to–audio converter that complement the app's own classes.
-For advanced conversions using the Python pipeline, run `../../scripts/ebook2audiobook_bridge.py MyBook.epub`.
+For advanced conversions using the Python pipeline, call
+`convert_ebook_to_audio("MyBook.epub")` from `audio_utils.py` or run
+`../../scripts/ebook2audiobook_bridge.py MyBook.epub`.
 To polish training samples, run `services/voice_cleaner.py AUDIO.wav` and use the resulting file in `VoiceTrainer`.
 You can also turn a dialogue script into audio using `../../scripts/chatterbox_bridge.py script.txt` once your Chatterbox API endpoint is configured.
 

--- a/apps/CoreForgeAudio/audio_utils.py
+++ b/apps/CoreForgeAudio/audio_utils.py
@@ -1,4 +1,7 @@
 from pydub import AudioSegment
+import subprocess
+import sys
+from pathlib import Path
 
 
 def normalize_volume(path: str, target_dbfs: float = -20.0) -> AudioSegment:
@@ -6,3 +9,19 @@ def normalize_volume(path: str, target_dbfs: float = -20.0) -> AudioSegment:
     audio = AudioSegment.from_file(path)
     change = target_dbfs - audio.dBFS
     return audio.apply_gain(change)
+
+
+def convert_ebook_to_audio(ebook_path: str, output_dir: str = "output") -> None:
+    """Run the bundled ebook2audiobook pipeline on an ebook.
+
+    Parameters
+    ----------
+    ebook_path: str
+        Path to the input eBook file.
+    output_dir: str, optional
+        Directory where audio files will be written.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "ebook2audiobook_bridge.py"
+    subprocess.run([sys.executable, str(script), ebook_path, "-o", output_dir], check=True)

--- a/apps/CoreForgeAudio/baseline_requirements.md
+++ b/apps/CoreForgeAudio/baseline_requirements.md
@@ -17,6 +17,6 @@ This document outlines the minimal setup required to build and run **CoreForge A
 2. Open `CoreForgeAudio.xcodeproj` and build the **CoreForgeAudio** scheme.
 3. Execute `npm test` from the repo root to ensure shared packages pass.
 4. (Optional) run `pip install -r ../ebook2audiobook/requirements.txt` to use
-   the Python ebook2audiobook features.
+   the Python ebook2audiobook features exposed by `audio_utils.convert_ebook_to_audio`.
 
 These requirements align with the repo-wide AGENTS checklist and provide a baseline for all contributors.


### PR DESCRIPTION
## Summary
- expose a `convert_ebook_to_audio` helper in `audio_utils.py`
- document the new helper in the CoreForge Audio README
- mention the helper in developer setup and requirements docs
- note helper usage in CoreForge Audio agent checklist

## Testing
- `npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685dddfb1a88832197603cccfc1773e4