### PR TITLE
Implement audio helper utilities

### DIFF
--- a/generated/CoreForgeAudio/AI_coach_for_pronunciation_pacing_performance_feedback.py
+++ b/generated/CoreForgeAudio/AI_coach_for_pronunciation_pacing_performance_feedback.py
@@ -1,4 +1,47 @@
 # Auto-generated for AI “coach” for pronunciation, pacing, performance feedback
-def ai_coach_for():
-    """AI “coach” for pronunciation, pacing, performance feedback"""
-    pass
+"""Utility helpers for basic speech performance analysis."""
+
+from __future__ import annotations
+
+import re
+import statistics
+from typing import Dict
+
+
+def analyze_speech(transcript: str, duration_seconds: float) -> Dict[str, float | str]:
+    """Return simple pacing metrics and feedback.
+
+    Parameters
+    ----------
+    transcript: str
+        Full transcript of the spoken audio.
+    duration_seconds: float
+        Length of the audio in seconds.
+
+    Returns
+    -------
+    dict
+        A dictionary containing ``wpm`` and ``avg_word_length`` plus a feedback
+        string suggesting pacing adjustments.
+    """
+
+    words = re.findall(r"\b\w+\b", transcript)
+    if duration_seconds > 0:
+        wpm = len(words) / (duration_seconds / 60)
+    else:
+        wpm = 0.0
+
+    avg_word_length = statistics.mean(len(w) for w in words) if words else 0.0
+
+    feedback_parts: list[str] = []
+    if wpm < 120:
+        feedback_parts.append("Consider speaking faster.")
+    elif wpm > 190:
+        feedback_parts.append("Consider slowing down.")
+
+    feedback = " ".join(feedback_parts)
+
+    return {"wpm": wpm, "avg_word_length": avg_word_length, "feedback": feedback}
+
+
+__all__ = ["analyze_speech"]

--- a/generated/CoreForgeAudio/Add_DRM_toggle_for_exports_requiring_usage_protection.py
+++ b/generated/CoreForgeAudio/Add_DRM_toggle_for_exports_requiring_usage_protection.py
@@ -1,4 +1,17 @@
 # Auto-generated for Add DRM toggle for exports requiring usage protection
-def add_drm_toggle():
-    """Add DRM toggle for exports requiring usage protection"""
-    pass
+"""Utilities for marking exports with a DRM flag."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def apply_drm(metadata: Dict[str, str], enable: bool = True) -> Dict[str, str]:
+    """Return a copy of ``metadata`` updated with a DRM flag."""
+
+    meta = dict(metadata)
+    meta["drm_protected"] = "true" if enable else "false"
+    return meta
+
+
+__all__ = ["apply_drm"]

--- a/generated/CoreForgeAudio/Add_cross_device_sync_track_last_listened_chapter_scene_and_timestamp.py
+++ b/generated/CoreForgeAudio/Add_cross_device_sync_track_last_listened_chapter_scene_and_timestamp.py
@@ -1,4 +1,55 @@
 # Auto-generated for Add cross-device sync: track last listened chapter, scene, and timestamp
-def add_cross_device():
-    """Add cross-device sync: track last listened chapter, scene, and timestamp"""
-    pass
+"""Simple JSON-based cross-device sync helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+
+DEFAULT_SYNC_FILE = Path.home() / ".coreforge_sync.json"
+
+
+def update_position(
+    book_id: str,
+    chapter: int,
+    scene: int,
+    timestamp: float,
+    file_path: Path = DEFAULT_SYNC_FILE,
+) -> None:
+    """Store the latest position for ``book_id`` in ``file_path``."""
+
+    data = _load_sync(file_path)
+    data[book_id] = {
+        "chapter": chapter,
+        "scene": scene,
+        "timestamp": timestamp,
+    }
+    _save_sync(file_path, data)
+
+
+def load_position(book_id: str, file_path: Path = DEFAULT_SYNC_FILE) -> Optional[Dict[str, float]]:
+    """Return the last stored position for ``book_id`` if available."""
+
+    data = _load_sync(file_path)
+    return data.get(book_id)
+
+
+def _load_sync(file_path: Path) -> Dict[str, Dict[str, float]]:
+    if file_path.is_file():
+        with open(file_path, "r", encoding="utf-8") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def _save_sync(file_path: Path, data: Dict[str, Dict[str, float]]) -> None:
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+__all__ = ["update_position", "load_position"]

--- a/tests/python/test_audio_new_helpers.py
+++ b/tests/python/test_audio_new_helpers.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from generated.CoreForgeAudio.AI_coach_for_pronunciation_pacing_performance_feedback import analyze_speech
+from generated.CoreForgeAudio.Add_cross_device_sync_track_last_listened_chapter_scene_and_timestamp import update_position, load_position
+from generated.CoreForgeAudio.Add_DRM_toggle_for_exports_requiring_usage_protection import apply_drm
+
+
+def test_analyze_speech_basic():
+    transcript = "hello world " * 50  # 100 words
+    result = analyze_speech(transcript, 50)  # 50 seconds -> 120 WPM
+    assert 119 <= result["wpm"] <= 121
+    assert result["avg_word_length"] > 0
+
+
+def test_cross_device_sync(tmp_path):
+    sync_file = tmp_path / "sync.json"
+    update_position("book1", 1, 2, 33.5, sync_file)
+    pos = load_position("book1", sync_file)
+    assert pos == {"chapter": 1, "scene": 2, "timestamp": 33.5}
+
+
+def test_apply_drm():
+    meta = {"title": "Test"}
+    out = apply_drm(meta, True)
+    assert out["drm_protected"] == "true"
+    out = apply_drm(meta, False)
+    assert out["drm_protected"] == "false"


### PR DESCRIPTION
## Summary
- add basic speech analysis helper
- add cross-device sync helpers
- add DRM toggle helper
- test new audio utilities

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(failed: Exited with unexpected signal code 4)*
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f1d967e40832192fb37a555c87cf5