### PR TITLE
Add dynamic voiceover controls

### DIFF
--- a/Sources/CreatorCoreForge/RealisticVoiceoverEngine.swift
+++ b/Sources/CreatorCoreForge/RealisticVoiceoverEngine.swift
@@ -15,16 +15,23 @@ public final class RealisticVoiceoverEngine {
     /// - Parameters:
     ///   - segment: Text segment to speak.
     ///   - emotion: Optional emotion override.
+    ///   - depth: Override for voice resonance.
+    ///   - scope: Override for voice pitch range.
     ///   - completion: Called with synthesized audio data.
     public func speak(_ segment: Segment,
                       emotion: String? = nil,
+                      depth: Double? = nil,
+                      scope: Double? = nil,
                       completion: @escaping (Result<Data, Error>) -> Void) {
         var text = segment.text
         if let emotion = emotion {
             emotionAdapter.updateEmotion(emotion)
             text = emotionAdapter.adapt(text)
         }
-        let profile = segment.voice ?? VoiceProfile(name: "Default")
+        var profile = segment.voice ?? VoiceProfile(name: "Default")
+        if let d = depth { profile.depth = d }
+        if let s = scope { profile.scope = s }
+        if let emotion = emotion { profile.emotion = emotion }
         voiceAI.synthesize(text: text, with: profile) { result in
             completion(result)
         }

--- a/Tests/CreatorCoreForgeTests/RealisticVoiceoverEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/RealisticVoiceoverEngineTests.swift
@@ -40,4 +40,29 @@ final class RealisticVoiceoverEngineTests: XCTestCase {
         XCTAssertNotNil(data2)
         XCTAssertNotEqual(data1, data2)
     }
+
+    func testDepthScopeOverrides() {
+        let profile = VoiceProfile(name: "Base")
+        let segment = Segment(text: "Hi", voice: profile)
+        let engine = RealisticVoiceoverEngine()
+
+        let exp1 = expectation(description: "default")
+        var data1: Data?
+        engine.speak(segment) { result in
+            if case .success(let data) = result { data1 = data }
+            exp1.fulfill()
+        }
+
+        let exp2 = expectation(description: "override")
+        var data2: Data?
+        engine.speak(segment, depth: 1.5, scope: 1.2) { result in
+            if case .success(let data) = result { data2 = data }
+            exp2.fulfill()
+        }
+
+        wait(for: [exp1, exp2], timeout: 1)
+        XCTAssertNotNil(data1)
+        XCTAssertNotNil(data2)
+        XCTAssertNotEqual(data1, data2)
+    }
 }

--- a/docs/NextGenSpeech.md
+++ b/docs/NextGenSpeech.md
@@ -13,3 +13,15 @@ service.generate(text: "Hello world", profile: profile) { data in
 let result = service.recognize(Data("hello".utf8))
 print(result) // "hello"
 ```
+
+## Realistic Voiceover Engine
+
+`RealisticVoiceoverEngine.speak` now accepts optional `depth` and `scope` overrides so each line can be delivered with custom resonance and pitch range.
+
+```swift
+let engine = RealisticVoiceoverEngine()
+let segment = Segment(text: "Welcome back", voice: profile)
+engine.speak(segment, emotion: "happy", depth: 1.4, scope: 1.3) { result in
+    // handle `result`
+}
+```


### PR DESCRIPTION
## Summary
- allow runtime depth and scope overrides in `RealisticVoiceoverEngine`
- test new voiceover overrides
- document updated API for NextGen Speech

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68603ea1169083219cc3ba53474fec4f