### PR TITLE
Add billing cycle to SubscriptionManager

### DIFF
--- a/Sources/CreatorCoreForge/SubscriptionManager.swift
+++ b/Sources/CreatorCoreForge/SubscriptionManager.swift
@@ -9,33 +9,67 @@ public final class SubscriptionManager {
         case enterprise
     }
 
-    /// Price and monthly export allowance per plan.
+    /// Billing cycle for subscription pricing.
+    public enum BillingCycle: String {
+        case monthly
+        case annual
+    }
+
+    /// Pricing and credit info per plan.
     private struct TierInfo {
-        let price: Double
-        let monthlyExports: Int
+        let monthlyPrice: Double
+        let annualPrice: Double
+        let monthlyCredits: Int
+        let nsfwIncluded: Bool
     }
 
     private static let tierInfo: [Plan: TierInfo] = [
-        .free: TierInfo(price: 0, monthlyExports: 5),
-        .creator: TierInfo(price: 9.99, monthlyExports: 50),
-        .author: TierInfo(price: 14.99, monthlyExports: 100),
-        .enterprise: TierInfo(price: 29.99, monthlyExports: 500)
+        .free: TierInfo(monthlyPrice: 0,
+                        annualPrice: 0,
+                        monthlyCredits: 20_000,
+                        nsfwIncluded: false),
+        .creator: TierInfo(monthlyPrice: 19.99,
+                           annualPrice: 179.91,
+                           monthlyCredits: 150_000,
+                           nsfwIncluded: false),
+        .enterprise: TierInfo(monthlyPrice: 49.99,
+                              annualPrice: 449.91,
+                              monthlyCredits: 600_000,
+                              nsfwIncluded: true),
+        .author: TierInfo(monthlyPrice: 99.99,
+                          annualPrice: 899.91,
+                          monthlyCredits: 2_000_000,
+                          nsfwIncluded: true)
     ]
 
     public private(set) var activePlan: Plan
+    public private(set) var billingCycle: BillingCycle
+    public private(set) var creditsRemaining: Int
     public private(set) var isNSFWUnlocked: Bool
     private var exportsThisMonth: Int
     private let defaults: UserDefaults
     private let monthKey = "SubMgrMonth"
     private let exportKey = "SubMgrExports"
     private let nsfwKey = "SubMgrNSFW"
+    private let cycleKey = "SubMgrCycle"
+    private let planKey = "SubMgrPlan"
+    private let creditKey = "SubMgrCredits"
 
-    public init(plan: Plan = .free, userDefaults: UserDefaults = .standard) {
-        self.activePlan = plan
+    public init(plan: Plan = .free,
+                cycle: BillingCycle = .monthly,
+                userDefaults: UserDefaults = .standard) {
         self.defaults = userDefaults
+        let storedPlan = Plan(rawValue: userDefaults.string(forKey: planKey) ?? "") ?? plan
+        let storedCycle = BillingCycle(rawValue: userDefaults.string(forKey: cycleKey) ?? "") ?? cycle
+        self.activePlan = storedPlan
+        self.billingCycle = storedCycle
         self.exportsThisMonth = userDefaults.integer(forKey: exportKey)
         self.isNSFWUnlocked = userDefaults.bool(forKey: nsfwKey)
-        if plan == .author || plan == .enterprise {
+        self.creditsRemaining = userDefaults.integer(forKey: creditKey)
+        if self.creditsRemaining == 0 {
+            self.creditsRemaining = Self.tierInfo[storedPlan]!.monthlyCredits
+        }
+        if storedPlan == .author || storedPlan == .enterprise {
             self.isNSFWUnlocked = true
             userDefaults.set(true, forKey: nsfwKey)
         }
@@ -43,22 +77,28 @@ public final class SubscriptionManager {
     }
 
     /// Upgrade the current subscription plan.
-    public func upgrade(to plan: Plan) {
+    public func upgrade(to plan: Plan, cycle: BillingCycle? = nil) {
         activePlan = plan
+        if let cycle = cycle { billingCycle = cycle }
+        creditsRemaining = Self.tierInfo[plan]!.monthlyCredits
+        defaults.set(plan.rawValue, forKey: planKey)
+        defaults.set(billingCycle.rawValue, forKey: cycleKey)
+        defaults.set(creditsRemaining, forKey: creditKey)
         if plan == .author || plan == .enterprise {
             unlockNSFW()
         }
     }
 
     /// Price for a specific plan.
-    public func price(for plan: Plan) -> Double {
-        Self.tierInfo[plan]!.price
+    public func price(for plan: Plan, cycle: BillingCycle = .monthly) -> Double {
+        let info = Self.tierInfo[plan]!
+        return cycle == .monthly ? info.monthlyPrice : info.annualPrice
     }
 
     /// Remaining export actions for the current month.
     public func remainingExports() -> Int {
         resetIfNeeded()
-        let limit = Self.tierInfo[activePlan]!.monthlyExports
+        let limit = Self.tierInfo[activePlan]!.monthlyCredits
         return max(limit - exportsThisMonth, 0)
     }
 
@@ -66,13 +106,24 @@ public final class SubscriptionManager {
     public func recordExport() {
         resetIfNeeded()
         exportsThisMonth += 1
+        creditsRemaining = max(0, creditsRemaining - 1)
         persist()
+    }
+
+    /// Consume a number of word credits, if available.
+    @discardableResult
+    public func consumeCredits(_ amount: Int) -> Bool {
+        resetIfNeeded()
+        guard creditsRemaining >= amount else { return false }
+        creditsRemaining -= amount
+        persist()
+        return true
     }
 
     /// Whether another export is allowed this month.
     public func canExport() -> Bool {
         resetIfNeeded()
-        return exportsThisMonth < Self.tierInfo[activePlan]!.monthlyExports
+        return exportsThisMonth < Self.tierInfo[activePlan]!.monthlyCredits
     }
 
     /// Manually unlock NSFW access for the current user.
@@ -86,12 +137,16 @@ public final class SubscriptionManager {
         if defaults.string(forKey: monthKey) != current {
             defaults.set(current, forKey: monthKey)
             exportsThisMonth = 0
+            creditsRemaining = Self.tierInfo[activePlan]!.monthlyCredits
             persist()
         }
     }
 
     private func persist() {
         defaults.set(exportsThisMonth, forKey: exportKey)
+        defaults.set(activePlan.rawValue, forKey: planKey)
+        defaults.set(billingCycle.rawValue, forKey: cycleKey)
+        defaults.set(creditsRemaining, forKey: creditKey)
     }
 
     private static var currentMonth: String {

--- a/Tests/CreatorCoreForgeTests/SubscriptionManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/SubscriptionManagerTests.swift
@@ -5,9 +5,13 @@ final class SubscriptionManagerTests: XCTestCase {
     func testPlanPrices() {
         let manager = SubscriptionManager()
         XCTAssertEqual(manager.price(for: .free), 0)
-        XCTAssertEqual(manager.price(for: .creator), 9.99)
-        XCTAssertEqual(manager.price(for: .author), 14.99)
-        XCTAssertEqual(manager.price(for: .enterprise), 29.99)
+        XCTAssertEqual(manager.price(for: .creator), 19.99)
+        XCTAssertEqual(manager.price(for: .author), 99.99)
+        XCTAssertEqual(manager.price(for: .enterprise), 49.99)
+
+        XCTAssertEqual(manager.price(for: .creator, cycle: .annual), 179.91)
+        XCTAssertEqual(manager.price(for: .author, cycle: .annual), 899.91)
+        XCTAssertEqual(manager.price(for: .enterprise, cycle: .annual), 449.91)
     }
 
     func testExportLimits() {


### PR DESCRIPTION
## Summary
- expand `SubscriptionManager` with `BillingCycle` enum and credit tracking
- add annual pricing for all plans
- update tests for new pricing

## Testing
- `swift test` *(fails: Exited with signal 4)*
- `npm test --workspaces` *(fails: TS2345 in AICopilotService)*

------
https://chatgpt.com/codex/tasks/task_e_68600823b5948321b99ecbde2c77394f