### PR TITLE
Improve Visual modules

### DIFF
--- a/VisualLab/src/ARService.ts
+++ b/VisualLab/src/ARService.ts
@@ -2,8 +2,27 @@ export interface Scene {
   id: string;
 }
 
+export interface Overlay {
+  modelId: string;
+  position: [number, number, number];
+}
+
 export class ARService {
-  async previewScene(scene: Scene): Promise<void> {
-    console.log('Previewing scene', scene.id);
+  private models = new Map<string, Buffer>();
+
+  async registerModel(id: string, data: Buffer): Promise<void> {
+    this.models.set(id, data);
+  }
+
+  async previewScene(scene: Scene): Promise<Overlay[]> {
+    const overlays: Overlay[] = [];
+    for (const id of this.models.keys()) {
+      overlays.push({
+        modelId: id,
+        position: [Math.random(), Math.random(), Math.random()],
+      });
+    }
+    console.log('Previewing scene', scene.id, 'with', overlays.length, 'models');
+    return overlays;
   }
 }

--- a/VisualLab/test/newFeatures.test.ts
+++ b/VisualLab/test/newFeatures.test.ts
@@ -17,7 +17,9 @@ import React from 'react';
 import assert from 'node:assert';
 
 const svc = new ARService();
-await svc.previewScene({ id: '1' });
+await svc.registerModel('cube', Buffer.from('m'));
+const overlays = await svc.previewScene({ id: '1' });
+assert.strictEqual(overlays.length, 1);
 
 const gpu = new GPUVideoRenderer();
 const clip = await gpu.render([], { width: 100, height: 100 });

--- a/apps/CoreForgeVisual/Desktop/main.js
+++ b/apps/CoreForgeVisual/Desktop/main.js
@@ -1,0 +1,29 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    }
+  });
+
+  win.loadFile(path.join(__dirname, 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});


### PR DESCRIPTION
## Summary
- add an Electron entry point for CoreForge Visual Desktop
- enhance ARService with model registration and overlay output
- update newFeatures test to validate new ARService behavior

## Testing
- `npm test`
- `swift test --enable-code-coverage` *(fails: signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f15cbf8188321a377c58a2134c3cf