### PR TITLE
Add sarcasm detection and tests for TTS layers

### DIFF
--- a/Sources/CreatorCoreForge/EmotionAnalyzer.swift
+++ b/Sources/CreatorCoreForge/EmotionAnalyzer.swift
@@ -28,7 +28,9 @@ public final class EmotionAnalyzer {
     /// Analyze text and suggest a narration tone.
     public func recommendTone(for text: String) -> String {
         let lowered = text.lowercased()
-        if lowered.contains("excited") || lowered.contains("amazing") {
+        if lowered.contains("yeah right") || lowered.contains("as if") || lowered.contains("/s") {
+            return "sarcastic"
+        } else if lowered.contains("excited") || lowered.contains("amazing") {
             return "excited"
         } else if lowered.contains("sad") || lowered.contains("lost") {
             return "somber"
@@ -44,7 +46,10 @@ public final class EmotionAnalyzer {
         var emotion = "neutral"
         var intensity: Float = 0.0
 
-        if lowered.contains("excited") || lowered.contains("amazing") {
+        if lowered.contains("yeah right") || lowered.contains("as if") || lowered.contains("/s") {
+            emotion = "sarcastic"
+            intensity = 0.4
+        } else if lowered.contains("excited") || lowered.contains("amazing") {
             emotion = "excited"
             intensity = 0.5
         } else if lowered.contains("sad") || lowered.contains("lost") {
@@ -82,6 +87,8 @@ public final class EmotionAnalyzer {
             pitch = 1.1
         case "hesitant":
             speed = 0.95; pitch = 0.95
+        case "sarcastic":
+            speed = 1.05; pitch = 0.95
         default:
             break
         }
@@ -97,6 +104,9 @@ public final class EmotionAnalyzer {
     /// Very naive implementation using punctuation and keywords.
     public func classify(sentence: String) -> String {
         let lowered = sentence.lowercased()
+        if lowered.contains("yeah right") || lowered.contains("as if") || lowered.contains("/s") {
+            return "sarcastic"
+        }
         if lowered.contains("sad") { return "sad" }
         if lowered.contains("wow") || lowered.contains("!") { return "excited" }
         if lowered.contains("?") { return "curious" }

--- a/Tests/CreatorCoreForgeTests/AudioImperfectionFilterTests.swift
+++ b/Tests/CreatorCoreForgeTests/AudioImperfectionFilterTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class AudioImperfectionFilterTests: XCTestCase {
+    func testApplyKeepsData() {
+        let filter = AudioImperfectionFilter()
+        let input = Data([1,2,3])
+        let output = filter.apply(to: input)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/CreatorCoreForgeTests/ConversationalLayerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ConversationalLayerTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ConversationalLayerTests: XCTestCase {
+    func testApplyAddsSpeed() {
+        let layer = ConversationalLayer()
+        let text = layer.apply(to: "This is a very long sentence that should be slowed down slightly")
+        XCTAssertTrue(text.contains("<speed=0.9>") || text.contains("<speed=0.8>"))
+    }
+}

--- a/Tests/CreatorCoreForgeTests/EmotionAnalyzerTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionAnalyzerTests.swift
@@ -7,6 +7,7 @@ final class EmotionAnalyzerTests: XCTestCase {
         XCTAssertEqual(analyzer.recommendTone(for: "This is amazing!"), "excited")
         XCTAssertEqual(analyzer.recommendTone(for: "I am so sad"), "somber")
         XCTAssertEqual(analyzer.recommendTone(for: "He was furious"), "angry")
+        XCTAssertEqual(analyzer.recommendTone(for: "Yeah right"), "sarcastic")
         XCTAssertEqual(analyzer.recommendTone(for: "Just reading"), "calm")
     }
 
@@ -22,6 +23,7 @@ final class EmotionAnalyzerTests: XCTestCase {
         XCTAssertEqual(analyzer.classify(sentence: "Wow!"), "excited")
         XCTAssertEqual(analyzer.classify(sentence: "Is this real?"), "curious")
         XCTAssertEqual(analyzer.classify(sentence: "I feel so sad"), "sad")
+        XCTAssertEqual(analyzer.classify(sentence: "Yeah right."), "sarcastic")
         XCTAssertEqual(analyzer.classify(sentence: "Just a line"), "neutral")
     }
 }

--- a/Tests/CreatorCoreForgeTests/ProsodyCurveManagerTests.swift
+++ b/Tests/CreatorCoreForgeTests/ProsodyCurveManagerTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class ProsodyCurveManagerTests: XCTestCase {
+    func testCurveType() {
+        let manager = ProsodyCurveManager()
+        XCTAssertEqual(manager.curveType(for: "Is this working?"), "rise")
+        XCTAssertEqual(manager.curveType(for: "Amazing!"), "burst")
+        XCTAssertEqual(manager.curveType(for: "Just a line."), "fall")
+    }
+
+    func testStressIndices() {
+        let manager = ProsodyCurveManager()
+        let indices = manager.stressIndices(in: "This is *really* IMPORTANT text")
+        XCTAssertTrue(indices.contains(2))
+        XCTAssertTrue(indices.contains(3))
+    }
+}


### PR DESCRIPTION
## Summary
- detect sarcastic statements in `EmotionAnalyzer`
- unit tests for new sarcasm detection
- add tests for prosody curves, conversational interjections and imperfection filter

## Testing
- `swift test --filter EmotionAnalyzerTests`
- `swift test --filter ProsodyCurveManagerTests`
- `swift test --filter AudioImperfectionFilterTests`
- `swift test --filter ConversationalLayerTests`


------
https://chatgpt.com/codex/tasks/task_e_68605d4d94ac8321a6b9b4bec159fad9