### PR TITLE
Add referral credit tracking and persistent user ID

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AuthManager.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AuthManager.swift
@@ -11,19 +11,32 @@ final class AuthManager: ObservableObject {
     @AppStorage("isLoggedIn") private var isLoggedIn: Bool = false
     @AppStorage("email") private var storedEmail: String = ""
     @AppStorage("planTier") private var planTier: String = SubscriptionManager.Plan.free.rawValue
+    @AppStorage("userID") private var storedUserID: String = ""
+    @AppStorage("userTier") private var storedUserTier: String = SubscriptionManager.Plan.free.rawValue
+    @AppStorage("referralCode") private var storedReferral: String = ""
     #endif
 
     private init() {}
 
+    /// Unique ID for the current user.
+    var userID: String {
+        if storedUserID.isEmpty { storedUserID = UUID().uuidString }
+        return storedUserID
+    }
+
     /// Currently selected subscription plan.
     var activePlan: SubscriptionManager.Plan {
         get { SubscriptionManager.Plan(rawValue: planTier) ?? .free }
-        set { planTier = newValue.rawValue }
+        set {
+            planTier = newValue.rawValue
+            storedUserTier = newValue.rawValue
+        }
     }
 
     /// Sign in with an email and password. Always succeeds in this demo.
     func signIn(email: String, password: String, completion: @escaping (Result<Void, Error>) -> Void) {
         storedEmail = email
+        if storedUserID.isEmpty { storedUserID = UUID().uuidString }
         isLoggedIn = true
         completion(.success(()))
     }
@@ -32,6 +45,7 @@ final class AuthManager: ObservableObject {
     func signUp(email: String, password: String, plan: SubscriptionManager.Plan = .free, completion: @escaping (Result<Void, Error>) -> Void) {
         storedEmail = email
         activePlan = plan
+        storedUserID = UUID().uuidString
         isLoggedIn = true
         completion(.success(()))
     }
@@ -40,6 +54,7 @@ final class AuthManager: ObservableObject {
     func signInAnonymously(completion: @escaping () -> Void) {
         storedEmail = ""
         activePlan = .free
+        if storedUserID.isEmpty { storedUserID = UUID().uuidString }
         isLoggedIn = true
         completion()
     }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CreditStore.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CreditStore.swift
@@ -11,6 +11,8 @@ final class CreditStore: ObservableObject {
     @Published private(set) var history: [String]
     @Published var lastAdded: Int? = nil
 
+    @AppStorage("creditsEarnedFromReferral") private var referralTotal: Int = 0
+
     private let creditsKey = "CFACredits"
     private let historyKey = "CFACreditHistory"
     private let defaults: UserDefaults
@@ -22,9 +24,12 @@ final class CreditStore: ObservableObject {
     }
 
     /// Add credits and record a history entry.
-    func addCredits(_ amount: Int, reason: String) {
+    func addCredits(_ amount: Int, reason: String, referral: Bool = false) {
         credits += amount
         history.append("+\(amount) - \(reason)")
+        if referral {
+            referralTotal += amount
+        }
         lastAdded = amount
         persist()
     }

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Info.plist
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Info.plist
@@ -37,5 +37,7 @@
             </dict>
         </dict>
     </dict>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Used for anonymized analytics to improve features.</string>
 </dict>
 </plist>

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ReferralManager.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ReferralManager.swift
@@ -45,7 +45,7 @@ final class ReferralManager: ObservableObject {
         rewards[referralCode, default: 0] += bonus
         defaults.set(rewards, forKey: rewardsKey)
         lastReward = bonus
-        CreditStore.shared.addCredits(bonus, reason: "Referral reward")
+        CreditStore.shared.addCredits(bonus, reason: "Referral reward", referral: true)
     }
 
     /// Total credits earned for a specific referral code.

--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/RegisterView.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/RegisterView.swift
@@ -43,6 +43,7 @@ struct RegisterView: View {
             switch result {
             case .success:
                 SubscriptionManager().upgrade(to: selectedTier)
+                ReferralManager.shared.rewardReferrer(for: selectedTier)
                 onComplete()
             case .failure(let err):
                 error = err.localizedDescription


### PR DESCRIPTION
## Summary
- store user IDs and user tiers in app storage
- track referral credits in `CreditStore`
- record referral rewards on signup
- add analytics usage string

## Testing
- `npm test`
- `swift test` *(fails: Exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_686077f0112c832199dbad883034c8d8