### PR TITLE
Improve TTS model loading

### DIFF
--- a/generated/CreatorCoreForge/AI_coach_and_performance_review_for_narration_voice.py
+++ b/generated/CreatorCoreForge/AI_coach_and_performance_review_for_narration_voice.py
@@ -1,4 +1,15 @@
 # Auto-generated for AI “coach” and performance review for narration/voice
-def ai_coach_and():
-    """AI “coach” and performance review for narration/voice"""
-    pass
+from __future__ import annotations
+import soundfile as sf
+import numpy as np
+
+
+def ai_coach_and(audio_path: str) -> dict:
+    """Return simple narration metrics from an audio file."""
+    try:
+        data, sr = sf.read(audio_path)
+        duration = len(data) / float(sr)
+        rms = float(np.sqrt(np.mean(np.square(data))))
+        return {"duration": duration, "rms": rms}
+    except Exception as e:
+        return {"error": str(e)}

--- a/generated/CreatorCoreForge/Real_time_emotional_arc_tone_adaptation.py
+++ b/generated/CreatorCoreForge/Real_time_emotional_arc_tone_adaptation.py
@@ -1,4 +1,16 @@
 # Auto-generated for Real-time emotional arc & tone adaptation
-def real_time_emotional():
-    """Real-time emotional arc & tone adaptation"""
-    pass
+from __future__ import annotations
+import re
+
+POSITIVE_WORDS = {"good", "great", "happy", "excited", "love", "excellent", "positive"}
+NEGATIVE_WORDS = {"bad", "sad", "angry", "hate", "terrible", "negative"}
+
+
+def real_time_emotional(text: str) -> float:
+    """Return a simple sentiment score for the given text."""
+    tokens = re.findall(r"[a-zA-Z]+", text.lower())
+    pos = sum(1 for t in tokens if t in POSITIVE_WORDS)
+    neg = sum(1 for t in tokens if t in NEGATIVE_WORDS)
+    if not tokens:
+        return 0.0
+    return (pos - neg) / len(tokens)


### PR DESCRIPTION
## Summary
- add custom model support for multiple TTS engines
- implement simple audio coaching helper
- implement tiny sentiment scorer

## Testing
- `swift test -c release` *(fails: Exited with unexpected signal code 4)*
- `pytest -q tests/python` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_685f2911b68c832184d713f4c9fa0bb3