### PR TITLE
Add guest login option

### DIFF
--- a/apps/CoreForgeAudio/Managers/AuthManager.swift
+++ b/apps/CoreForgeAudio/Managers/AuthManager.swift
@@ -36,6 +36,14 @@ final class AuthManager: ObservableObject {
         completion(.success(()))
     }
 
+    /// Continue without an account using the free plan.
+    func signInAnonymously(completion: @escaping () -> Void) {
+        storedEmail = ""
+        activePlan = .free
+        isLoggedIn = true
+        completion()
+    }
+
     /// Simulate sending a password reset email.
     func resetPassword(email: String, completion: @escaping (Error?) -> Void) {
         completion(nil)

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LoginView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LoginView.swift
@@ -31,6 +31,12 @@ struct LoginView: View {
                 .font(.caption)
             Button("Register") { onRegister() }
                 .font(.caption)
+            Button("Continue as Guest") {
+                AuthManager.shared.signInAnonymously {
+                    onSuccess()
+                }
+            }
+            .font(.caption)
             Spacer()
         }
         .padding()

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
@@ -12,6 +12,8 @@ struct SettingsView: View {
     @State private var showAgeSheet = false
     @State private var inputPIN = ""
     @State private var showIncorrectAlert = false
+    @AppStorage("isLoggedIn") private var isLoggedIn = false
+    @State private var showRegister = false
 
     private let voices = VoiceConfig.voices.map { $0.name }
 
@@ -43,6 +45,14 @@ struct SettingsView: View {
                     Button("Change PIN") { showPinPrompt = true }
                     Toggle("Stealth Vault", isOn: $stealthMode)
                 }
+                if !isLoggedIn {
+                    Section(header: Text("Account")) {
+                        Text("Create an account to sync your library across devices.")
+                            .font(.caption)
+                        Button("Create Account") { showRegister = true }
+                            .buttonStyle(GlowingButtonStyle())
+                    }
+                }
             }
             .navigationTitle("Settings")
             .alert("Incorrect PIN", isPresented: $showIncorrectAlert) {
@@ -58,6 +68,9 @@ struct SettingsView: View {
             }
             .sheet(isPresented: $showPinPrompt) {
                 PinEntryView(pin: $inputPIN, onDone: handlePinEntry)
+            }
+            .sheet(isPresented: $showRegister) {
+                RegisterView { isLoggedIn = true }
             }
         }
     }

--- a/apps/CoreForgeAudio/views/LoginView.swift
+++ b/apps/CoreForgeAudio/views/LoginView.swift
@@ -34,6 +34,12 @@ struct LoginView: View {
                 .font(.caption)
             Button("Register") { onRegister() }
                 .font(.caption)
+            Button("Continue as Guest") {
+                AuthManager.shared.signInAnonymously {
+                    onSuccess()
+                }
+            }
+            .font(.caption)
             Spacer()
         }
         .padding()


### PR DESCRIPTION
## Summary
- support guest login in `AuthManager`
- allow skipping login from both `LoginView` implementations
- show account signup nudge in Settings

## Testing
- `npm test --workspaces`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685efd8ea9f08321b7aaeb1aa7ec09c2