### PR TITLE
Enhance network-aware TTS switching

### DIFF
--- a/Sources/CreatorCoreForge/FusionVoiceController.swift
+++ b/Sources/CreatorCoreForge/FusionVoiceController.swift
@@ -49,7 +49,10 @@ public final class FusionVoiceController {
             }
         }
 
-        if preferOnline, let renderer = remoteRenderer {
+        if preferOnline,
+           !AppSettings.shared.offlineMode,
+           NetworkMonitor.shared.isConnected,
+           let renderer = remoteRenderer {
             renderer.render(text: text, voiceID: profile.id) { [weak self] result in
                 guard let self = self else { completion(nil); return }
                 switch result {

--- a/Sources/CreatorCoreForge/NetworkMonitor.swift
+++ b/Sources/CreatorCoreForge/NetworkMonitor.swift
@@ -1,0 +1,42 @@
+import Foundation
+#if canImport(Network)
+import Network
+#endif
+
+/// Monitors basic network connectivity status.
+public final class NetworkMonitor {
+    public static let shared = NetworkMonitor()
+
+    #if canImport(Network)
+    private let monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "network.monitor")
+    #endif
+
+    private(set) var _isConnected: Bool = true
+    private var overrideActive = false
+
+    public var isConnected: Bool {
+        #if canImport(Network)
+        return _isConnected
+        #else
+        return true
+        #endif
+    }
+
+    /// Overrides the connection status for unit tests.
+    func setTestConnection(_ connected: Bool) {
+        overrideActive = true
+        _isConnected = connected
+    }
+
+    private init() {
+        #if canImport(Network)
+        monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self, !self.overrideActive else { return }
+            self._isConnected = path.status == .satisfied
+        }
+        monitor.start(queue: queue)
+        #endif
+    }
+}

--- a/Tests/CreatorCoreForgeTests/FusionVoiceControllerFallbackTests.swift
+++ b/Tests/CreatorCoreForgeTests/FusionVoiceControllerFallbackTests.swift
@@ -25,12 +25,27 @@ final class FusionVoiceControllerFallbackTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
 
-    func testUsesRemoteWhenAvailable() {
+    func testUsesRemoteWhenConnected() {
+        NetworkMonitor.shared.setTestConnection(true)
+        AppSettings.shared.offlineMode = false
         let controller = FusionVoiceController(remoteRenderer: MockRenderer())
         let profile = VoiceProfile(name: "Test")
         let exp = expectation(description: "remote")
         controller.speak(text: "Hi", using: profile) { data in
             XCTAssertEqual(data, Data("remote".utf8))
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testFallsBackWhenOffline() {
+        NetworkMonitor.shared.setTestConnection(false)
+        AppSettings.shared.offlineMode = false
+        let controller = FusionVoiceController(remoteRenderer: MockRenderer())
+        let profile = VoiceProfile(name: "Test")
+        let exp = expectation(description: "local")
+        controller.speak(text: "Hi", using: profile) { data in
+            XCTAssertNotEqual(data, Data("remote".utf8))
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1)


### PR DESCRIPTION
## Summary
- add `NetworkMonitor` for connectivity checks
- switch FusionVoiceController to online voices only when connected and not offline mode
- extend FusionVoiceController tests for network conditions

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_68602851802c8321a652859176379d79