### PR TITLE
Improve VisualMemoryEngine utilities

### DIFF
--- a/Sources/CreatorCoreForge/VisualMemoryEngine.swift
+++ b/Sources/CreatorCoreForge/VisualMemoryEngine.swift
@@ -30,6 +30,11 @@ public final class VisualMemoryEngine {
         timeline.filter { $0.project == project }.map { $0.frame }
     }
 
+    /// Return the most recently added frame for the given project.
+    public func lastFrame(for project: String) -> String? {
+        frames(for: project).last
+    }
+
     /// Combine frames from all projects in the order they were added.
     public func allFramesTimeline() -> [String] {
         timeline.map { $0.frame }
@@ -38,6 +43,12 @@ public final class VisualMemoryEngine {
     /// Clear all stored frames.
     public func clear() {
         timeline.removeAll()
+        persist()
+    }
+
+    /// Remove all frames associated with a specific project.
+    public func removeFrames(for project: String) {
+        timeline.removeAll { $0.project == project }
         persist()
     }
 

--- a/Tests/CreatorCoreForgeTests/VisualMemoryEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/VisualMemoryEngineTests.swift
@@ -13,4 +13,25 @@ final class VisualMemoryEngineTests: XCTestCase {
         XCTAssertEqual(loaded.allFramesTimeline(), ["f1", "f2"])
         suite.removePersistentDomain(forName: "VisualMemTest")
     }
+
+    func testRemoveFrames() {
+        let suite = UserDefaults(suiteName: "VisualMemRemoveTest")!
+        let engine = VisualMemoryEngine(store: suite)
+        engine.addFrame("a", project: "P1")
+        engine.addFrame("b", project: "P1")
+        engine.addFrame("c", project: "P2")
+        engine.removeFrames(for: "P1")
+        XCTAssertEqual(engine.frames(for: "P1"), [])
+        XCTAssertEqual(engine.allFramesTimeline(), ["c"])
+        suite.removePersistentDomain(forName: "VisualMemRemoveTest")
+    }
+
+    func testLastFrame() {
+        let suite = UserDefaults(suiteName: "VisualMemLastTest")!
+        let engine = VisualMemoryEngine(store: suite)
+        engine.addFrame("a", project: "P1")
+        engine.addFrame("b", project: "P1")
+        XCTAssertEqual(engine.lastFrame(for: "P1"), "b")
+        suite.removePersistentDomain(forName: "VisualMemLastTest")
+    }
 }


### PR DESCRIPTION
## Summary
- add `lastFrame` and `removeFrames` utilities to `VisualMemoryEngine`
- add tests covering new methods

## Testing
- `swift test --enable-code-coverage` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f248631188321881fc8a56eb57225