### PR TITLE
Fix CoreForge audio data handling

### DIFF
--- a/Sources/CreatorCoreForge/NSFWHabitBehaviorSimulator.swift
+++ b/Sources/CreatorCoreForge/NSFWHabitBehaviorSimulator.swift
@@ -44,7 +44,7 @@ public final class NSFWHabitBehaviorSimulator: ObservableObject {
                 }
             }
         }
-        return ""
+        return nil
     }
 
     /// Remove registered habits for a specific character, or all habits if nil.

--- a/Sources/CreatorCoreForge/VaultService.swift
+++ b/Sources/CreatorCoreForge/VaultService.swift
@@ -22,10 +22,9 @@ public final class VaultService {
     }
 
     public func loadAudio(bookId: String, nsfw: Bool = false) -> Data? {
-        if let url = manager.retrieve(named: bookId, nsfw: nsfw) {
-            return try? Data(contentsOf: url)
+        guard let url = manager.retrieve(named: bookId, nsfw: nsfw) else {
+            return nil
         }
-        // Return empty data when the file is missing so playback can continue
-        return Data()
+        return try? Data(contentsOf: url)
     }
 }


### PR DESCRIPTION
## Summary
- return nil instead of empty string in `NSFWHabitBehaviorSimulator`
- return nil when audio files are missing in `VaultService`

## Testing
- `swift test --skip-build` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f1d5b72888321a5c5cb89f1a4c5bc