### PR TITLE
Implement AutoVoiceSelector accent logic

### DIFF
--- a/Sources/CreatorCoreForge/AutoVoiceSelector.swift
+++ b/Sources/CreatorCoreForge/AutoVoiceSelector.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Automatically select narrator and character accents for an entire document.
+public struct AutoVoiceSelector {
+    private let mapper: CharacterVoiceMapper
+
+    public init(mapper: CharacterVoiceMapper = CharacterVoiceMapper()) {
+        self.mapper = mapper
+    }
+
+    public struct CharacterAccent {
+        public let name: String
+        public let voice: String
+        public let accent: MultiLanguageAccentNarrator.VoiceAccent
+    }
+
+    /// Select accents for narrator and all detected characters.
+    /// - Parameter text: Full book or document text.
+    /// - Returns: Narrator accent and per-character accent mapping.
+    public func selectVoices(for text: String) -> (narrator: MultiLanguageAccentNarrator.VoiceAccent, characters: [CharacterAccent]) {
+        let narratorAccent = Self.guessAccent(in: text)
+        let voiceMaps = mapper.assignVoices(to: text)
+        let nsText = text as NSString
+        var results: [CharacterAccent] = []
+        for map in voiceMaps {
+            let range = nsText.range(of: map.name, options: .caseInsensitive)
+            let snippet: String
+            if range.location != NSNotFound {
+                let start = max(0, range.location - 80)
+                let len = min(nsText.length - start, 160)
+                snippet = nsText.substring(with: NSRange(location: start, length: len))
+            } else {
+                snippet = ""
+            }
+            let accent = Self.guessAccent(in: snippet)
+            results.append(CharacterAccent(name: map.name, voice: map.assignedVoice, accent: accent))
+        }
+        return (narratorAccent, results)
+    }
+
+    private static func guessAccent(in text: String) -> MultiLanguageAccentNarrator.VoiceAccent {
+        let lower = text.lowercased()
+        if lower.contains("british") || lower.contains("london") || lower.contains("england") {
+            return .british
+        }
+        if lower.contains("french") || lower.contains("paris") || lower.contains("france") {
+            return .french
+        }
+        if lower.contains("german") || lower.contains("berlin") || lower.contains("germany") {
+            return .german
+        }
+        if lower.contains("italian") || lower.contains("rome") || lower.contains("italy") {
+            return .italian
+        }
+        if lower.contains("spanish") || lower.contains("madrid") || lower.contains("spain") {
+            return .spanish
+        }
+        return .american
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AutoVoiceSelectorTests.swift
+++ b/Tests/CreatorCoreForgeTests/AutoVoiceSelectorTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AutoVoiceSelectorTests: XCTestCase {
+    func testSelectVoicesDetectsAccents() {
+        let text = """
+        The story begins in London.
+        Alice, the French spy: Bonjour.
+        Bob from Germany: Guten tag.
+        """
+        let selector = AutoVoiceSelector()
+        let result = selector.selectVoices(for: text)
+        XCTAssertEqual(result.narrator, .british)
+        let map = Dictionary(uniqueKeysWithValues: result.characters.map { ($0.name, $0.accent) })
+        XCTAssertEqual(map["Alice"], .french)
+        XCTAssertEqual(map["Bob"], .german)
+    }
+
+    func testDefaultsToAmericanAccent() {
+        let text = "John: Hello there."
+        let selector = AutoVoiceSelector()
+        let result = selector.selectVoices(for: text)
+        XCTAssertEqual(result.narrator, .american)
+        let map = Dictionary(uniqueKeysWithValues: result.characters.map { ($0.name, $0.accent) })
+        XCTAssertEqual(map["John"], .american)
+    }
+}


### PR DESCRIPTION
## Summary
- add `AutoVoiceSelector` to detect narrator and character accents by heuristic
- test accent detection logic in `AutoVoiceSelectorTests`

## Testing
- `swift test --enable-test-discovery` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f31a69d2c83218312ad16700bf1a2