### PR TITLE
Fix return statements in analytics and review services

### DIFF
--- a/Sources/CreatorCoreForge/ReplayAnalyticsService.swift
+++ b/Sources/CreatorCoreForge/ReplayAnalyticsService.swift
@@ -10,7 +10,7 @@ public final class ReplayAnalyticsService {
     }
 
     public func stats(for line: String) -> ReplayAnalytics.Stats {
-        analytics.stats(for: line)
+        return analytics.stats(for: line)
     }
 
     public func reset() {

--- a/Sources/CreatorCoreForge/VoiceReviewSystem.swift
+++ b/Sources/CreatorCoreForge/VoiceReviewSystem.swift
@@ -35,7 +35,7 @@ public final class VoiceReviewSystem {
 
     /// Return all reviews for a voice.
     public func allReviews(for name: String) -> [Review] {
-        reviews[name] ?? []
+        return reviews[name] ?? []
     }
 
     /// Remove all stored reviews.


### PR DESCRIPTION
## Summary
- fix missing `return` in `ReplayAnalyticsService.stats`
- fix missing `return` in `VoiceReviewSystem.allReviews`

## Testing
- `swift test -c release` *(fails: signal 4)*
- `npm test` *(fails: TypeScript error in CoreForgeBuild)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f29d4a8cc8321b733d796352ff546