### PR TITLE
Implement selective voice assignment for major characters

### DIFF
--- a/Tests/CreatorCoreForgeTests/CharacterVoiceMapperTests.swift
+++ b/Tests/CreatorCoreForgeTests/CharacterVoiceMapperTests.swift
@@ -9,7 +9,7 @@ final class CharacterVoiceMapperTests: XCTestCase {
         Bob: Hi
         Alice: How are you?
         """
-        let result = mapper.assignVoices(to: text)
+        let result = mapper.assignVoicesSelective(to: text)
         XCTAssertEqual(result.count, 2)
         let aliceVoice = mapper.getVoice(for: "Alice")
         let bobVoice = mapper.getVoice(for: "Bob")
@@ -24,8 +24,25 @@ final class CharacterVoiceMapperTests: XCTestCase {
         Alice - Hello
         Bob — Hi there
         """
-        let result = mapper.assignVoices(to: text)
+        let result = mapper.assignVoicesSelective(to: text)
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result.map { $0.assignedVoice }, ["One", "Two"])
+    }
+
+    func testManualSelectionForFrequentSpeakers() {
+        let mapper = CharacterVoiceMapper(voices: ["Auto1", "Auto2"])
+        let speech = Array(repeating: "Hello.", count: 11).joined(separator: " ")
+        let text = "Alice: \(speech)\nBob: Hi."
+        var selected: [String] = []
+        let result = mapper.assignVoicesSelective(to: text) { name, _ in
+            selected.append(name)
+            return "Manual"
+        }
+        XCTAssertTrue(selected.contains("Alice"))
+        XCTAssertFalse(selected.contains("Bob"))
+        let alice = result.first { $0.name == "Alice" }!
+        let bob = result.first { $0.name == "Bob" }!
+        XCTAssertEqual(alice.assignedVoice, "Manual")
+        XCTAssertEqual(bob.assignedVoice, "Auto1")
     }
 }

--- a/apps/CoreForgeStudio/VocalVisionFull/Sources/VocalVision/VideoExportManager.swift
+++ b/apps/CoreForgeStudio/VocalVisionFull/Sources/VocalVision/VideoExportManager.swift
@@ -24,7 +24,7 @@ public final class VideoExportManager {
                        progress: @escaping (Double) -> Void,
                        completion: @escaping (URL?) -> Void) {
         let scenes = sceneGenerator.generateScenes(from: bookText)
-        _ = voiceMapper.assignVoices(to: bookText)
+        _ = voiceMapper.assignVoicesSelective(to: bookText)
         let voiced = caster.assignVoices(to: scenes)
         renderer.exportMultiHourVideo(scenes: voiced,
                                       to: outputURL,
@@ -46,7 +46,7 @@ public final class VideoExportManager {
                                           completion: @escaping (URL?) -> Void) {
         var metadata = ["unabridged": "3h"]
         let scenes = sceneGenerator.generateScenes(from: bookText)
-        _ = voiceMapper.assignVoices(to: bookText)
+        _ = voiceMapper.assignVoicesSelective(to: bookText)
         let voiced = caster.assignVoices(to: scenes)
         renderer.exportMultiHourVideo(scenes: voiced,
                                      to: outputURL,
@@ -74,7 +74,7 @@ public final class VideoExportManager {
             completion(nil)
             return
         }
-        _ = voiceMapper.assignVoices(to: bookText)
+        _ = voiceMapper.assignVoicesSelective(to: bookText)
         let voiced = caster.assignVoices(to: highlights)
         renderer.exportMultiHourVideo(scenes: voiced,
                                      to: outputURL,

--- a/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/BookExporter.swift
+++ b/apps/CoreForgeWriter/InkwellAIFull/InkwellAI/BookExporter.swift
@@ -42,7 +42,7 @@ struct BookExporter {
     /// This demo uses AVSpeechSynthesizer to produce the audio sequentially.
     static func exportAudiobook(text: String, to url: URL, voice: AVSpeechSynthesisVoice? = nil, rate: Float = AVSpeechUtteranceDefaultSpeechRate) throws -> URL {
         let mapper = CharacterVoiceMapper()
-        _ = mapper.assignVoices(to: text)
+        _ = mapper.assignVoicesSelective(to: text)
 
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = voice
@@ -59,7 +59,7 @@ struct BookExporter {
     #else
     static func exportAudiobook(text: String, to url: URL, voice: Any? = nil, rate: Float = 0) throws -> URL {
         let mapper = CharacterVoiceMapper()
-        _ = mapper.assignVoices(to: text)
+        _ = mapper.assignVoicesSelective(to: text)
         try text.write(to: url, atomically: true, encoding: .utf8)
         return url
     }


### PR DESCRIPTION
## Summary
- enable manual voice selection for characters with extensive dialogue via `assignVoicesSelective`
- update audiobook and video export flows to use new selective voice mapping
- cover edge cases with new unit test for manual voice overrides

## Testing
- `swift test --filter CharacterVoiceMapperTests`
- `npm test` *(fails: TSError during CoreForgeBuild tests)*

------
https://chatgpt.com/codex/tasks/task_e_685f2f327e6883219d29a8cab842cc78