### PR TITLE
Use cross-platform theme colors

### DIFF
--- a/Sources/CreatorCoreForge/AppTheme.swift
+++ b/Sources/CreatorCoreForge/AppTheme.swift
@@ -6,7 +6,7 @@ public enum AppTheme {
     /// Primary gradient used across backgrounds.
     public static var primaryGradient: LinearGradient {
         LinearGradient(
-            colors: [Color.purple, Color.blue],
+            colors: [Color.accentColor, Color.accentColor.opacity(0.7)],
             startPoint: .topLeading,
             endPoint: .bottomTrailing
         )
@@ -14,17 +14,17 @@ public enum AppTheme {
 
     /// Accent color used for icons and interactive elements.
     public static var accentColor: Color {
-        Color.purple
+        Color.accentColor
     }
 
     /// Material for cards and popups.
-    public static var cardMaterial: Material { .ultraThinMaterial }
+    public static var cardMaterial: Material { .regularMaterial }
 
     /// Standard corner radius for cards.
-    public static var cornerRadius: CGFloat { 12 }
+    public static var cornerRadius: CGFloat { 8 }
 
     /// Standard shadow radius for cards.
-    public static var shadowRadius: CGFloat { 4 }
+    public static var shadowRadius: CGFloat { 2 }
 }
 #endif
 


### PR DESCRIPTION
## Summary
- switch AppTheme to system accent and regular materials
- adjust standard card styling

## Testing
- `swift test` *(fails: exited with signal code 4)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec05610a48321bc9ad7d2484cde2c