### PR TITLE
Add CreatorCoreForge package to CoreForgeAudio project

### DIFF
--- a/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.pbxproj
+++ b/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.pbxproj
@@ -341,8 +341,11 @@
 			name = CoreForgeAudio;
 			productName = CoreForgeAudio;
 			productReference = E02E020F26944937A89871CC /* CoreForgeAudio.app */;
-			productType = "com.apple.product-type.application";
-		};
+                        productType = "com.apple.product-type.application";
+                        packageProductDependencies = (
+                                AA0011223344556677889902 /* CreatorCoreForge */,
+                        );
+                };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -550,6 +553,24 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-	};
-	rootObject = 7DA13769B4924EBB818522CE /* Project object */;
+/* Begin XCRemoteSwiftPackageReference section */
+                AA0011223344556677889901 /* XCRemoteSwiftPackageReference "CreatorCoreForge" */ = {
+                        isa = XCRemoteSwiftPackageReference;
+                        repositoryURL = "";
+                        requirement = {
+                                kind = localPackage;
+                                path = "../../";
+                        };
+                };
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+                AA0011223344556677889902 /* CreatorCoreForge */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        package = AA0011223344556677889901 /* XCRemoteSwiftPackageReference "CreatorCoreForge" */;
+                        productName = CreatorCoreForge;
+                };
+/* End XCSwiftPackageProductDependency section */
+        };
+        rootObject = 7DA13769B4924EBB818522CE /* Project object */;
 }

--- a/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/CoreForgeAudio/CoreForgeAudio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,13 @@
+{
+  "pins" : [
+    {
+      "identity" : "creatorcoreforge",
+      "kind" : "local",
+      "location" : "../../",
+      "state" : {
+        "revision" : ""
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
## Summary
- integrate CreatorCoreForge as a local Swift package in CoreForgeAudio
- store resolved package info so Xcode doesn't require `swift package resolve`

## Testing
- `bash scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ecc25abf48321a1819cc0e6da8720