### PR TITLE
Improve VisualLab drag-and-drop detection

### DIFF
--- a/VisualLab/src/dragDropHelper.ts
+++ b/VisualLab/src/dragDropHelper.ts
@@ -1,7 +1,9 @@
-export function detectBookFormat(fileName: string): string | null {
+export function detectBookFormat(fileName: string): string {
   const lower = fileName.toLowerCase();
   if (lower.endsWith('.epub')) return 'epub';
   if (lower.endsWith('.pdf')) return 'pdf';
   if (lower.endsWith('.txt')) return 'txt';
-  return null;
+  if (lower.endsWith('.docx') || lower.endsWith('.doc')) return 'docx';
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) return 'markdown';
+  return 'unknown';
 }

--- a/VisualLab/test/newFeatures.test.ts
+++ b/VisualLab/test/newFeatures.test.ts
@@ -89,6 +89,9 @@ assert.deepStrictEqual(detectCharacters('Alice meets Bob.'), ['Alice','Bob']);
 assert.strictEqual(matchLocationToTemplate('Old Castle Tower'), 'castle');
 assert.deepStrictEqual(generateStoryboard(['a','b'])[1], { index: 1, text: 'b' });
 assert.strictEqual(detectBookFormat('novel.epub'), 'epub');
+assert.strictEqual(detectBookFormat('chapter.docx'), 'docx');
+assert.strictEqual(detectBookFormat('notes.md'), 'markdown');
+assert.strictEqual(detectBookFormat('image.png'), 'unknown');
 assert.deepStrictEqual(mergeScenes(['a','b','c'],1), ['a','b c']);
 
 console.log('New features tests passed');


### PR DESCRIPTION
## Summary
- enhance `detectBookFormat` to handle more extensions and never return null
- expand tests for additional file types

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_685f1f91f1d0832197b8d3024fb61d57