### PR TITLE
Enable narrator voice assignment and selective casting

### DIFF
--- a/Sources/CreatorCoreForge/CharacterVoiceMapper.swift
+++ b/Sources/CreatorCoreForge/CharacterVoiceMapper.swift
@@ -11,6 +11,7 @@ public final class CharacterVoiceMapper {
     private var knownCharacters: [String: String] = [:]
     private let availableVoices: [String]
     private var voiceIndex = 0
+    private var narratorVoice: String?
 
     /// Create a mapper with an optional custom list of voices.
     public init(voices: [String] = [
@@ -86,7 +87,11 @@ public final class CharacterVoiceMapper {
     /// Characters with more than 10 sentences will be passed to `manualSelector`
     /// for a custom voice choice. Others receive automatic round-robin voices.
     public func assignVoicesSelective(to ebookText: String,
+                                      narratorVoice: String? = nil,
                                       manualSelector: ((String, [String]) -> String?)? = nil) -> [CharacterVoiceMap] {
+        if let nv = narratorVoice {
+            setNarratorVoice(nv)
+        }
         let lines = ebookText.components(separatedBy: "\n")
         let separators = [":", " - ", " — "]
         var counts: [String: Int] = [:]
@@ -118,6 +123,10 @@ public final class CharacterVoiceMapper {
             knownCharacters[name] = voice
             results.append(CharacterVoiceMap(name: name, assignedVoice: voice))
         }
+        if let nv = narratorVoice ?? self.narratorVoice {
+            knownCharacters["Narrator"] = nv
+            results.append(CharacterVoiceMap(name: "Narrator", assignedVoice: nv))
+        }
         return results
     }
 
@@ -137,5 +146,16 @@ public final class CharacterVoiceMapper {
         for (name, voice) in knownCharacters {
             print("\(name): \(voice)")
         }
+    }
+
+    /// Manually set the voice used for narration segments.
+    public func setNarratorVoice(_ voice: String) {
+        narratorVoice = voice
+        knownCharacters["Narrator"] = voice
+    }
+
+    /// Retrieve the currently selected narrator voice, if any.
+    public func getNarratorVoice() -> String? {
+        narratorVoice
     }
 }

--- a/Tests/CreatorCoreForgeTests/CharacterVoiceMapperTests.swift
+++ b/Tests/CreatorCoreForgeTests/CharacterVoiceMapperTests.swift
@@ -45,4 +45,12 @@ final class CharacterVoiceMapperTests: XCTestCase {
         XCTAssertEqual(alice.assignedVoice, "Manual")
         XCTAssertEqual(bob.assignedVoice, "Auto1")
     }
+
+    func testNarratorVoiceAssignment() {
+        let mapper = CharacterVoiceMapper()
+        let result = mapper.assignVoicesSelective(to: "Alice: Hi.", narratorVoice: "Storyteller")
+        let narrator = result.first { $0.name == "Narrator" }!
+        XCTAssertEqual(narrator.assignedVoice, "Storyteller")
+        XCTAssertEqual(mapper.getNarratorVoice(), "Storyteller")
+    }
 }

--- a/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/VisualMemoryManager.swift
+++ b/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/VisualMemoryManager.swift
@@ -27,6 +27,7 @@ public struct VisualMemorySnapshot: Codable {
     public let locationModels: [String: String]
     public let seriesThemes: [String]
     public let characterArcs: [String: [Int: CharacterVisualState]]
+    public let narratorVoice: String?
 }
 
 /// Manages visual memory across books and scenes.
@@ -45,6 +46,7 @@ public final class VisualMemoryManager {
     public private(set) var memoryGraph: [SceneKey: [SceneKey]] = [:]
     public private(set) var memoryGraphIntegrated = false
     public private(set) var handoffHistory: [String] = []
+    public private(set) var narratorVoice: String?
 
     public init() {}
 
@@ -88,6 +90,14 @@ public final class VisualMemoryManager {
     public func recordVisualArc(character: String, scene: Int, state: CharacterVisualState) {
         characterArcs[character, default: [:]][scene] = state
     }
+
+    /// Set the voice used for narration segments.
+    public func setNarratorVoice(_ voice: String) {
+        narratorVoice = voice
+    }
+
+    /// Retrieve the currently selected narrator voice.
+    public func getNarratorVoice() -> String? { narratorVoice }
 
     /// Suggest framing technique based on memory weight.
     public func adaptFraming(weight: Double) -> String {
@@ -184,7 +194,8 @@ public final class VisualMemoryManager {
             fxHistory: fxHistory,
             locationModels: locationModels,
             seriesThemes: Array(seriesThemes),
-            characterArcs: characterArcs)
+            characterArcs: characterArcs,
+            narratorVoice: narratorVoice)
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("memory-\(account).json")
         do {

--- a/apps/CoreForgeVisual/LoreForgeAIFull/Tests/LoreForgeAITests/VisualMemoryManagerTests.swift
+++ b/apps/CoreForgeVisual/LoreForgeAIFull/Tests/LoreForgeAITests/VisualMemoryManagerTests.swift
@@ -30,5 +30,11 @@ final class VisualMemoryManagerTests: XCTestCase {
         XCTAssertTrue(issues.contains("mood"))
         XCTAssertFalse(issues.contains("outfit"))
     }
+
+    func testNarratorVoiceStorage() {
+        let manager = VisualMemoryManager()
+        manager.setNarratorVoice("Calm")
+        XCTAssertEqual(manager.getNarratorVoice(), "Calm")
+    }
 }
 


### PR DESCRIPTION
## Summary
- allow specifying a narrator voice inside `CharacterVoiceMapper`
- expose narrator voice in `VisualMemoryManager` and snapshots
- support setting/getting narrator voice via new APIs
- add tests for narrator voice handling in audio and visual modules

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f31f72e6483219ca45b524316c5b2