### PR TITLE
Implement NSFW add-on gating

### DIFF
--- a/Sources/CreatorCoreForge/NSFWAddonManager.swift
+++ b/Sources/CreatorCoreForge/NSFWAddonManager.swift
@@ -1,0 +1,53 @@
+import Foundation
+#if canImport(SwiftyStoreKit)
+import SwiftyStoreKit
+#endif
+
+/// Manages the NSFW monthly add-on purchase for Free and Creator tiers.
+public final class NSFWAddonManager {
+    public static let shared = NSFWAddonManager()
+    private let defaults: UserDefaults
+
+    public init(userDefaults: UserDefaults = .standard) {
+        self.defaults = userDefaults
+    }
+
+    private let productId = "nsfw_addon"
+    private let unlockKey = "SubMgrNSFW"
+
+    public var isUnlocked: Bool {
+        defaults.bool(forKey: unlockKey)
+    }
+
+    /// Purchase the NSFW add-on. Success sets the unlock flag.
+    public func purchase(completion: @escaping (Bool) -> Void) {
+#if canImport(SwiftyStoreKit)
+        SwiftyStoreKit.purchaseProduct(productId, quantity: 1, atomically: true) { result in
+            switch result {
+            case .success(let purchase):
+                SwiftyStoreKit.finishTransaction(purchase.transaction)
+                self.defaults.set(true, forKey: self.unlockKey)
+                completion(true)
+            case .error:
+                completion(false)
+            }
+        }
+#else
+        defaults.set(true, forKey: unlockKey)
+        completion(true)
+#endif
+    }
+
+    /// Restore purchases and update the unlock flag.
+    public func restore(completion: @escaping (Bool) -> Void) {
+#if canImport(SwiftyStoreKit)
+        SwiftyStoreKit.restorePurchases { results in
+            let success = !results.restoreFailedPurchases.isEmpty || !results.restoredPurchases.isEmpty
+            if success { self.defaults.set(true, forKey: self.unlockKey) }
+            completion(success)
+        }
+#else
+        completion(isUnlocked)
+#endif
+    }
+}

--- a/Sources/CreatorCoreForge/StoreKitManager.swift
+++ b/Sources/CreatorCoreForge/StoreKitManager.swift
@@ -1,0 +1,36 @@
+import Foundation
+#if canImport(SwiftyStoreKit)
+import SwiftyStoreKit
+#endif
+
+/// Lightweight wrapper around StoreKit used for internal purchases.
+public final class StoreKitManager {
+    public static let shared = StoreKitManager()
+    private init() {}
+
+    public func purchase(productId: String, completion: @escaping (Bool) -> Void) {
+#if canImport(SwiftyStoreKit)
+        SwiftyStoreKit.purchaseProduct(productId, quantity: 1, atomically: true) { result in
+            switch result {
+            case .success(let purchase):
+                SwiftyStoreKit.finishTransaction(purchase.transaction)
+                completion(true)
+            case .error:
+                completion(false)
+            }
+        }
+#else
+        completion(true)
+#endif
+    }
+
+    public func restore(completion: @escaping () -> Void) {
+#if canImport(SwiftyStoreKit)
+        SwiftyStoreKit.restorePurchases { _ in
+            completion()
+        }
+#else
+        completion()
+#endif
+    }
+}

--- a/Tests/CreatorCoreForgeTests/NSFWAddonManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/NSFWAddonManagerTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class NSFWAddonManagerTests: XCTestCase {
+    func testPurchaseUnlocksFlag() {
+        let defaults = UserDefaults(suiteName: "AddonTest")!
+        defaults.removePersistentDomain(forName: "AddonTest")
+        let manager = NSFWAddonManager(userDefaults: defaults)
+        manager.purchase { success in
+            XCTAssertTrue(success)
+            XCTAssertTrue(manager.isUnlocked)
+        }
+        defaults.removePersistentDomain(forName: "AddonTest")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/SubscriptionManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/SubscriptionManagerTests.swift
@@ -21,4 +21,15 @@ final class SubscriptionManagerTests: XCTestCase {
         XCTAssertTrue(manager.canExport())
         suite.removePersistentDomain(forName: "SubMgr")
     }
+
+    func testNSFWUnlock() {
+        let suite = UserDefaults(suiteName: "SubMgrNSFW")!
+        var manager = SubscriptionManager(plan: .creator, userDefaults: suite)
+        XCTAssertFalse(manager.isNSFWUnlocked)
+        manager.unlockNSFW()
+        XCTAssertTrue(manager.isNSFWUnlocked)
+        manager.upgrade(to: .enterprise)
+        XCTAssertTrue(manager.isNSFWUnlocked)
+        suite.removePersistentDomain(forName: "SubMgrNSFW")
+    }
 }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
@@ -10,6 +10,7 @@ struct PlayerView: View {
     @EnvironmentObject var library: LibraryModel
     @EnvironmentObject var usage: UsageStats
     @EnvironmentObject var prefs: UserPreferences
+    @AppStorage("isNSFWUnlocked") private var isNSFWUnlocked = false
 #if canImport(AVFoundation)
     @StateObject private var highlighter = SpeechHighlighter()
 #endif
@@ -67,7 +68,8 @@ struct PlayerView: View {
 
 #if canImport(AVFoundation)
     private func toggleSpeech(text: String) {
-        guard ContentPolicyManager.isAllowed(text: text, nsfw: prefs.nsfwEnabled, age: prefs.age) else {
+        let nsfwAllowed = prefs.nsfwEnabled && isNSFWUnlocked
+        guard ContentPolicyManager.isAllowed(text: text, nsfw: nsfwAllowed, age: prefs.age) else {
             isSpeaking = false
             return
         }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
@@ -5,6 +5,7 @@ import CreatorCoreForge
 struct SettingsView: View {
     @AppStorage("selectedVoice") private var selectedVoice = "Default"
     @AppStorage("nsfwEnabled") private var nsfwEnabled = false
+    @AppStorage("isNSFWUnlocked") private var isNSFWUnlocked = false
     @AppStorage("parentalPIN") private var parentalPIN = "1234"
     @AppStorage("birthDate") private var birthDateString = ""
     @AppStorage("stealthMode") private var stealthMode = false
@@ -29,16 +30,24 @@ struct SettingsView: View {
                 }
 
                 Section(header: Text("Content")) {
-                    Toggle("Allow NSFW", isOn: Binding(
-                        get: { nsfwEnabled },
-                        set: { newValue in
-                            if newValue {
-                                showAgeSheet = true
-                            } else {
-                                nsfwEnabled = false
-                                NSFWSoundFXEngine.shared.stopAll()
+                    if isNSFWUnlocked {
+                        Toggle("Allow NSFW", isOn: Binding(
+                            get: { nsfwEnabled },
+                            set: { newValue in
+                                if newValue {
+                                    showAgeSheet = true
+                                } else {
+                                    nsfwEnabled = false
+                                    NSFWSoundFXEngine.shared.stopAll()
+                                }
+                            }))
+                    } else {
+                        Button("Unlock NSFW Mode ($4.99/month)") {
+                            NSFWAddonManager.shared.purchase { success in
+                                if success { isNSFWUnlocked = true }
                             }
-                        }))
+                        }
+                    }
                 }
 
                 Section(header: Text("Security")) {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/UserPreferences.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/UserPreferences.swift
@@ -8,6 +8,7 @@ final class UserPreferences: ObservableObject {
     static let shared = UserPreferences()
 
     @AppStorage("nsfwEnabled") var nsfwEnabled: Bool = false
+    @AppStorage("isNSFWUnlocked") var isNSFWUnlocked: Bool = false
     @AppStorage("wifiOnly") var wifiOnly: Bool = true
     @AppStorage("autoScroll") var autoScroll: Bool = false
     @AppStorage("selectedVoice") var selectedVoice: String = "Default"

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
@@ -7,8 +7,10 @@ struct VoiceCastView: View {
     let characters: [String]
     let series: String
     @State private var selections: [String: String] = [:]
+    @AppStorage("isNSFWUnlocked") private var isNSFWUnlocked = false
 
     private let voices = VoiceConfig.voices
+    private let nsfwVoices: Set<String> = ["ultra", "aisynth"]
 
     var body: some View {
         NavigationView {
@@ -19,7 +21,9 @@ struct VoiceCastView: View {
                         set: { selections[name] = $0 }
                     )) {
                         ForEach(voices, id: \.id) { voice in
-                            Text(voice.name).tag(voice.id)
+                            Text(voice.name)
+                                .tag(voice.id)
+                                .disabled(nsfwVoices.contains(voice.id) && !isNSFWUnlocked)
                         }
                     }
                 }

--- a/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/UI/SubscriptionPlanSelector.swift
+++ b/apps/CoreForgeVisual/LoreForgeAIFull/LoreForgeAI/UI/SubscriptionPlanSelector.swift
@@ -7,11 +7,21 @@ enum SubscriptionTier: String, CaseIterable {
     case free
     case creator
     case enterprise
+    case author
 }
 
 #if canImport(SwiftUI)
 struct SubscriptionPlanSelector: View {
     @Binding var tier: SubscriptionTier
+
+    private var nsfwInfo: String {
+        switch tier {
+        case .free, .creator:
+            return "NSFW Mode requires Add-On"
+        case .enterprise, .author:
+            return "NSFW Mode Included"
+        }
+    }
 
     var body: some View {
         Picker("Plan", selection: $tier) {
@@ -20,6 +30,8 @@ struct SubscriptionPlanSelector: View {
             }
         }
         .pickerStyle(.segmented)
+        Text(nsfwInfo)
+            .font(.caption)
     }
 }
 


### PR DESCRIPTION
## Summary
- add NSFWAddonManager to handle add-on purchases
- track NSFW unlock state in SubscriptionManager
- gate NSFW settings and player access
- disable NSFW voices without unlock
- show NSFW plan info in SubscriptionPlanSelector
- add unit tests for new managers

## Testing
- `swift test` *(fails: SceneDetectorTests, NSFWHabitBehaviorSimulatorTests, NextGenVideoGenerationTests)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fc62283dc8321bffb1e39a4b1438f