### PR TITLE
Add daily app favorite voice tracking

### DIFF
--- a/Tests/CreatorCoreForgeTests/AppFavoriteVoiceServiceTests.swift
+++ b/Tests/CreatorCoreForgeTests/AppFavoriteVoiceServiceTests.swift
@@ -17,4 +17,19 @@ final class AppFavoriteVoiceServiceTests: XCTestCase {
         XCTAssertEqual(service.dailyTopVoiceIDs.first, "v1")
         XCTAssertEqual(service.dailyTopVoiceIDs.count, 2)
     }
+
+    func testTopListLimitedToTen() {
+        let suite = UserDefaults(suiteName: "AppFavLimitTest")!
+        suite.removePersistentDomain(forName: "AppFavLimitTest")
+        let service = AppFavoriteVoiceService(store: suite)
+        for i in 0..<15 {
+            for _ in 0...i {
+                service.recordUsage(voiceID: "v\(i)")
+            }
+        }
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: Date())!
+        _ = service.updateIfNeeded(for: tomorrow)
+        XCTAssertEqual(service.dailyTopVoiceIDs.count, 10)
+        XCTAssertEqual(service.dailyTopVoiceIDs.first, "v14")
+    }
 }

--- a/apps/CoreForgeAudio/components/VoicePickerView.swift
+++ b/apps/CoreForgeAudio/components/VoicePickerView.swift
@@ -26,6 +26,7 @@ struct VoicePickerView: View {
                 Image(systemName: "chevron.down")
             }
         }
+        .onAppear { appFav.updateIfNeeded(for: Date()) }
     }
 
     private var appFavoriteNames: [String] {


### PR DESCRIPTION
## Summary
- update `VoicePickerView` to refresh daily top voices on appear
- add test ensuring AppFavoriteVoiceService limits list to 10 voices

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_685fba437ec483218b2bc1366499ad3c