### PR TITLE
Add series-based voice memory

### DIFF
--- a/Sources/CreatorCoreForge/VoiceMemoryManager.swift
+++ b/Sources/CreatorCoreForge/VoiceMemoryManager.swift
@@ -56,6 +56,30 @@ public final class VoiceMemoryManager {
         persist()
     }
 
+    /// Retrieve all voice assignments for a specific series.
+    /// - Parameter series: Series identifier used when assigning voices.
+    /// - Returns: Mapping of character names to voice IDs.
+    public func assignments(for series: String) -> [String: String] {
+        let prefix = series.lowercased() + "|"
+        var result: [String: String] = [:]
+        for (key, value) in assignments where key.hasPrefix(prefix) {
+            let character = String(key.dropFirst(prefix.count))
+            result[character] = value
+        }
+        return result
+    }
+
+    /// Retrieve all assignments grouped by series name.
+    public func allAssignments() -> [String: [String: String]] {
+        var grouped: [String: [String: String]] = [:]
+        for (key, value) in assignments {
+            let parts = key.split(separator: "|", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            grouped[parts[0], default: [:]][parts[1]] = value
+        }
+        return grouped
+    }
+
     private func persist() {
         userDefaults.set(assignments, forKey: key)
         if let data = try? JSONSerialization.data(withJSONObject: assignments, options: []) {

--- a/Tests/CreatorCoreForgeTests/VoiceMemoryManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceMemoryManagerTests.swift
@@ -31,4 +31,18 @@ final class VoiceMemoryManagerTests: XCTestCase {
         manager = VoiceMemoryManager(userDefaults: UserDefaults(suiteName: UUID().uuidString)!, directory: tempDir)
         XCTAssertEqual(manager.voiceID(for: "Alice", in: "Saga"), "V1")
     }
+
+    func testSeriesAssignmentsRetrieval() {
+        let manager = VoiceMemoryManager.shared
+        manager.clear(series: "Epic")
+        manager.assign(voiceID: "VA", to: "Hero", in: "Epic")
+        manager.assign(voiceID: "VB", to: "Villain", in: "Epic")
+
+        let map = manager.assignments(for: "Epic")
+        XCTAssertEqual(map["Hero"], "VA")
+        XCTAssertEqual(map["Villain"], "VB")
+
+        let grouped = manager.allAssignments()
+        XCTAssertEqual(grouped["Epic"]?["Hero"], "VA")
+    }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift
@@ -49,6 +49,6 @@ final class AppleBooksService {
         let chapters = paragraphs.enumerated().map { idx, str in
             Chapter(title: "Part \(idx + 1)", text: str.trimmingCharacters(in: .whitespacesAndNewlines))
         }
-        return Book(title: book.title, author: book.author, chapters: chapters)
+        return Book(title: book.title, author: book.author, series: nil, chapters: chapters)
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookCardView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookCardView.swift
@@ -42,7 +42,7 @@ struct BookCardView: View {
 }
 
 #Preview {
-    BookCardView(book: Book(title: "Sample", author: "Author", chapters: []))
+    BookCardView(book: Book(title: "Sample", author: "Author", series: nil, chapters: []))
         .environmentObject(LibraryModel())
 }
 #endif

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift
@@ -43,7 +43,8 @@ struct BookDetailView: View {
             }
         }
         .sheet(isPresented: $showVoiceCast) {
-            VoiceCastView(characters: extractCharacters(from: book))
+            VoiceCastView(characters: extractCharacters(from: book),
+                          series: book.series ?? book.title)
         }
     }
 

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CharacterVoiceMemory.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CharacterVoiceMemory.swift
@@ -1,44 +1,30 @@
 import Foundation
+import CreatorCoreForge
 
-/// Stores persistent voice assignments for characters across different book series.
+/// Wrapper around `VoiceMemoryManager` exposing simple helpers for the app.
 final class CharacterVoiceMemory {
     static let shared = CharacterVoiceMemory()
-    private var assignments: [String: String] = [:] // character -> voiceID
-    private let userDefaultsKey = "CharacterVoiceAssignments"
+    private let manager = VoiceMemoryManager.shared
 
-    private init() {
-        if let saved = UserDefaults.standard.dictionary(forKey: userDefaultsKey) as? [String: String] {
-            assignments = saved
-        }
+    private init() {}
+
+    func assignVoice(_ voice: Voice, to character: String, in series: String) {
+        manager.assign(voiceID: voice.id, to: character, in: series)
     }
 
-    func assignVoice(_ voice: Voice, to character: String) {
-        assignments[character.lowercased()] = voice.id
-        persist()
-    }
-
-    /// Return the assigned voice for a given character. If no explicit
-    /// assignment exists, fall back to the default voice so callers never
-    /// receive `nil`.
-    func voiceForCharacter(_ character: String) -> Voice {
-        if let id = assignments[character.lowercased()],
+    func voiceForCharacter(_ character: String, in series: String) -> Voice {
+        if let id = manager.voiceID(for: character, in: series),
            let voice = VoiceConfig.voices.first(where: { $0.id == id }) {
             return voice
         }
         return VoiceConfig.voices.first ?? Voice(id: "default", name: "Default")
     }
 
-    func clearAll() {
-        assignments.removeAll()
-        persist()
+    func assignments(for series: String) -> [String: String] {
+        manager.assignments(for: series)
     }
 
-    private func persist() {
-        UserDefaults.standard.set(assignments, forKey: userDefaultsKey)
-    }
-
-    /// Return all stored character to voice ID assignments.
-    func allAssignments() -> [String: String] {
-        assignments
+    func allAssignments() -> [String: [String: String]] {
+        manager.allAssignments()
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift
@@ -24,7 +24,7 @@ struct ImportView: View {
             case .success(let urls):
                 if let url = urls.first {
                     let chapters = EbookImporter().importEbook(from: url.path).map { Chapter(title: "Chapter", text: $0) }
-                    let book = Book(title: url.lastPathComponent, author: "", chapters: chapters)
+                    let book = Book(title: url.lastPathComponent, author: "", series: nil, chapters: chapters)
                     library.addBook(book)
                     usage.recordImport()
                 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift
@@ -56,7 +56,7 @@ final class KindleService {
             let chapters = sections.enumerated().map { idx, str in
                 Chapter(title: "Section \(idx + 1)", text: str)
             }
-            completion(Book(title: book.title, author: book.author, chapters: chapters))
+            completion(Book(title: book.title, author: book.author, series: nil, chapters: chapters))
         }.resume()
     }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift
@@ -21,7 +21,7 @@ final class LibraryModel: ObservableObject {
             self.books = decoded
         } else {
             self.books = [
-                Book(title: "Sample Adventure", author: "A. Author", chapters: [
+                Book(title: "Sample Adventure", author: "A. Author", series: "Demo Saga", chapters: [
                     Chapter(title: "Intro", text: "@Hero begins the journey."),
                     Chapter(title: "Conflict", text: "@Villain appears in town.")
                 ])

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct VoiceCastView: View {
     @Environment(\.dismiss) private var dismiss
     let characters: [String]
+    let series: String
     @State private var selections: [String: String] = [:]
 
     private let voices = VoiceConfig.voices
@@ -14,7 +15,7 @@ struct VoiceCastView: View {
             Form {
                 ForEach(characters, id: \.self) { name in
                     Picker(name, selection: Binding(
-                        get: { selections[name] ?? CharacterVoiceMemory.shared.voiceForCharacter(name).id ?? voices.first?.id ?? "" },
+                        get: { selections[name] ?? CharacterVoiceMemory.shared.voiceForCharacter(name, in: series).id ?? voices.first?.id ?? "" },
                         set: { selections[name] = $0 }
                     )) {
                         ForEach(voices, id: \.id) { voice in
@@ -25,15 +26,23 @@ struct VoiceCastView: View {
             }
             .navigationTitle("Voice Cast")
             .toolbar {
+                Button("Use Previous") {
+                    let mem = CharacterVoiceMemory.shared.assignments(for: series)
+                    for (char, id) in mem { selections[char] = id }
+                }
                 Button("Done") {
                     for (char, id) in selections {
                         if let voice = voices.first(where: { $0.id == id }) {
-                            CharacterVoiceMemory.shared.assignVoice(voice, to: char)
+                            CharacterVoiceMemory.shared.assignVoice(voice, to: char, in: series)
                         }
                     }
                     dismiss()
                 }
             }
+        }
+        .onAppear {
+            let mem = CharacterVoiceMemory.shared.assignments(for: series)
+            for (char, id) in mem { selections[char] = id }
         }
     }
 }

--- a/apps/CoreForgeAudio/models/Book.swift
+++ b/apps/CoreForgeAudio/models/Book.swift
@@ -5,6 +5,8 @@ struct Book: Identifiable, Codable {
     let id: UUID
     var title: String
     var author: String
+    /// Optional series name for sequels or related books.
+    var series: String?
     var coverImage: String?
     var chapters: [Chapter]
     var progress: Double
@@ -15,6 +17,7 @@ struct Book: Identifiable, Codable {
     init(id: UUID = UUID(),
          title: String,
          author: String,
+         series: String? = nil,
          coverImage: String? = nil,
          chapters: [Chapter] = [],
          progress: Double = 0,
@@ -24,6 +27,7 @@ struct Book: Identifiable, Codable {
         self.id = id
         self.title = title
         self.author = author
+        self.series = series
         self.coverImage = coverImage
         self.chapters = chapters
         self.progress = progress

--- a/apps/CoreForgeAudio/views/FeaturedCarouselView.swift
+++ b/apps/CoreForgeAudio/views/FeaturedCarouselView.swift
@@ -49,8 +49,8 @@ struct FeaturedCarouselView: View {
 
 #Preview {
     FeaturedCarouselView(books: [
-        Book(title: "Sample", author: "A"),
-        Book(title: "Sample 2", author: "B")
+        Book(title: "Sample", author: "A", series: nil),
+        Book(title: "Sample 2", author: "B", series: nil)
     ])
     .environmentObject(LibraryModel())
 }

--- a/apps/CoreForgeAudio/views/ImportShortcutsPanel.swift
+++ b/apps/CoreForgeAudio/views/ImportShortcutsPanel.swift
@@ -52,7 +52,7 @@ struct ImportShortcutsPanel: View {
             #if canImport(VisionKit)
             DocumentScannerView { text in
                 let chapter = Chapter(title: "Scan", text: text)
-                let book = Book(title: "Scanned Document", author: "", chapters: [chapter])
+                let book = Book(title: "Scanned Document", author: "", series: nil, chapters: [chapter])
                 library.addBook(book)
                 usage.recordImport()
             }
@@ -72,6 +72,7 @@ struct ImportShortcutsPanel: View {
                         let chapters = try await BookImporter.importBook(from: url)
                         let book = Book(title: url.deletingPathExtension().lastPathComponent,
                                         author: "",
+                                        series: nil,
                                         chapters: chapters)
                         library.addBook(book)
                         usage.recordImport()
@@ -129,7 +130,7 @@ struct ImportShortcutsPanel: View {
                 let (localURL, _) = try await URLSession.shared.download(from: remoteURL)
                 let chapters = try await BookImporter.importBook(from: localURL)
                 let title = remoteURL.deletingPathExtension().lastPathComponent
-                let book = Book(title: title, author: "", chapters: chapters)
+                let book = Book(title: title, author: "", series: nil, chapters: chapters)
                 library.addBook(book)
                 usage.recordImport()
             } catch {

--- a/apps/CoreForgeAudio/views/MiniPlayerView.swift
+++ b/apps/CoreForgeAudio/views/MiniPlayerView.swift
@@ -38,7 +38,7 @@ struct MiniPlayerView: View {
 
         var body: some View {
             MiniPlayerView(
-                book: Book(title: "Sample Book", author: "Author"),
+                book: Book(title: "Sample Book", author: "Author", series: nil),
                 chapter: Chapter(title: "Chapter 1", text: "Sample"),
                 namespace: ns,
                 isExpanded: $expanded

--- a/apps/CoreForgeAudio/views/VoiceMemoryView.swift
+++ b/apps/CoreForgeAudio/views/VoiceMemoryView.swift
@@ -3,15 +3,21 @@ import SwiftUI
 
 /// Displays persistent character to voice assignments across books.
 struct VoiceMemoryView: View {
-    @State private var assignments: [(String, String)] = []
+    @State private var assignments: [String: [(String, String)]] = [:]
 
     var body: some View {
-        List(assignments, id: \.0) { character, voice in
-            HStack {
-                Text(character.capitalized)
-                Spacer()
-                Text(voice)
-                    .foregroundColor(.secondary)
+        List {
+            ForEach(assignments.keys.sorted(), id: \.self) { series in
+                Section(header: Text(series.capitalized)) {
+                    ForEach(assignments[series]!, id: \.0) { character, voice in
+                        HStack {
+                            Text(character.capitalized)
+                            Spacer()
+                            Text(voice)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
             }
         }
         .onAppear(perform: loadAssignments)
@@ -19,10 +25,14 @@ struct VoiceMemoryView: View {
     }
 
     private func loadAssignments() {
-        assignments = CharacterVoiceMemory.shared.allAssignments().map { (char, voiceID) in
-            let name = VoiceConfig.voices.first { $0.id == voiceID }?.name ?? voiceID
-            return (char, name)
-        }
+        let all = CharacterVoiceMemory.shared.allAssignments()
+        assignments = Dictionary(uniqueKeysWithValues: all.map { series, map in
+            let entries = map.map { (char, id) in
+                let name = VoiceConfig.voices.first { $0.id == id }?.name ?? id
+                return (char, name)
+            }
+            return (series, entries)
+        })
     }
 }
 

--- a/apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp/LibraryView.swift
+++ b/apps/CoreForgeLibrary/LibraryApp/CoreForgeLibraryApp/LibraryView.swift
@@ -86,11 +86,11 @@ struct LibraryView: View {
 }
 
 private let demoBooks: [Book] = [
-    Book(title: "Sample Adventure", author: "A. Author", chapters: [
+    Book(title: "Sample Adventure", author: "A. Author", series: nil, chapters: [
         Chapter(title: "Intro", text: "Welcome to the adventure."),
         Chapter(title: "Conflict", text: "The story continues.")
     ]),
-    Book(title: "Mystery Night", author: "B. Writer", chapters: [
+    Book(title: "Mystery Night", author: "B. Writer", series: nil, chapters: [
         Chapter(title: "Start", text: "It was a dark night."),
         Chapter(title: "Clue", text: "A clue appears.")
     ])


### PR DESCRIPTION
## Summary
- extend `VoiceMemoryManager` with series helper APIs
- bridge `CharacterVoiceMemory` to `VoiceMemoryManager`
- include series field on `Book` model
- preload previous assignments when casting voices and allow quick reuse
- show series sections in voice memory view
- adjust demo data and creation points
- expand tests for voice memory

## Testing
- `swift test -q` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685f38c0dd98832197c2767de8a7df22