### PR TITLE
Improve CoreForge Audio components

### DIFF
--- a/apps/CoreForgeAudio/Desktop/main.js
+++ b/apps/CoreForgeAudio/Desktop/main.js
@@ -1,0 +1,31 @@
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 900,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+ipcMain.handle('open-file', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({ properties: ['openFile'] });
+  return canceled ? null : filePaths[0];
+});
+
+ipcMain.handle('get-version', () => {
+  return app.getVersion();
+});

--- a/apps/CoreForgeAudio/components/NowPlayingBadge.tsx
+++ b/apps/CoreForgeAudio/components/NowPlayingBadge.tsx
@@ -2,8 +2,24 @@ import React from 'react';
 
 export interface NowPlayingBadgeProps {
   title: string;
+  progress: number;
+  isPlaying: boolean;
+  onToggle: () => void;
 }
 
-export const NowPlayingBadge: React.FC<NowPlayingBadgeProps> = ({ title }) => (
-  <div className="now-playing-badge">Now Playing: {title}</div>
+export const NowPlayingBadge: React.FC<NowPlayingBadgeProps> = ({
+  title,
+  progress,
+  isPlaying,
+  onToggle,
+}) => (
+  <div className="now-playing-badge" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+    <span>Now Playing: {title}</span>
+    <button onClick={onToggle}>{isPlaying ? 'Pause' : 'Play'}</button>
+    <div style={{ flex: 1, height: '4px', background: '#ccc' }}>
+      <div
+        style={{ width: `${Math.round(progress * 100)}%`, height: '100%', background: '#6a5acd' }}
+      />
+    </div>
+  </div>
 );

--- a/apps/CoreForgeAudio/hooks/README.md
+++ b/apps/CoreForgeAudio/hooks/README.md
@@ -1,1 +1,5 @@
-# CoreForgeAudio hooks
+# CoreForge Audio Hooks
+
+Helper scripts and Git hooks used during development. These include sample
+pre-commit hooks for formatting Swift and TypeScript code as well as utilities
+for validating assets before packaging the app.

--- a/apps/CoreForgeAudio/models/README.md
+++ b/apps/CoreForgeAudio/models/README.md
@@ -1,1 +1,5 @@
-# CoreForgeAudio models
+# CoreForge Audio Models
+
+Swift data structures describing books, chapters, and usage statistics used by
+the app. These models are intentionally lightweight so they can be serialized to
+JSON and synced between devices.

--- a/apps/CoreForgeAudio/services/AudioDeviceManager.ts
+++ b/apps/CoreForgeAudio/services/AudioDeviceManager.ts
@@ -5,9 +5,38 @@ export interface AudioDevice {
 
 export class AudioDeviceManager {
   private devices: AudioDevice[] = [];
+  private activeId: string | null = null;
 
   register(device: AudioDevice): void {
     this.devices.push(device);
+  }
+
+  unregister(deviceId: string): void {
+    this.devices = this.devices.filter(d => d.id !== deviceId);
+    if (this.activeId === deviceId) {
+      this.activeId = null;
+    }
+  }
+
+  setActive(deviceId: string): void {
+    if (this.devices.find(d => d.id === deviceId)) {
+      this.activeId = deviceId;
+    }
+  }
+
+  getActive(): AudioDevice | undefined {
+    return this.devices.find(d => d.id === this.activeId);
+  }
+
+  async refreshFromBrowser(): Promise<void> {
+    // Only available in browser/Electron contexts
+    const navigatorRef: any = (globalThis as any).navigator;
+    if (navigatorRef && navigatorRef.mediaDevices?.enumerateDevices) {
+      const media = await navigatorRef.mediaDevices.enumerateDevices();
+      this.devices = media
+        .filter((m: any) => m.kind === 'audiooutput')
+        .map((d: any) => ({ id: d.deviceId, name: d.label || 'Output' }));
+    }
   }
 
   list(): AudioDevice[] {

--- a/apps/CoreForgeAudio/views/README.md
+++ b/apps/CoreForgeAudio/views/README.md
@@ -1,1 +1,9 @@
-# CoreForgeAudio views
+# CoreForge Audio Views
+
+This directory contains SwiftUI views used throughout the CoreForge Audio
+application. Each file defines a standalone UI component such as the library
+dashboard, player controls, onboarding screens, and settings panels.
+
+Views are organized by feature area to keep the project maintainable. Previews
+are provided where possible so components can be inspected without launching the
+full app.


### PR DESCRIPTION
## Summary
- add missing Electron `main.js` for the desktop launcher
- enhance `AudioDeviceManager` utilities
- expand `NowPlayingBadge` with controls and progress
- fill out documentation placeholders for hooks, models, and views

## Testing
- `pip install -r requirements.txt`
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*
- `pytest -q tests/python` *(fails: AttributeError: module 'matplotlib.pyplot' has no attribute 'subplots')*


------
https://chatgpt.com/codex/tasks/task_e_685f12d265e8832185f36eb354e06ded