### PR TITLE
Add advanced options for ElevenLabs TTS

### DIFF
--- a/Sources/CreatorCoreForge/ElevenLabsClient.swift
+++ b/Sources/CreatorCoreForge/ElevenLabsClient.swift
@@ -9,6 +9,24 @@ public struct ElevenLabsClient {
     private let apiKey: String
     private let session: URLSession
 
+    /// Options for advanced synthesis quality tuning.
+    public struct Options {
+        /// Voice stability between 0 and 1.0.
+        public var stability: Double
+        /// Similarity boost between 0 and 1.0.
+        public var similarityBoost: Double
+        /// Optional model identifier, e.g. `eleven_multilingual_v2`.
+        public var modelID: String?
+
+        public init(stability: Double = 0.75,
+                    similarityBoost: Double = 0.75,
+                    modelID: String? = nil) {
+            self.stability = stability
+            self.similarityBoost = similarityBoost
+            self.modelID = modelID
+        }
+    }
+
     public init(apiKey: String = ProcessInfo.processInfo.environment["ELEVEN_API_KEY"] ?? "",
                 session: URLSession = .shared) {
         self.apiKey = apiKey
@@ -28,6 +46,19 @@ public struct ElevenLabsClient {
     /// Synthesize text to speech using a voice identifier.
     public func synthesize(text: String, voiceID: String, completion: @escaping (Result<Data, Error>) -> Void) {
         let body = try? JSONSerialization.data(withJSONObject: ["text": text])
+        request(endpoint: "text-to-speech/\(voiceID)", method: "POST", body: body, completion: completion)
+    }
+
+    /// Synthesize text with advanced quality options.
+    public func synthesize(text: String,
+                           voiceID: String,
+                           options: Options,
+                           completion: @escaping (Result<Data, Error>) -> Void) {
+        var payload: [String: Any] = ["text": text,
+                                      "voice_settings": ["stability": options.stability,
+                                                         "similarity_boost": options.similarityBoost]]
+        if let model = options.modelID { payload["model_id"] = model }
+        let body = try? JSONSerialization.data(withJSONObject: payload)
         request(endpoint: "text-to-speech/\(voiceID)", method: "POST", body: body, completion: completion)
     }
 

--- a/Tests/CreatorCoreForgeTests/ElevenLabsClientAdvancedTests.swift
+++ b/Tests/CreatorCoreForgeTests/ElevenLabsClientAdvancedTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import CreatorCoreForge
+
+final class ElevenLabsClientAdvancedTests: XCTestCase {
+    private class MockURLProtocol: URLProtocol {
+        static var lastRequest: URLRequest?
+        static var responseData: Data?
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+        override func startLoading() {
+            Self.lastRequest = request
+            if let data = Self.responseData {
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+        override func stopLoading() {}
+    }
+
+    func testAdvancedSynthesisPayloadIncludesOptions() throws {
+        let options = ElevenLabsClient.Options(stability: 0.55, similarityBoost: 0.85, modelID: "test-model")
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+        MockURLProtocol.responseData = Data("ok".utf8)
+        let client = ElevenLabsClient(apiKey: "TEST", session: session)
+        let exp = expectation(description: "tts")
+        client.synthesize(text: "Hello", voiceID: "voice", options: options) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+
+        guard let body = MockURLProtocol.lastRequest?.httpBody else {
+            XCTFail("Missing body"); return
+        }
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let settings = json["voice_settings"] as? [String: Double]
+        XCTAssertEqual(settings?["stability"] ?? -1, 0.55, accuracy: 0.001)
+        XCTAssertEqual(settings?["similarity_boost"] ?? -1, 0.85, accuracy: 0.001)
+        XCTAssertEqual(json["model_id"] as? String, "test-model")
+    }
+}

--- a/docs/PRACTICAL_PLAN.md
+++ b/docs/PRACTICAL_PLAN.md
@@ -14,7 +14,7 @@ This document outlines a phased plan for implementing the key features across th
 2. **Chapter Detection** – add logic and GPT prompts to locate chapter boundaries in raw text.
 3. **Segment Service** – split chapters into narration-ready segments with semantic boundaries.
 4. **Voice Manager** – map segments to voice models and persist character mappings.
-5. **TTS Service** – interface with ElevenLabs or LocalVoiceAI to render audio, including retry logic.
+5. **TTS Service** – interface with ElevenLabs or LocalVoiceAI to render audio, including retry logic. Use `ElevenLabsClient.Options` to tune stability, similarity, and model ID for higher quality online output.
 6. **Ambient Mixer** – layer ambience and SFX with volume envelopes and 3D positioning.
 7. **NSFW Service** – detect explicit text, gate content, and enforce parental PIN checks.
 8. **Playback Engine** – implement basic `play`, `pause`, and `seek` controls with a simple React UI.


### PR DESCRIPTION
## Summary
- add `ElevenLabsClient.Options` for advanced online synthesis
- support advanced options in `ElevenLabsClient`
- document new options in `PRACTICAL_PLAN.md`
- add unit test for new functionality

## Testing
- `swift test` *(fails: signal 4)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68602ccf7ecc83219d0461c5f54ef38a