### PR TITLE
Add advanced voiceover engine

### DIFF
--- a/Sources/CreatorCoreForge/RealisticVoiceoverEngine.swift
+++ b/Sources/CreatorCoreForge/RealisticVoiceoverEngine.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Generates voiceover audio with emotion-aware text adaptation.
+public final class RealisticVoiceoverEngine {
+    private let voiceAI: LocalVoiceAI
+    private let emotionAdapter: RealTimeEmotionAdapter
+
+    public init(voiceAI: LocalVoiceAI = LocalVoiceAI(),
+                emotionAdapter: RealTimeEmotionAdapter = RealTimeEmotionAdapter()) {
+        self.voiceAI = voiceAI
+        self.emotionAdapter = emotionAdapter
+    }
+
+    /// Synthesize audio for a segment using the provided voice profile.
+    /// - Parameters:
+    ///   - segment: Text segment to speak.
+    ///   - emotion: Optional emotion override.
+    ///   - completion: Called with synthesized audio data.
+    public func speak(_ segment: Segment,
+                      emotion: String? = nil,
+                      completion: @escaping (Result<Data, Error>) -> Void) {
+        var text = segment.text
+        if let emotion = emotion {
+            emotionAdapter.updateEmotion(emotion)
+            text = emotionAdapter.adapt(text)
+        }
+        let profile = segment.voice ?? VoiceProfile(name: "Default")
+        voiceAI.synthesize(text: text, with: profile) { result in
+            completion(result)
+        }
+    }
+}

--- a/Tests/CreatorCoreForgeTests/RealisticVoiceoverEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/RealisticVoiceoverEngineTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class RealisticVoiceoverEngineTests: XCTestCase {
+    func testSpeakProducesData() {
+        let profile = VoiceProfile(name: "NextGen", depth: 1.3, scope: 1.2)
+        let segment = Segment(text: "Hello world", character: "narrator", voice: profile)
+        let engine = RealisticVoiceoverEngine()
+        let exp = expectation(description: "speak")
+        engine.speak(segment) { result in
+            switch result {
+            case .success(let data):
+                XCTAssertFalse(data.isEmpty)
+            case .failure:
+                XCTFail("Unexpected failure")
+            }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testEmotionChangesOutput() {
+        let profile = VoiceProfile(name: "NextGen")
+        let segment = Segment(text: "Hello world", voice: profile)
+        let engine = RealisticVoiceoverEngine()
+        let exp1 = expectation(description: "neutral")
+        var data1: Data?
+        engine.speak(segment) { result in
+            if case .success(let data) = result { data1 = data }
+            exp1.fulfill()
+        }
+        let exp2 = expectation(description: "sad")
+        var data2: Data?
+        engine.speak(segment, emotion: "sad") { result in
+            if case .success(let data) = result { data2 = data }
+            exp2.fulfill()
+        }
+        wait(for: [exp1, exp2], timeout: 1)
+        XCTAssertNotNil(data1)
+        XCTAssertNotNil(data2)
+        XCTAssertNotEqual(data1, data2)
+    }
+}


### PR DESCRIPTION
## Summary
- implement `RealisticVoiceoverEngine` to synthesize text with emotion-aware adaptation
- add unit tests covering the new engine

## Testing
- `swift test` *(fails: exited with signal)*
- `npm test` in `VisualLab`
- `npm test` in `VoiceLab`


------
https://chatgpt.com/codex/tasks/task_e_68603caa5dc4832194ffc482f6dc62d7