### PR TITLE
Add advanced audio normalization utilities

### DIFF
--- a/apps/CoreForgeAudio/DeveloperSetup.md
+++ b/apps/CoreForgeAudio/DeveloperSetup.md
@@ -6,3 +6,5 @@
 - Optional: `pip install -r ../ebook2audiobook/requirements.txt` to enable
   the ebook2audiobook pipeline used by `scripts/ebook2audiobook_bridge.py` or
   the `convert_ebook_to_audio` helper in `audio_utils.py`.
+- Install `ffmpeg` and ensure it is on your `PATH` to use
+  `advanced_normalize_wav_file` and `advanced_normalize_wav_folder`.

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -42,6 +42,9 @@ For advanced conversions using the Python pipeline, call
 `convert_ebook_to_audio("MyBook.epub")` from `audio_utils.py` or run
 `../../scripts/ebook2audiobook_bridge.py MyBook.epub`.
 To polish training samples, run `services/voice_cleaner.py AUDIO.wav` and use the resulting file in `VoiceTrainer`.
+For final mastering you can call `advanced_normalize_wav_file` or
+`advanced_normalize_wav_folder` from `audio_utils.py` to apply the
+ebook2audiobook FFmpeg pipeline for consistent levels and tone.
 You can also turn a dialogue script into audio using `../../scripts/chatterbox_bridge.py script.txt` once your Chatterbox API endpoint is configured.
 
 Full details on the Python-based feature set live in

--- a/tests/python/test_audio_utils.py
+++ b/tests/python/test_audio_utils.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from pydub.generators import Sine
+from shutil import which
+
+# Ensure project root is on path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from apps.CoreForgeAudio.audio_utils import advanced_normalize_wav_file
+
+
+def _tone(path: Path, duration=200):
+    Sine(440).to_audio_segment(duration=duration).export(path, format="wav")
+
+
+def test_advanced_normalize_wav_file(tmp_path: Path):
+    if which("ffmpeg") is None:
+        import pytest
+        pytest.skip("ffmpeg not installed")
+    src = tmp_path / "tone.wav"
+    out = tmp_path / "out.wav"
+    _tone(src)
+    advanced_normalize_wav_file(str(src), str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add ffmpeg based normalizer utilities to `audio_utils.py`
- document new normalization tools in README and DeveloperSetup
- create unit tests for the new helper

## Testing
- `npm test --workspaces`
- `pytest -q`
- `swift test` *(failed: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685de31148e08321900a717a30bc8f9c