### PR TITLE
Implement subscription manager and pricing UI

### DIFF
--- a/apps/CoreForgeAudio/Managers/ExportManager.swift
+++ b/apps/CoreForgeAudio/Managers/ExportManager.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Handles credit-gated exports for audio projects.
+struct ExportManager {
+    static func export(usingCredits credits: Int = 1) -> Bool {
+        let sub = SubscriptionManager.shared
+        guard sub.consume(credits) else { return false }
+        // Placeholder export logic
+        return true
+    }
+}

--- a/apps/CoreForgeAudio/Managers/SubscriptionManager.swift
+++ b/apps/CoreForgeAudio/Managers/SubscriptionManager.swift
@@ -1,0 +1,94 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+import Foundation
+
+/// Tracks the active subscription tier, remaining credits and billing cycle.
+final class SubscriptionManager: ObservableObject {
+    static let shared = SubscriptionManager()
+
+    /// Subscription tiers available in the app.
+    enum Plan: String, CaseIterable {
+        case free
+        case creator
+        case enterprise
+        case authorPro
+
+        var displayName: String {
+            switch self {
+            case .free: return "Free"
+            case .creator: return "Creator"
+            case .enterprise: return "Enterprise"
+            case .authorPro: return "Author Pro"
+            }
+        }
+    }
+
+    /// Billing cycle for recurring subscriptions.
+    enum BillingCycle: String, CaseIterable {
+        case monthly
+        case annual
+
+        var displayName: String { rawValue.capitalized }
+    }
+
+    /// Info for each plan including pricing and credits.
+    struct PlanInfo {
+        let monthlyPrice: Double
+        let credits: Int
+        let nsfwIncluded: Bool
+    }
+
+    /// Pricing table with 3 months free on annual plans.
+    private let planInfo: [Plan: PlanInfo] = [
+        .free: PlanInfo(monthlyPrice: 0, credits: 20_000, nsfwIncluded: false),
+        .creator: PlanInfo(monthlyPrice: 19.99, credits: 150_000, nsfwIncluded: false),
+        .enterprise: PlanInfo(monthlyPrice: 49.99, credits: 600_000, nsfwIncluded: true),
+        .authorPro: PlanInfo(monthlyPrice: 99.99, credits: 2_000_000, nsfwIncluded: true)
+    ]
+
+    // Stored properties
+    @AppStorage("userTier") private var tierRaw: String = Plan.free.rawValue
+    @AppStorage("billingCycle") private var cycleRaw: String = BillingCycle.monthly.rawValue
+    @AppStorage("creditsRemaining") public var creditsRemaining: Int = 20_000
+
+    private init() {}
+
+    /// Currently active tier.
+    var tier: Plan { Plan(rawValue: tierRaw) ?? .free }
+
+    /// Current billing cycle.
+    var cycle: BillingCycle { BillingCycle(rawValue: cycleRaw) ?? .monthly }
+
+    /// Price for a given plan and cycle.
+    func price(for plan: Plan, cycle: BillingCycle) -> Double {
+        let monthly = planInfo[plan]?.monthlyPrice ?? 0
+        return cycle == .monthly ? monthly : monthly * 9 // 3 months free for annual
+    }
+
+    /// Credits included for a given plan.
+    func credits(for plan: Plan) -> Int { planInfo[plan]?.credits ?? 0 }
+
+    /// Whether NSFW features are included in the given plan.
+    func nsfwIncluded(in plan: Plan) -> Bool { planInfo[plan]?.nsfwIncluded ?? false }
+
+    /// Select a new plan and billing cycle.
+    func select(plan: Plan, cycle: BillingCycle) {
+        tierRaw = plan.rawValue
+        cycleRaw = cycle.rawValue
+        creditsRemaining = credits(for: plan)
+    }
+
+    /// Consume some credits if available.
+    @discardableResult
+    func consume(_ amount: Int) -> Bool {
+        guard creditsRemaining >= amount else { return false }
+        creditsRemaining -= amount
+        return true
+    }
+
+    /// Placeholder to refresh subscription status from StoreKit.
+    func refreshFromReceipt() {
+        // Actual StoreKit validation would go here.
+    }
+}

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift
@@ -10,6 +10,9 @@ struct PlayerView: View {
     @EnvironmentObject var library: LibraryModel
     @EnvironmentObject var usage: UsageStats
     @EnvironmentObject var prefs: UserPreferences
+#if canImport(SwiftUI)
+    @ObservedObject private var sub = SubscriptionManager.shared
+#endif
 #if canImport(AVFoundation)
     @StateObject private var highlighter = SpeechHighlighter()
 #endif
@@ -30,6 +33,9 @@ struct PlayerView: View {
                 VStack(spacing: 20) {
                     Text(chapter.title)
                         .font(.title)
+                        .foregroundColor(.white)
+                    Text("Credits: \(sub.creditsRemaining)")
+                        .font(.caption)
                         .foregroundColor(.white)
                     ScrollView {
                         if #available(iOS 15.0, *) {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift
@@ -15,6 +15,8 @@ struct SettingsView: View {
     @AppStorage("isLoggedIn") private var isLoggedIn = false
     @State private var showRegister = false
 
+    @ObservedObject private var sub = SubscriptionManager.shared
+
     private let voices = VoiceConfig.voices.map { $0.name }
 
     var body: some View {
@@ -44,6 +46,21 @@ struct SettingsView: View {
                 Section(header: Text("Security")) {
                     Button("Change PIN") { showPinPrompt = true }
                     Toggle("Stealth Vault", isOn: $stealthMode)
+                }
+                Section(header: Text("Subscription")) {
+                    HStack {
+                        Text("Plan")
+                        Spacer()
+                        Text(sub.tier.displayName)
+                    }
+                    HStack {
+                        Text("Credits")
+                        Spacer()
+                        Text("\(sub.creditsRemaining)")
+                    }
+                    NavigationLink("Upgrade") {
+                        TierUpgradeView()
+                    }
                 }
                 if !isLoggedIn {
                     Section(header: Text("Account")) {

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift
@@ -8,7 +8,16 @@ struct VoiceCastView: View {
     let series: String
     @State private var selections: [String: String] = [:]
 
-    private let voices = VoiceConfig.voices
+    @ObservedObject private var sub = SubscriptionManager.shared
+    private var voices: [Voice] {
+        if sub.tier == .enterprise || sub.tier == .authorPro {
+            return VoiceConfig.voices
+        } else {
+            return VoiceConfig.voices.filter { voice in
+                !["ultra", "aisynth", "hermes"].contains(voice.id)
+            }
+        }
+    }
 
     var body: some View {
         NavigationView {

--- a/apps/CoreForgeAudio/views/ExportView.swift
+++ b/apps/CoreForgeAudio/views/ExportView.swift
@@ -1,0 +1,25 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Simple export button that consumes credits via `ExportManager`.
+struct ExportView: View {
+    @State private var message = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Button("Export Project") {
+                if ExportManager.export() {
+                    message = "Export started"
+                } else {
+                    message = "Not enough credits"
+                }
+            }
+            Text(message)
+                .font(.caption)
+        }
+        .padding()
+    }
+}
+
+#Preview { ExportView() }
+#endif

--- a/apps/CoreForgeAudio/views/PricingView.swift
+++ b/apps/CoreForgeAudio/views/PricingView.swift
@@ -1,0 +1,50 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays pricing for all subscription tiers with monthly/annual toggle.
+struct PricingView: View {
+    @State private var cycle: SubscriptionManager.BillingCycle = .monthly
+    @ObservedObject private var manager = SubscriptionManager.shared
+
+    var body: some View {
+        VStack {
+            Picker("Billing", selection: $cycle) {
+                ForEach(SubscriptionManager.BillingCycle.allCases, id: \.self) { cycle in
+                    Text(cycle.displayName).tag(cycle)
+                }
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            List {
+                ForEach(SubscriptionManager.Plan.allCases, id: \.self) { plan in
+                    pricingRow(for: plan)
+                }
+            }
+        }
+    }
+
+    private func pricingRow(for plan: SubscriptionManager.Plan) -> some View {
+        let price = manager.price(for: plan, cycle: cycle)
+        let credits = manager.credits(for: plan)
+        let monthly = manager.price(for: plan, cycle: .monthly)
+        let savings = cycle == .annual ? monthly * 12 - price : 0
+        return HStack {
+            VStack(alignment: .leading) {
+                Text(plan.displayName).font(.headline)
+                Text("\(credits) credits").font(.caption)
+                if savings > 0 {
+                    Text(String(format: "Save $%.0f", savings))
+                        .font(.caption2)
+                        .foregroundStyle(.green)
+                }
+            }
+            Spacer()
+            Text(String(format: "$%.2f", price))
+                .bold()
+        }
+    }
+}
+
+#Preview {
+    PricingView()
+}
+#endif

--- a/apps/CoreForgeAudio/views/TierUpgradeView.swift
+++ b/apps/CoreForgeAudio/views/TierUpgradeView.swift
@@ -1,38 +1,40 @@
 #if canImport(SwiftUI)
 import SwiftUI
-import CreatorCoreForge
 
-/// In-app tier selection modal.
+/// Allows upgrading the subscription tier with an annual toggle.
 struct TierUpgradeView: View {
-    @Binding var isPresented: Bool
-    @State private var selected: SubscriptionManager.Plan = .creator
-    var onUpgrade: (SubscriptionManager.Plan) -> Void
+    @State private var selectedPlan: SubscriptionManager.Plan = .creator
+    @State private var cycle: SubscriptionManager.BillingCycle = .monthly
+    @ObservedObject private var manager = SubscriptionManager.shared
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(spacing: 20) {
-            Picker("Plan", selection: $selected) {
-                Text("Creator").tag(SubscriptionManager.Plan.creator)
-                Text("Author").tag(SubscriptionManager.Plan.author)
-                Text("Enterprise").tag(SubscriptionManager.Plan.enterprise)
+            PricingView()
+                .frame(height: 300)
+            Picker("Plan", selection: $selectedPlan) {
+                ForEach(SubscriptionManager.Plan.allCases, id: \.self) { plan in
+                    Text(plan.displayName).tag(plan)
+                }
             }
-            .pickerStyle(.segmented)
-            Button("Upgrade") {
-                onUpgrade(selected)
-                isPresented = false
+            .pickerStyle(MenuPickerStyle())
+            Picker("Billing", selection: $cycle) {
+                ForEach(SubscriptionManager.BillingCycle.allCases, id: \.self) { c in
+                    Text(c.displayName).tag(c)
+                }
             }
-            .font(.headline)
-            .buttonStyle(GlowingButtonStyle())
+            .pickerStyle(SegmentedPickerStyle())
+            Button("Purchase") {
+                manager.select(plan: selectedPlan, cycle: cycle)
+                dismiss()
+            }
+            .buttonStyle(.borderedProminent)
         }
         .padding()
-        .background(Theme.cardMaterial)
-        .cornerRadius(Theme.cornerRadius)
-        .shadow(radius: Theme.shadowRadius)
     }
 }
 
 #Preview {
-    TierUpgradeView(isPresented: .constant(true)) { _ in }
-        .padding()
-        .background(Color.gray)
+    TierUpgradeView()
 }
 #endif

--- a/apps/CoreForgeAudio/views/UnlockWithPromoView.swift
+++ b/apps/CoreForgeAudio/views/UnlockWithPromoView.swift
@@ -1,0 +1,34 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Simple promo code unlock screen.
+struct UnlockWithPromoView: View {
+    @State private var code = ""
+    @Environment(\.dismiss) private var dismiss
+    private let manager = SubscriptionManager.shared
+
+    var body: some View {
+        NavigationView {
+            Form {
+                TextField("Promo Code", text: $code)
+                Button("Apply") { applyCode() }
+            }
+            .navigationTitle("Promo Code")
+        }
+    }
+
+    private func applyCode() {
+        switch code.uppercased() {
+        case "CREATORACCESS":
+            manager.select(plan: .creator, cycle: .monthly)
+        case "VISIONBETA":
+            manager.select(plan: .enterprise, cycle: .monthly)
+        default:
+            break
+        }
+        dismiss()
+    }
+}
+
+#Preview { UnlockWithPromoView() }
+#endif


### PR DESCRIPTION
## Summary
- add subscription manager with 4-tier plans and billing cycle support
- create PricingView, TierUpgradeView, UnlockWithPromoView and ExportView
- display subscription credits in PlayerView and SettingsView
- gate premium voices by tier in VoiceCastView
- track credit usage via new ExportManager

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*
- `swift test` *(fails: exited with signal 4)*

------
https://chatgpt.com/codex/tasks/task_e_685fc697332c8321ae04985eb1eb6b02