### PR TITLE
Add GitHub Flow release guide

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,14 @@
+# Release Process – GitHub Flow
+
+CreatorCoreForge has migrated from a trunk-based workflow to **GitHub Flow**. All changes now go through a pull request before merging into `main`.
+
+## Steps
+
+1. **Create a branch** for each feature or fix.
+2. **Run the test suites** locally and in CI.
+3. **Open a pull request** and request code review.
+4. **Address feedback** until tests pass and approvals are granted.
+5. **Merge** the pull request into `main`.
+6. **Tag a release** from the `main` branch and publish binaries.
+
+This process keeps `main` stable and ensures each release is well tested and reviewed.


### PR DESCRIPTION
## Summary
- document new GitHub Flow in `docs/release.md`

## Testing
- `bash scripts/run_all_tests.sh` *(fails: Unable to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_685fca83ebd88321941b35d937e62830