### PR TITLE
Add daily top voices to voice selector

### DIFF
--- a/Sources/CreatorCoreForge/AppFavoriteVoiceService.swift
+++ b/Sources/CreatorCoreForge/AppFavoriteVoiceService.swift
@@ -1,0 +1,49 @@
+import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+
+/// Tracks app-wide voice usage and exposes daily top voices.
+public final class AppFavoriteVoiceService: ObservableObject {
+    public static let shared = AppFavoriteVoiceService()
+
+    @Published public private(set) var dailyTopVoiceIDs: [String]
+
+    private let usageKey = "AFV_Usage"
+    private let topKey = "AFV_Top"
+    private let dateKey = "AFV_Last"
+    private var usage: [String: Int]
+    private var lastUpdate: Date
+    private let store: UserDefaults
+
+    public init(store: UserDefaults = .standard) {
+        self.store = store
+        self.usage = store.dictionary(forKey: usageKey) as? [String: Int] ?? [:]
+        self.dailyTopVoiceIDs = store.array(forKey: topKey) as? [String] ?? []
+        self.lastUpdate = store.object(forKey: dateKey) as? Date ?? Date()
+        updateIfNeeded(for: Date())
+    }
+
+    /// Record a voice usage event.
+    public func recordUsage(voiceID: String) {
+        updateIfNeeded(for: Date())
+        usage[voiceID, default: 0] += 1
+        store.set(usage, forKey: usageKey)
+    }
+
+    /// Updates daily favorites if a new day has started.
+    @discardableResult
+    public func updateIfNeeded(for date: Date) -> Bool {
+        let start = Calendar.current.startOfDay(for: date)
+        guard lastUpdate < start else { return false }
+        dailyTopVoiceIDs = usage.sorted { $0.value > $1.value }
+            .prefix(10)
+            .map { $0.key }
+        store.set(dailyTopVoiceIDs, forKey: topKey)
+        usage.removeAll()
+        store.set(usage, forKey: usageKey)
+        lastUpdate = start
+        store.set(lastUpdate, forKey: dateKey)
+        return true
+    }
+}

--- a/Tests/CreatorCoreForgeTests/AppFavoriteVoiceServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/AppFavoriteVoiceServiceTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AppFavoriteVoiceServiceTests: XCTestCase {
+    func testDailyTopUpdates() {
+        let suite = UserDefaults(suiteName: "AppFavVoiceTest")!
+        suite.removePersistentDomain(forName: "AppFavVoiceTest")
+        let service = AppFavoriteVoiceService(store: suite)
+        service.recordUsage(voiceID: "v1")
+        service.recordUsage(voiceID: "v1")
+        service.recordUsage(voiceID: "v2")
+
+        // simulate next day
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        _ = service.updateIfNeeded(for: tomorrow)
+
+        XCTAssertEqual(service.dailyTopVoiceIDs.first, "v1")
+        XCTAssertEqual(service.dailyTopVoiceIDs.count, 2)
+    }
+}

--- a/apps/CoreForgeAudio/components/VoicePickerView.swift
+++ b/apps/CoreForgeAudio/components/VoicePickerView.swift
@@ -1,16 +1,44 @@
 #if canImport(SwiftUI)
 import SwiftUI
+import CreatorCoreForge
 
 /// Dropdown for selecting an active narration voice.
 struct VoicePickerView: View {
     @Binding var voice: String
+    @ObservedObject private var appFav = AppFavoriteVoiceService.shared
     private let voices = VoiceConfig.voiceNames
 
     var body: some View {
-        Picker("Voice", selection: $voice) {
-            ForEach(voices, id: \.self) { Text($0) }
+        Menu {
+            if !appFavoriteNames.isEmpty {
+                Text("App Favorites")
+                ForEach(appFavoriteNames, id: \.self) { name in
+                    Button(name) { select(name) }
+                }
+                Divider()
+            }
+            ForEach(voices, id: \.self) { name in
+                Button(name) { select(name) }
+            }
+        } label: {
+            HStack {
+                Text(voice)
+                Image(systemName: "chevron.down")
+            }
         }
-        .pickerStyle(.menu)
+    }
+
+    private var appFavoriteNames: [String] {
+        appFav.dailyTopVoiceIDs.compactMap { id in
+            VoiceConfig.voices.first { $0.id == id }?.name
+        }
+    }
+
+    private func select(_ name: String) {
+        voice = name
+        if let id = VoiceConfig.voices.first(where: { $0.name == name })?.id {
+            appFav.recordUsage(voiceID: id)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show app favorite voices in the voice picker menu
- track daily voice usage with `AppFavoriteVoiceService`
- test daily top voice update logic

## Testing
- `swift test --filter AppFavoriteVoiceServiceTests`
- `npm test` *(fails: ts-node compile error)*

------
https://chatgpt.com/codex/tasks/task_e_685f478ad484832198fc65b475b276c6