### PR TITLE
Add CoreForge Audio login and splash views

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,6 @@
 // swift-tools-version:5.7
 import PackageDescription
 
-
 var products: [PackageDescription.Product] = [
     .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"])
 ]
@@ -14,47 +13,18 @@ products.append(contentsOf: [
 #endif
 
 var targets: [PackageDescription.Target] = [
-    .target(name: "CreatorCoreForge", path: "Sources/CreatorCoreForge"),
-    .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")
+    .target(name: "CreatorCoreForge",
+            path: "Sources/CreatorCoreForge",
+            resources: [
+                .copy("Resources/app_completion_report.json")
+            ]),
+    .testTarget(name: "CreatorCoreForgeTests",
+                dependencies: ["CreatorCoreForge"],
+                path: "Tests/CreatorCoreForgeTests")
 ]
 
 #if os(iOS) || os(macOS)
 targets.append(contentsOf: [
-    .executableTarget(name: "CoreForgeLibraryApp",
-                      dependencies: ["CreatorCoreForge"],
-                      path: "apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp",
-                      exclude: ["Info.plist"]),
-    .executableTarget(name: "CoreForgeAudioApp",
-                      dependencies: ["CreatorCoreForge"],
-                      path: "apps/CoreForgeAudio/VocalVerseFull/VocalVerse",
-                      exclude: ["Info.plist"]),
-    .testTarget(name: "CoreForgeAudioAppTests", dependencies: ["CoreForgeAudioApp"], path: "Tests/CoreForgeAudioAppTests")
-])
-=======
-var products: [Product] = [
-    .library(name: "CreatorCoreForge", targets: ["CreatorCoreForge"])
-]
-
-#if !os(Linux)
-products += [
-    .executable(name: "CoreForgeLibraryApp", targets: ["CoreForgeLibraryApp"]),
-    .executable(name: "CoreForgeAudioApp", targets: ["CoreForgeAudioApp"])
-]
-#endif
-
-var targets: [Target] = [
-    .target(
-        name: "CreatorCoreForge",
-        path: "Sources/CreatorCoreForge",
-        resources: [
-            .copy("Resources/app_completion_report.json")
-        ]
-    ),
-    .testTarget(name: "CreatorCoreForgeTests", dependencies: ["CreatorCoreForge"], path: "Tests/CreatorCoreForgeTests")
-]
-
-#if !os(Linux)
-targets += [
     .executableTarget(
         name: "CoreForgeLibraryApp",
         dependencies: ["CreatorCoreForge"],
@@ -73,9 +43,10 @@ targets += [
             "prompts.json"
         ]
     ),
-    .testTarget(name: "CoreForgeAudioAppTests", dependencies: ["CoreForgeAudioApp"], path: "Tests/CoreForgeAudioAppTests")
-]
-
+    .testTarget(name: "CoreForgeAudioAppTests",
+                dependencies: ["CoreForgeAudioApp"],
+                path: "Tests/CoreForgeAudioAppTests")
+])
 #endif
 
 let package = Package(

--- a/apps/CoreForgeAudio/Managers/AuthManager.swift
+++ b/apps/CoreForgeAudio/Managers/AuthManager.swift
@@ -1,0 +1,48 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+import Foundation
+
+/// Simple authentication manager storing login state locally.
+final class AuthManager: ObservableObject {
+    static let shared = AuthManager()
+
+    #if canImport(SwiftUI)
+    @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
+    @AppStorage("email") private var storedEmail: String = ""
+    @AppStorage("planTier") private var planTier: String = SubscriptionManager.Plan.free.rawValue
+    #endif
+
+    private init() {}
+
+    /// Current subscription plan saved in user defaults.
+    var activePlan: SubscriptionManager.Plan {
+        get { SubscriptionManager.Plan(rawValue: planTier) ?? .free }
+        set { planTier = newValue.rawValue }
+    }
+
+    /// Sign in with existing credentials (no validation for this stub).
+    func signIn(email: String, password: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        storedEmail = email
+        isLoggedIn = true
+        completion(.success(()))
+    }
+
+    /// Register a new account and immediately log in.
+    func signUp(email: String, password: String, plan: SubscriptionManager.Plan, completion: @escaping (Result<Void, Error>) -> Void) {
+        storedEmail = email
+        activePlan = plan
+        isLoggedIn = true
+        completion(.success(()))
+    }
+
+    /// Simulate sending a password reset email.
+    func resetPassword(email: String, completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+
+    /// Sign out the current user.
+    func signOut() {
+        isLoggedIn = false
+    }
+}

--- a/apps/CoreForgeAudio/Resources/LaunchScreen.storyboard
+++ b/apps/CoreForgeAudio/Resources/LaunchScreen.storyboard
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" launchScreen="YES">
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="launchScene">
+            <objects>
+                <viewController id="launchVC" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="launchView">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <subviews>
+                            <label id="launchLabel">
+                                <rect key="frame" x="20" y="20" width="335" height="28"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="text" value="CoreForge Audio"/>
+                                </userDefinedRuntimeAttributes>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="0.1" green="0.1" blue="0.3" alpha="1" colorSpace="calibratedRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="firstResponder" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/apps/CoreForgeAudio/Theme/GlowingButtonStyle.swift
+++ b/apps/CoreForgeAudio/Theme/GlowingButtonStyle.swift
@@ -1,0 +1,17 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Glowing button style matching CoreForge branding.
+struct GlowingButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .background(AppTheme.primaryGradient)
+            .foregroundColor(.white)
+            .cornerRadius(AppTheme.cornerRadius)
+            .shadow(color: Color.white.opacity(configuration.isPressed ? 0.4 : 0.8), radius: configuration.isPressed ? 4 : 8)
+            .scaleEffect(configuration.isPressed ? 0.97 : 1)
+    }
+}
+#endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift
@@ -25,7 +25,6 @@ struct ContentView: View {
 
     var body: some View {
         Group {
-
             if showSplash {
                 WelcomeSplashView { showSplash = false }
                     .transition(.opacity)
@@ -41,33 +40,18 @@ struct ContentView: View {
                         ForgotPasswordView { }
                     }
             } else if hasSeenOnboarding || onboarding.isCompleted(.finished) {
-=======
-            if hasSeenOnboarding {
-
                 MainTabView(namespace: ns, selection: $selectedTab)
                     .environmentObject(library)
                     .environmentObject(usage)
-
                     .environmentObject(onboarding)
                     .environmentObject(prefs)
-                    .environmentObject(offlineManager)
-
-                    .transition(.scale)
-            } else {
-                OnboardingView(hasSeenOnboarding: $hasSeenOnboarding, namespace: ns)
-=======
-                    .environmentObject(onboarding)
-                    .environmentObject(prefs)
-
-                    .transition(.scale)
-=======
                     .environmentObject(offlineManager)
                     .transition(.scale)
             } else {
                 OnboardingView(hasSeenOnboarding: $hasSeenOnboarding, namespace: ns)
                     .environmentObject(onboarding)
                     .environmentObject(prefs)
-
+                    .environmentObject(offlineManager)
                     .transition(.scale)
             }
         }

--- a/apps/CoreForgeAudio/views/ForgotPasswordView.swift
+++ b/apps/CoreForgeAudio/views/ForgotPasswordView.swift
@@ -1,0 +1,48 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Password reset via email.
+struct ForgotPasswordView: View {
+    @State private var email = ""
+    @State private var message: String?
+    var onComplete: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Text("Reset Password")
+                .font(.title)
+                .foregroundColor(AppTheme.foregroundColor)
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+            if let message = message {
+                Text(message)
+                    .font(.caption)
+                    .foregroundColor(.green)
+            }
+            Button("Send Reset") { reset() }
+                .font(.headline)
+                .buttonStyle(GlowingButtonStyle())
+            Spacer()
+        }
+        .padding()
+        .background(AppTheme.primaryGradient.ignoresSafeArea())
+    }
+
+    private func reset() {
+        AuthManager.shared.resetPassword(email: email) { error in
+            if let error = error {
+                message = error.localizedDescription
+            } else {
+                message = "Email sent"
+                onComplete()
+            }
+        }
+    }
+}
+
+#Preview {
+    ForgotPasswordView(onComplete: {})
+}
+#endif

--- a/apps/CoreForgeAudio/views/LoginView.swift
+++ b/apps/CoreForgeAudio/views/LoginView.swift
@@ -1,0 +1,58 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Login screen with email and password fields.
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var error: String?
+    var onRegister: () -> Void
+    var onForgot: () -> Void
+    var onSuccess: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Text("CoreForge Audio")
+                .font(.title)
+                .foregroundColor(AppTheme.foregroundColor)
+                .transition(.scale)
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            if let error = error {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+            Button("Sign In") { login() }
+                .font(.headline)
+                .buttonStyle(GlowingButtonStyle())
+            Button("Forgot Password?", action: onForgot)
+                .font(.caption)
+            Button("Register") { onRegister() }
+                .font(.caption)
+            Spacer()
+        }
+        .padding()
+        .background(AppTheme.primaryGradient.ignoresSafeArea())
+    }
+
+    private func login() {
+        AuthManager.shared.signIn(email: email, password: password) { result in
+            switch result {
+            case .success:
+                onSuccess()
+            case .failure(let err):
+                error = err.localizedDescription
+            }
+        }
+    }
+}
+
+#Preview {
+    LoginView(onRegister: {}, onForgot: {}, onSuccess: {})
+}
+#endif

--- a/apps/CoreForgeAudio/views/RegisterView.swift
+++ b/apps/CoreForgeAudio/views/RegisterView.swift
@@ -1,0 +1,59 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Registration screen with tier selection.
+struct RegisterView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @State private var selectedTier: SubscriptionManager.Plan = .free
+    @State private var error: String?
+    var onComplete: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Text("Create Account")
+                .font(.title)
+                .foregroundColor(AppTheme.foregroundColor)
+            TextField("Email", text: $email)
+                .textFieldStyle(.roundedBorder)
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+            Picker("Tier", selection: $selectedTier) {
+                Text("Free").tag(SubscriptionManager.Plan.free)
+                Text("Creator").tag(SubscriptionManager.Plan.creator)
+                Text("Enterprise").tag(SubscriptionManager.Plan.enterprise)
+            }
+            .pickerStyle(.segmented)
+            if let error = error {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+            Button("Register") { register() }
+                .font(.headline)
+                .buttonStyle(GlowingButtonStyle())
+            Spacer()
+        }
+        .padding()
+        .background(AppTheme.primaryGradient.ignoresSafeArea())
+    }
+
+    private func register() {
+        AuthManager.shared.signUp(email: email, password: password, plan: selectedTier) { result in
+            switch result {
+            case .success:
+                SubscriptionManager().upgrade(to: selectedTier)
+                onComplete()
+            case .failure(let err):
+                error = err.localizedDescription
+            }
+        }
+    }
+}
+
+#Preview {
+    RegisterView(onComplete: {})
+}
+#endif

--- a/apps/CoreForgeAudio/views/TierUpgradeView.swift
+++ b/apps/CoreForgeAudio/views/TierUpgradeView.swift
@@ -1,0 +1,37 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// In-app tier selection modal.
+struct TierUpgradeView: View {
+    @Binding var isPresented: Bool
+    @State private var selected: SubscriptionManager.Plan = .creator
+    var onUpgrade: (SubscriptionManager.Plan) -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Picker("Plan", selection: $selected) {
+                Text("Creator").tag(SubscriptionManager.Plan.creator)
+                Text("Enterprise").tag(SubscriptionManager.Plan.enterprise)
+            }
+            .pickerStyle(.segmented)
+            Button("Upgrade") {
+                onUpgrade(selected)
+                isPresented = false
+            }
+            .font(.headline)
+            .buttonStyle(GlowingButtonStyle())
+        }
+        .padding()
+        .background(Theme.cardMaterial)
+        .cornerRadius(Theme.cornerRadius)
+        .shadow(radius: Theme.shadowRadius)
+    }
+}
+
+#Preview {
+    TierUpgradeView(isPresented: .constant(true)) { _ in }
+        .padding()
+        .background(Color.gray)
+}
+#endif

--- a/apps/CoreForgeAudio/views/WelcomeSplashView.swift
+++ b/apps/CoreForgeAudio/views/WelcomeSplashView.swift
@@ -1,0 +1,38 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import CreatorCoreForge
+
+/// Animated splash screen with logo and brand colors.
+struct WelcomeSplashView: View {
+    var onFinish: () -> Void
+    @State private var show = false
+
+    var body: some View {
+        VStack {
+            if show {
+                Image(systemName: "headphones")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 120, height: 120)
+                    .transition(.scale)
+                Text("CoreForge Audio")
+                    .font(.title)
+                    .foregroundColor(AppTheme.foregroundColor)
+                    .transition(.opacity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppTheme.primaryGradient.ignoresSafeArea())
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.6)) { show = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                onFinish()
+            }
+        }
+    }
+}
+
+#Preview {
+    WelcomeSplashView(onFinish: {})
+}
+#endif


### PR DESCRIPTION
## Summary
- implement minimal `AuthManager` for local login state
- add themed login, register, forgot password, splash, and tier upgrade views
- apply glowing button style and gradient backgrounds
- copy launch screen storyboard
- clean up ContentView and Package manifest

## Testing
- `./scripts/clean_install.sh` *(failed: npm warnings)*
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(failed: exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685efaaa853083218a4beeba89ca5fe2