### PR TITLE
Add adaptive TTS fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
   - AnalyticsLogger for basic event tracking
   - PerformanceModeSelector to switch rendering presets
   - FusionVoiceController orchestrates LocalVoiceAI and emotion cues
+  - Adaptive online/offline TTS via ElevenLabsRenderer fallback
   - MultiCastAudiobookGenerator enables ensemble narration
   - DramatizedAudiobookProducer creates immersive dramatized audiobooks
   - Extra helpers in `Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift`

--- a/Sources/CreatorCoreForge/FusionVoiceController.swift
+++ b/Sources/CreatorCoreForge/FusionVoiceController.swift
@@ -1,29 +1,67 @@
 import Foundation
 
+public protocol TTSAudioRendering {
+    func render(text: String, voiceID: String, completion: @escaping (Result<Data, Error>) -> Void)
+}
+
+extension ElevenLabsRenderer: TTSAudioRendering {}
+
 /// Orchestrates voice synthesis by combining multiple engines together.
 public final class FusionVoiceController {
     private let voiceAI = LocalVoiceAI()
     private let emotionEngine = AIEmotionEngine()
     private let cache = OfflineTTSCache()
+    private let remoteRenderer: TTSAudioRendering?
 
-    public init() {}
+    public init(remoteRenderer: TTSAudioRendering? = nil,
+                apiKey: String? = ProcessInfo.processInfo.environment["ELEVEN_API_KEY"]) {
+        if let renderer = remoteRenderer {
+            self.remoteRenderer = renderer
+        } else if let key = apiKey, !key.isEmpty {
+            self.remoteRenderer = ElevenLabsRenderer(apiKey: key)
+        } else {
+            self.remoteRenderer = nil
+        }
+    }
 
     /// Synthesizes the given text with emotion analysis and caching.
-    public func speak(text: String, using profile: VoiceProfile, completion: @escaping (Data?) -> Void) {
+    /// Attempts remote rendering first if available, falling back to local.
+    public func speak(text: String,
+                      using profile: VoiceProfile,
+                      preferOnline: Bool = true,
+                      completion: @escaping (Data?) -> Void) {
         if let cached = cache.data(for: text) {
             completion(cached)
             return
         }
         let emotion = emotionEngine.analyze(text: text)
         let shift = Self.shift(for: emotion)
-        voiceAI.synthesize(text: text, with: profile, emotionShift: shift) { [weak self] result in
-            guard let self = self else { completion(nil); return }
-            if case .success(let data) = result {
-                self.cache.store(data, for: text)
-                completion(data)
-            } else {
-                completion(nil)
+
+        let localRender = {
+            self.voiceAI.synthesize(text: text, with: profile, emotionShift: shift) { [weak self] result in
+                guard let self = self else { completion(nil); return }
+                if case .success(let data) = result {
+                    self.cache.store(data, for: text)
+                    completion(data)
+                } else {
+                    completion(nil)
+                }
             }
+        }
+
+        if preferOnline, let renderer = remoteRenderer {
+            renderer.render(text: text, voiceID: profile.id) { [weak self] result in
+                guard let self = self else { completion(nil); return }
+                switch result {
+                case .success(let data):
+                    self.cache.store(data, for: text)
+                    completion(data)
+                case .failure:
+                    localRender()
+                }
+            }
+        } else {
+            localRender()
         }
     }
 

--- a/Tests/CreatorCoreForgeTests/FusionVoiceControllerFallbackTests.swift
+++ b/Tests/CreatorCoreForgeTests/FusionVoiceControllerFallbackTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class FusionVoiceControllerFallbackTests: XCTestCase {
+    private final class FailingRenderer: TTSAudioRendering {
+        func render(text: String, voiceID: String, completion: @escaping (Result<Data, Error>) -> Void) {
+            completion(.failure(NSError(domain: "test", code: -1)))
+        }
+    }
+
+    private final class MockRenderer: TTSAudioRendering {
+        func render(text: String, voiceID: String, completion: @escaping (Result<Data, Error>) -> Void) {
+            completion(.success(Data("remote".utf8)))
+        }
+    }
+
+    func testFallbackToLocalOnFailure() {
+        let controller = FusionVoiceController(remoteRenderer: FailingRenderer())
+        let profile = VoiceProfile(name: "Test")
+        let exp = expectation(description: "local")
+        controller.speak(text: "Hello", using: profile) { data in
+            XCTAssertNotNil(data)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testUsesRemoteWhenAvailable() {
+        let controller = FusionVoiceController(remoteRenderer: MockRenderer())
+        let profile = VoiceProfile(name: "Test")
+        let exp = expectation(description: "remote")
+        controller.speak(text: "Hi", using: profile) { data in
+            XCTAssertEqual(data, Data("remote".utf8))
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+}

--- a/apps/CoreForgeBuild/services/AICopilotService.ts
+++ b/apps/CoreForgeBuild/services/AICopilotService.ts
@@ -14,9 +14,10 @@ export class AICopilotService {
   private visitFunctions(file: ts.SourceFile, cb: (fn: ts.FunctionLikeDeclaration, span: number) => void) {
     const visit = (node: ts.Node) => {
       if (ts.isFunctionLike(node)) {
-        const span = file.getLineAndCharacterOfPosition(node.end).line -
+        const span =
+          file.getLineAndCharacterOfPosition(node.end).line -
           file.getLineAndCharacterOfPosition(node.pos).line;
-        cb(node, span);
+        cb(node as ts.FunctionLikeDeclaration, span);
       }
       ts.forEachChild(node, visit);
     };


### PR DESCRIPTION
## Summary
- support optional online TTS via `ElevenLabsRenderer` in `FusionVoiceController`
- allow fallback to local synthesis when remote fails
- fix TypeScript compile error in AICopilotService
- document new online/offline TTS capability
- test FusionVoiceController remote fallback behavior

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860132498a48321af138473583dd478