### PR TITLE
Add voice revision manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - Downloadable audiobooks with bookmarkable playback
   - Audiobook export engine (MP3/WAV with zip packaging via `AudiobookCompiler`)
   - OfflineTTSCache for local voice caching
+  - VoiceRevisionManager allows up to five full audiobook voice revisions within 30 days
   - AnalyticsLogger for basic event tracking
   - PerformanceModeSelector to switch rendering presets
   - FusionVoiceController orchestrates LocalVoiceAI and emotion cues

--- a/Sources/CreatorCoreForge/VoiceRevisionManager.swift
+++ b/Sources/CreatorCoreForge/VoiceRevisionManager.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Tracks free voice revisions for an audiobook project.
+public final class VoiceRevisionManager {
+    private let defaults: UserDefaults
+    private let dateKeyPrefix = "VRM_Date_"
+    private let countKeyPrefix = "VRM_Count_"
+    private let freeLimit = 5
+    private let freeDays = 30
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Returns true if a revision can be made without credits.
+    public func canRevise(bookID: String) -> Bool {
+        resetIfNeeded(bookID: bookID)
+        return defaults.integer(forKey: countKeyPrefix + bookID) < freeLimit
+    }
+
+    /// Record a revision for the given book.
+    public func recordRevision(bookID: String) {
+        resetIfNeeded(bookID: bookID)
+        let key = countKeyPrefix + bookID
+        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+    }
+
+    /// Indicates whether credits are required for another revision.
+    public func requiresCredit(bookID: String) -> Bool {
+        !canRevise(bookID: bookID)
+    }
+
+    private func resetIfNeeded(bookID: String) {
+        let dateKey = dateKeyPrefix + bookID
+        let countKey = countKeyPrefix + bookID
+        let now = Date()
+        if let created = defaults.object(forKey: dateKey) as? Date {
+            if let days = Calendar.current.dateComponents([.day], from: created, to: now).day, days >= freeDays {
+                defaults.set(now, forKey: dateKey)
+                defaults.set(0, forKey: countKey)
+            }
+        } else {
+            defaults.set(now, forKey: dateKey)
+            defaults.set(0, forKey: countKey)
+        }
+    }
+}

--- a/Tests/CreatorCoreForgeTests/VoiceRevisionManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/VoiceRevisionManagerTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class VoiceRevisionManagerTests: XCTestCase {
+    func testFreeRevisionsLimit() {
+        let suite = UserDefaults(suiteName: "VRMFree")!
+        suite.removePersistentDomain(forName: "VRMFree")
+        let manager = VoiceRevisionManager(defaults: suite)
+        let id = "book1"
+        for _ in 0..<5 {
+            XCTAssertTrue(manager.canRevise(bookID: id))
+            manager.recordRevision(bookID: id)
+        }
+        XCTAssertFalse(manager.canRevise(bookID: id))
+        XCTAssertTrue(manager.requiresCredit(bookID: id))
+        suite.removePersistentDomain(forName: "VRMFree")
+    }
+
+    func testRevisionResetAfterThirtyDays() {
+        let suite = UserDefaults(suiteName: "VRMReset")!
+        let id = "book2"
+        let dateKey = "VRM_Date_" + id
+        let countKey = "VRM_Count_" + id
+        suite.set(Date(timeIntervalSinceNow: -60*60*24*31), forKey: dateKey)
+        suite.set(4, forKey: countKey)
+        let manager = VoiceRevisionManager(defaults: suite)
+        XCTAssertTrue(manager.canRevise(bookID: id))
+        XCTAssertEqual(suite.integer(forKey: countKey), 0)
+        suite.removePersistentDomain(forName: "VRMReset")
+    }
+}

--- a/apps/CoreForgeAudio/README.md
+++ b/apps/CoreForgeAudio/README.md
@@ -22,6 +22,7 @@ vault system. It is written in SwiftUI and will expand to additional platforms.
 - **Audiobook compilation** with `AudiobookCompiler` for zipped exports
 - **Scene memory simulator** for replaying chapters in different moods
 - **Multi-cast audiobook generation** via `MultiCastAudiobookGenerator`
+- **VoiceRevisionManager** allows five full audiobook voice changes within the first 30 days
 - **Immersive dramatized production** with `DramatizedAudiobookProducer`
 - **Dashboard** tab with usage analytics and achievements
 - **Favorite Voices** tab for quickly selecting preferred voices

--- a/docs/PHASE_EIGHT.md
+++ b/docs/PHASE_EIGHT.md
@@ -127,6 +127,7 @@ Only a subset of those features are shown below for brevity.
 - [x] QuantumSceneLogic
 - [x] NeuralOptimizer
 - [x] CreditSystem
+- [x] VoiceRevisionManager
 - [x] OfflineDownloadQueue
 - [x] ExportTools
 - [x] NSFWVoiceEngine

--- a/features-phase8.json
+++ b/features-phase8.json
@@ -94,6 +94,7 @@
       "QuantumSceneLogic",
       "NeuralOptimizer",
       "CreditSystem",
+      "VoiceRevisionManager",
       "OfflineDownloadQueue",
       "ExportTools",
       "NSFWVoiceEngine",


### PR DESCRIPTION
## Summary
- implement `VoiceRevisionManager` to track up to five free audiobook voice revisions within 30 days
- document revision limits in README and CoreForge Audio README
- list `VoiceRevisionManager` in `features-phase8.json` and `PHASE_EIGHT.md`
- add unit tests for revision behavior

## Testing
- `npm test --silent`
- `swift test --filter VoiceRevisionManagerTests` *(failed to complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685f485731c88321862c68f546e8a43a