### PR TITLE
Add Xcode project for CoreForge Audio

### DIFF
--- a/CoreForgeAudio.xcodeproj/project.pbxproj
+++ b/CoreForgeAudio.xcodeproj/project.pbxproj
@@ -1,0 +1,2232 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		005D51E2174DF61B9111F94C /* AudioPlaybackEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E84D291AF2D77836623295C /* AudioPlaybackEngine.swift */; };
+		027ACED757C341A0BE7F75D5 /* SceneHeatmapManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A98C8C2B8DD8570DAF75073 /* SceneHeatmapManager.swift */; };
+		02C9035407F6A7F5755F57EE /* DashboardTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D33BD12089472D2B36DF821 /* DashboardTabView.swift */; };
+		03309982195100DB1BF92880 /* LibrarySync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69597CF80BB66D8310398AA3 /* LibrarySync.swift */; };
+		040DA31DE9F1E41322FE83C0 /* CrossBookNarration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FF61CD74066715BAE0549A /* CrossBookNarration.swift */; };
+		04775D25BB424C102EF3243D /* SettingsSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30720037E358F98EB2294275 /* SettingsSync.swift */; };
+		064D9271B19D714876328E0E /* EmotionShiftTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C0668F32F4C366E27BB183 /* EmotionShiftTracker.swift */; };
+		064E591D5E1FFA9E751173D3 /* BookImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F45AE4843DA80AD5DC4498 /* BookImporter.swift */; };
+		06743902790ADE532127C679 /* LongFormPacingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1CF1AEB6ADFED00BCD9A6A /* LongFormPacingEngine.swift */; };
+		0681005BCAE4DA682F64F125 /* ConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B80322224D366705B84E81 /* ConnectView.swift */; };
+		075904DECA83CB3517407B25 /* BasicAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8207E1404A6427ED22E0169 /* BasicAuthService.swift */; };
+		07CA134DC788B20337701705 /* AudioImperfectionFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 585F251F558DB5C37996FC73 /* AudioImperfectionFilter.swift */; };
+		07F16D3F23BE534A90B15CBD /* CrowdSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0DB4E15F3772BECF41011A /* CrowdSimulator.swift */; };
+		0910E9063A0D04A9135098E4 /* SpeechHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECB3DAECE635BA7241D837DB /* SpeechHighlighter.swift */; };
+		09171D31E39D8DEBA9CADC6E /* SleepReadMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B543380551D15B6DA9113424 /* SleepReadMode.swift */; };
+		09ED3FD10CE7470576D932D8 /* FirebaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D39E3C0B4A19A654E86F113 /* FirebaseService.swift */; };
+		0A14DDBD09CF1A3A8D7AB8B8 /* MultilingualEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A76BF19D0DB57116A1329C /* MultilingualEngine.swift */; };
+		0AD175243EBBA5CC2FDC627E /* VideoShareManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B210E7725846EA64F8D879B /* VideoShareManager.swift */; };
+		0BD4767E7486A4ED942C85EE /* RealisticVoiceoverEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9420E998989C4918D6FDAAC0 /* RealisticVoiceoverEngine.swift */; };
+		0BFE8C2FEF1E7CEC8B1E00D8 /* PluginManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F76E0FA9C08DD631B53BE43 /* PluginManifest.swift */; };
+		0DB8F67BE76D8FDB6314D31D /* LivePreviewPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03C93628622D7887535CA998 /* LivePreviewPane.swift */; };
+		0E33D410CE709C9EA47A2545 /* NSFWMoodHeatmap.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D75BDD390E8729F346721 /* NSFWMoodHeatmap.swift */; };
+		0E7393C1B40CD4EF040C8376 /* SceneIndexGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 010B81D3017528F5422D5FE3 /* SceneIndexGenerator.swift */; };
+		0E8A3BD2150DE0429FA98CC2 /* ProsodyCurveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D714071AC559756B977C227A /* ProsodyCurveManager.swift */; };
+		114420EC1862BCA1B8ECCAB5 /* VoiceTimbreModulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E210C8E620AC0CAD48EFA95B /* VoiceTimbreModulator.swift */; };
+		11466E5A50F6767754CB2046 /* GitSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8273D9EC0EBFB0EDE40DADE /* GitSync.swift */; };
+		11705C7E44854F3481CE51DC /* CRUDGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16A5964D3482688509443A89 /* CRUDGenerator.swift */; };
+		1198214AE85020218C038D22 /* NSFWSoundFXEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C001074AA0EE06F2B8CF218F /* NSFWSoundFXEngine.swift */; };
+		12438788C1AE4F304E94E70A /* CoreForgeMind_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDF6D29E2478B5A5AA627DC /* CoreForgeMind_MissingFeatures.swift */; };
+		13716A3BFEFDBE7E0E23FC12 /* FormFlowchartRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB95763F871B4D7E8537B05 /* FormFlowchartRenderer.swift */; };
+		13A5600DA2CE0181509BFE9B /* CharacterVoiceMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF468B5A961CACF766F59B98 /* CharacterVoiceMapper.swift */; };
+		15DDDDC765A892FA011749B5 /* FileManager+ZipFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67661206A60D2E343C101723 /* FileManager+ZipFallback.swift */; };
+		184CF49535D8A749D1929064 /* WelcomeSplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC9B497F82D0E4692AC6CA21 /* WelcomeSplashView.swift */; };
+		186C94DFDD52E0C5FD962BF6 /* NSFWToneSyncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B243FDEE24E5561C8A25F2C1 /* NSFWToneSyncer.swift */; };
+		199997C1AAEBC8CF9C165C4F /* AgeVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3C0B714AFE525C0C300173 /* AgeVerificationView.swift */; };
+		19AAFB3E1413212DEE4CBF2D /* ForgotPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F4FDA89478DA3C6805290E /* ForgotPasswordView.swift */; };
+		1A6D376754E002C610019DFB /* OfflineTTSCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F16CBBBF86D1D0410B6C31 /* OfflineTTSCache.swift */; };
+		1AA52E8403AA989F8816CCD0 /* ContentPolicyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D23F8A37F8D2031AFA05D6 /* ContentPolicyManager.swift */; };
+		1AA681C7991002EBE22B7193 /* EPUBParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA54D0E4E5B683C958E116E1 /* EPUBParser.swift */; };
+		1B46A74636D5700A1A29CA8D /* EbookImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0023E73BFB52710BF1A285F7 /* EbookImporter.swift */; };
+		1B5B659501CBD28FC2639D29 /* PronunciationEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073C2FC8529E554738DC84D9 /* PronunciationEditor.swift */; };
+		1B6F5A34E2EF61583FAA6327 /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9226EC17D7FF286BFBB579 /* FavoritesView.swift */; };
+		1BA4E1E789BEBE48C112337F /* EmotionGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0129C2D3610E506BC0C45C37 /* EmotionGraph.swift */; };
+		1CB19CA70DA23611AA6952A5 /* BannerCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4562748BF16196492E753927 /* BannerCarouselView.swift */; };
+		1D7ADADF07E3F32BDC0BD643 /* ACXComplianceChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978103783A50D41B8F4E1EAB /* ACXComplianceChecker.swift */; };
+		1D7FF9DA18CF7794727126B1 /* DownloadableAudiobookCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F172C449F889BD693E5974B6 /* DownloadableAudiobookCreator.swift */; };
+		1E23825BE372429455672A00 /* VoiceToneMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65D800B682C218999B0BEF1 /* VoiceToneMatcher.swift */; };
+		1F299562C899AC71A2E94D48 /* CoreForgeBloom_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = CADF87F5506C3142180CA951 /* CoreForgeBloom_MissingFeatures.swift */; };
+		1F948802D406681F2D12FC89 /* UnifiedVideoEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB886D3C6FEDFDCB3799211 /* UnifiedVideoEngine.swift */; };
+		2042632E5E8D4A8DCE21A04E /* VoiceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD76308D7454FC90EC2E514 /* VoiceManager.swift */; };
+		20D2D3743C9345950BAAF5F2 /* FirebaseAudioService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425D20F2474733935AE6ACB4 /* FirebaseAudioService.swift */; };
+		2104EAA6C308DCAF60EC1965 /* AppStoreMetadataConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CAFCC016F61DC70CCF5ED2 /* AppStoreMetadataConfig.swift */; };
+		2132CBAAC68F5F9C282803EC /* EnhancedTTSPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11F28ADB2CDF1CD1272AB215 /* EnhancedTTSPlayer.swift */; };
+		21EA60D07072D086FFC4976F /* AISummaryChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A271A03D265C19B76FB936 /* AISummaryChatService.swift */; };
+		22005E24E81A796F1A84BBE5 /* NetworkInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2154293C3749017C0F1B6DC /* NetworkInfoProvider.swift */; };
+		2236FDF5BFB1DFA38D9A32C0 /* CoreForgeVisual_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF409B58DBB0D3A0340C5A49 /* CoreForgeVisual_MissingFeatures.swift */; };
+		22CEB8648E03FF39A090F507 /* BuildQueueController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D4230D1EBE552B9A70A57E /* BuildQueueController.swift */; };
+		230DB31B8AE1570E75639873 /* VoiceForkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18C38C02AF14F176063F3A1 /* VoiceForkManager.swift */; };
+		23BC5473526F8DFCD7540583 /* CrossAppModuleManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCDE787B9A7CEEAE11BEA49 /* CrossAppModuleManager.swift */; };
+		247353514209079B6CC29D99 /* CrossPlatformVideoGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA503E4EE3E1AFE4021F9B2 /* CrossPlatformVideoGenerator.swift */; };
+		248986A22963864D51CFFE85 /* SceneAtmosphereBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E653A5ED88CD1D3E765779 /* SceneAtmosphereBuilder.swift */; };
+		24AC96F11743D6759F47CB56 /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A045866BEC81060ACA13C13 /* WaveformView.swift */; };
+		255920D82415805A3F34A04C /* VisualFXEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E48CC58DD2F58B715F7EAA /* VisualFXEngine.swift */; };
+		256297D22B2B992FA635421C /* AmbientFXEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF250F3D0B79FD1924F4EA65 /* AmbientFXEngine.swift */; };
+		2592B7447DA8DDE071668FE2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2274C8CE9C3215CC6A2440E5 /* Foundation.framework */; };
+		27964C1504EF283FAD01A430 /* SceneDramatization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA73F11AB22EA5DF4E7D6BB /* SceneDramatization.swift */; };
+		28847D57726AA25DA7F3A905 /* CinematicComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8288792AF0910E5822F0D0 /* CinematicComposer.swift */; };
+		28FAA76CD5E49E796E7E8A42 /* CoreForgeBuild_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E5C97E4D9835EE8984DAA5 /* CoreForgeBuild_MissingFeatures.swift */; };
+		297A8735EB92C4056E3B9628 /* AdaptiveLearningEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0A1EE74ACA6D03C7F1D8D7 /* AdaptiveLearningEngine.swift */; };
+		2A7934F8700FDD9D92C394AB /* NSFWAddonManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262AC36574561A21F69BD318 /* NSFWAddonManager.swift */; };
+		2A8C1CBA696FEC79628AC9A7 /* AIEmotionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44374A80D782947B93F54D9F /* AIEmotionEngine.swift */; };
+		2AC05A6DAE2D0B29C6882F62 /* SupportedLanguages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81B4A85A42A59233CA305BBB /* SupportedLanguages.swift */; };
+		2B64FA87540D332C5BF2D739 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 654E8C9E07A92A5C533F7B53 /* Assets.xcassets */; };
+		2B6E49DD6827B56D0E97511A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 052363B577A2D281EEB502DE /* LaunchScreen.storyboard */; };
+		2B97D0BA2FA4FBE35F909FB3 /* FXLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77148A0159522A538C086BB9 /* FXLibrary.swift */; };
+		2DE104251E58E3AD653FAB09 /* AutoUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F3B9D54CC0DC563D658DED /* AutoUpdater.swift */; };
+		2DF3955841BBCC8B5F7BFEB4 /* FigmaUIBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8068A4FD738BF29D093A78 /* FigmaUIBuilder.swift */; };
+		2E60FC5CB7D7E98DDF1CC41A /* GenesisModeEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AFB03B784E27ED1284F70D /* GenesisModeEngine.swift */; };
+		3088EA7E61532F563B18BE1C /* VoiceBookmarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C1D135E6C13268742F1D9D /* VoiceBookmarkService.swift */; };
+		30DF042D2448A39AD6F1A217 /* OfflineContentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC99EC025507285FC39297C6 /* OfflineContentManager.swift */; };
+		31123D1CDBF7F53EE9279E9C /* CodeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F40E5E7DDDCA6651A380385 /* CodeGenerator.swift */; };
+		311E6CE35A71CC30E1ED6AFF /* DAWSessionExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E5306332FF1A52998ED49 /* DAWSessionExporter.swift */; };
+		328480061620C45CD04FBD54 /* CommentSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C27C9C4BFBF2B9CF24D31FB /* CommentSystem.swift */; };
+		33A29DA511971DD062671DB7 /* GlowingButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB6F75388832B6BF354513 /* GlowingButtonStyle.swift */; };
+		34CF03C5874E9D43431DB859 /* PluginDependencyGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5C320DA7D9BC6667E9412A /* PluginDependencyGraph.swift */; };
+		353C8A7C270259E27F064876 /* MacroWorkflowEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8F3D19A68CF7269767A81B /* MacroWorkflowEngine.swift */; };
+		35648307004140061CB3B696 /* ChapterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91EFB03DAACD1E8F124C7775 /* ChapterManager.swift */; };
+		35F02281839F58A5CFA5B746 /* ViralityEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CE9A4C9987508E4D127839 /* ViralityEngine.swift */; };
+		36D4F73CDA8D458008694348 /* EnhancedReasoner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B23E77D8BF76D7F024565AD /* EnhancedReasoner.swift */; };
+		36EACDB98602DD38D08FC85E /* AmbientMixer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B61769BC6D4AA59CA2C882 /* AmbientMixer.swift */; };
+		3704094814ECD581CD39F03E /* BuildDeploymentEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5FEF75764864C9A9C94002 /* BuildDeploymentEngine.swift */; };
+		37837ADF86216B3DD6B09CA6 /* ThumbnailGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327E6E8DE0D3C53AC4B5CDF8 /* ThumbnailGenerator.swift */; };
+		3786BE1A49A9EBC839DBBBAE /* UnifiedAudioEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F69196BC094B0872D9D436 /* UnifiedAudioEngine.swift */; };
+		37B7137CE7E47E1D58586699 /* AdvancedTimelineEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1286FD3C857E8347C19E6398 /* AdvancedTimelineEditor.swift */; };
+		37D5F29DE309AB6524DDCD6C /* ReferralDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2555BAFC6776433B59A2C9 /* ReferralDashboard.swift */; };
+		37D7FE0EE5A9D000155BC0CB /* AutoCastingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CF2B9F06DCFD9CA4CC9887 /* AutoCastingEngine.swift */; };
+		39539AB63A32CB68B94D3D1F /* BestsellerStructureEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5491195D61E0DFF72DC0800B /* BestsellerStructureEngine.swift */; };
+		395EFB6CABE1B09024A21D5A /* SubtitleGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE626FBE2C669B1B1FFDF34 /* SubtitleGenerator.swift */; };
+		3A25DBA687CF96843EAF0858 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792D4FBDFF7FCDAF2D4DDB3E /* AuthManager.swift */; };
+		3CA58600564078D0F40B118B /* NSFWPaywallManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6088A773D9B94000391EF32 /* NSFWPaywallManager.swift */; };
+		3CCABB95C845EB7CFCEB93F9 /* RealTimeEmotionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CAF1A1236C35BB882B4F51 /* RealTimeEmotionAdapter.swift */; };
+		3CD77BE409207AB406ECBA30 /* SoundEffectsDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC931C47DFA210D36DCF0CD9 /* SoundEffectsDatabase.swift */; };
+		3D1064FDEB4C49B1452E657F /* EmotionPacingEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DDDA205B31498D838389E3 /* EmotionPacingEditor.swift */; };
+		3D18A55946D3EF6F9C6CCB65 /* NSFWToneStyler.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6EED8EA5142FD4BD3FB001 /* NSFWToneStyler.swift */; };
+		3EC198EEFBDBAA0F72FD376C /* ElevenLabsRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB57BD4D83F13CBFA1AECC /* ElevenLabsRenderer.swift */; };
+		3F3CC5E687BBA675CFDE4215 /* VaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B3C0E0AA374C1118BBF90A /* VaultService.swift */; };
+		40E899E399DDA4908A10CEF8 /* VisualDescriptionExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902F471013932BDB24F0ED3F /* VisualDescriptionExtractor.swift */; };
+		41211F13B520C3E3875949F6 /* PreviewKeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A0ECF9FA27D4114DC739A9 /* PreviewKeyManager.swift */; };
+		412E83DD9E45343C51AB6632 /* ExportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF513DCF4365BB974657167B /* ExportManager.swift */; };
+		413E93D574A68F15E6FF4DE9 /* FusionEnginePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C45DC1419B293D4E6E0D8CE8 /* FusionEnginePlugin.swift */; };
+		41506937E6E61F3E0B8AFE04 /* AutoFormatDialogue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19E5225D2FC6FC3E81088D3 /* AutoFormatDialogue.swift */; };
+		425AF288880971A5573ED12C /* AuthorAudiobookCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C553F7F7F652A0FD7ED0CE4 /* AuthorAudiobookCreator.swift */; };
+		431E034C866D60911B3A2A34 /* FormExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F26E6D6500600637F6932C0 /* FormExporter.swift */; };
+		43934736DD7B5CCC9AD7D829 /* UnlockableVoiceSkins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5701CCD3DDFFCAE74BE3CC66 /* UnlockableVoiceSkins.swift */; };
+		4412B8E008024A140DD1C86B /* MultiverseVoiceSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2029007383BCC8D4C67827C /* MultiverseVoiceSystem.swift */; };
+		44D332CDE81179577D74DDCA /* VisualFeatureEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F21C024DF50250A5812F54AD /* VisualFeatureEnhancer.swift */; };
+		44D3FFF891112C95A839871A /* VoiceRatingSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB5C2F2CDF9124C6B05D8D7 /* VoiceRatingSystem.swift */; };
+		467B1F3E41B71BA62F52A4A7 /* CharacterTics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0230221C41C6E4462406AE10 /* CharacterTics.swift */; };
+		467FB90EEB4B3935CA8EA703 /* AIEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C645B303664D65B664D563C /* AIEngine.swift */; };
+		468B1244B5A18F369E24C396 /* ParentReportManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB1AEC86E271F31DD5814AA /* ParentReportManager.swift */; };
+		46B3689308D17C553362DEBE /* CustomVoiceUploads.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC72C79B42D5A99BDF4CBE04 /* CustomVoiceUploads.swift */; };
+		46D865717869C6915D6255E4 /* SyncServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C346D4550D0D80C9E0D5F7 /* SyncServiceProtocol.swift */; };
+		475FD751E0D7D3EB23ABA741 /* EmotionDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6127557E6047EE304ED0E93 /* EmotionDatabase.swift */; };
+		47877AABAD9ED76E356E708D /* BuildMonetizationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE726ABED1D4B4CDD2649B3 /* BuildMonetizationManager.swift */; };
+		47893FBCED0C448FFBEBDC36 /* ParticleFXLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B06F23CDEF3916D1894050 /* ParticleFXLayer.swift */; };
+		47B3D019B8F084BFC0DEE478 /* CreditStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BC1F3482E6F4842815C9E84 /* CreditStore.swift */; };
+		47B41BC4AC3A5DAB3FB4859D /* LiveEnsembleRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05A6173FDA18CAA4E7EF42 /* LiveEnsembleRoom.swift */; };
+		4903CB4DC37626EEB44B716A /* FormTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614ABCDA49920304A3A31259 /* FormTemplate.swift */; };
+		49F1AEB974658D286996A3AF /* Ebook2AudiobookBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9720FBF067DDFCBFF29D98 /* Ebook2AudiobookBridge.swift */; };
+		49FD675FF708E635C8228900 /* PluginBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDABB0B7AD9DE841A39C505 /* PluginBuilder.swift */; };
+		4AC1174B673852DA60AECC00 /* PromptParserEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7EAD009805221D97DBC64C /* PromptParserEngine.swift */; };
+		4C92322F14BCD6FC88A4D23E /* BookCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04127A4EC76BA7118A1ECF7 /* BookCardView.swift */; };
+		4D5F9D99C88AFFFCB2A8133F /* CustomCodeInjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3EE3A96932C7E03F27CBDA /* CustomCodeInjector.swift */; };
+		4D967C143119185E67558A98 /* ExportProduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E66F6D5DB93E03B517B68C7 /* ExportProduction.swift */; };
+		4DC617994735458B2572B076 /* BranchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 130CDCFA23BE887A6E2D6F38 /* BranchService.swift */; };
+		4F01B11A5759DC54407DB41C /* CharacterTrackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6644AA983C29271472FA74C4 /* CharacterTrackManager.swift */; };
+		4F2C4056F9014AB67006CD32 /* SegmentEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0359EC4A0BEA93DF81DA560 /* SegmentEngine.swift */; };
+		4FE5471FFC1A840A58A83213 /* ViralEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75FD22EB6AFBE06E054DBD48 /* ViralEngine.swift */; };
+		501A660BB106D4E7E3375B3A /* CharacterVoiceAging.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F90FB13A14B307B0BF1C5D /* CharacterVoiceAging.swift */; };
+		505A2E13EFA2628627643505 /* ListeningStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FCDA66A3E18824091BD044 /* ListeningStatsView.swift */; };
+		5067F2E73E685F8D5D3A7880 /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E657C6292CA7FADB3A535124 /* MiniPlayerView.swift */; };
+		5084D332A9F8038018BA09D2 /* DramatizedAudiobookProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9384F21460309992B8F505 /* DramatizedAudiobookProducer.swift */; };
+		51CB0978FCBF107D2AF1F553 /* ExportQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1E8FB0E527703A9FDD133C /* ExportQueueManager.swift */; };
+		52402D28626D79E8F19E36B3 /* MultiTrackProductionSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BBA11B70AAC041D49BE4B9 /* MultiTrackProductionSuite.swift */; };
+		526D64352C8833FD2CA2FC0C /* AudiobookMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3257ADE7857F17CCD511FAC4 /* AudiobookMetadata.swift */; };
+		527E6BBA80DD1BB811055665 /* AutoRemixMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70B96E45436AE08041AA47AE /* AutoRemixMode.swift */; };
+		5512090500E8ABF3B1AEB746 /* UniversalVideoGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296C40B9AB0CD38DF85AAF27 /* UniversalVideoGenerator.swift */; };
+		55661DFECC530BDAA560682F /* AdaptiveMusicGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8A3E0B5D31FA53115229E4 /* AdaptiveMusicGenerator.swift */; };
+		55E69484754BC863B597221E /* HeatmapAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CB1E14EBB82C7398FE5E8D /* HeatmapAnalytics.swift */; };
+		562D3497768243EFFD9748F7 /* TimelineForkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F8DEAA4CACE814341BFC3 /* TimelineForkManager.swift */; };
+		56B7307A0336A3BA84A80C2C /* BookDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D637554812FCC8D2881BF5 /* BookDetailView.swift */; };
+		570FCBB4B86E3976F27C7547 /* DynamicChapterTransitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DB2833FAD412F2E644C779F /* DynamicChapterTransitions.swift */; };
+		5733D7B42A7FECF797DD2DB1 /* ExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B50B6DF825CA069E55C4952 /* ExportService.swift */; };
+		5742C754EEF630B40AFF787E /* SemanticSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 640CE93D2F0ED1998B5F88B6 /* SemanticSegmenter.swift */; };
+		57A1D93CF2F848499813B956 /* PerformanceModeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A98DB4F56393A3CF1517889 /* PerformanceModeSelector.swift */; };
+		57E62879ADEBFA563D51725F /* ReferralManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47B451741F5165402D4B3164 /* ReferralManager.swift */; };
+		5825090C727C413B9B5B2F1D /* AICoPilot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AD65F111609989C32F44B75 /* AICoPilot.swift */; };
+		589F6F4958AD13C359F7CA87 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAADFE407D11A43D434EA07 /* SearchView.swift */; };
+		58CD4E2EF74E261CDD2A2898 /* BreathingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482D62F635C01DD83AB31C3A /* BreathingLayer.swift */; };
+		5918A57843EA49B5C3CECF2F /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7104A997CAD2F933C45288 /* ThemeManager.swift */; };
+		5950103550D4A133B31D07AB /* VoiceAssigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA37D30F139C74EA5AF0EA96 /* VoiceAssigner.swift */; };
+		59E37EFC45EB8E0E3A406759 /* NarrationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A65E5668CD586ACD6AAE05 /* NarrationScheduler.swift */; };
+		5A02D8C72BA2EAC75B595C1B /* NSFWGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2EE858F6FE475D4AEFC4882 /* NSFWGate.swift */; };
+		5A581256B8E4042AA8784200 /* ArchitectureDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DFA23D5D6EE5EFD659F02C1 /* ArchitectureDetector.swift */; };
+		5A7B14656B8EA695993D6543 /* HeartRateAdaptiveAudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF7053C5A7232290849E7805 /* HeartRateAdaptiveAudio.swift */; };
+		5B4E2D6D962B2D273F1C3D87 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7BC4DD6FF9C73FB21B1B80F /* OpenAIService.swift */; };
+		5B634C46C8418ECA0690DE29 /* SceneFXPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E6435C3BDA69052484BCE25 /* SceneFXPresets.swift */; };
+		5B8DF9B333E9E13D694FCCB1 /* AIPlotBooster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C2B9D383958760603556680 /* AIPlotBooster.swift */; };
+		5BA3E9B42906632177D36CC4 /* StoryboardImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAF719FD6FF9E39702A6851 /* StoryboardImporter.swift */; };
+		5BDA0B79CF8C2258F7759EAF /* MultivoiceCharacterMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DEA77D495BDAAFD0953DAE5 /* MultivoiceCharacterMode.swift */; };
+		5BE4BA0BA03C8C7C0563E669 /* ProjectSharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA3ACCA478C63DEFE8B4B40 /* ProjectSharing.swift */; };
+		5C557C4318AFBE804A030AEE /* VoiceRevisionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF53738AFABE76D096CEA2D0 /* VoiceRevisionManager.swift */; };
+		5C60EAAC6D956CDE011CA0DE /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA6C2DB886BEE4830CDF9ED /* SignUpView.swift */; };
+		5D0C57F26BCF09CC67C0DC3A /* FrameInterpolationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C312AE303C709A1F2D3EC11 /* FrameInterpolationService.swift */; };
+		5D2AEF6467A89508D5300FFA /* StoryboardEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B6039E241918FFEF4DA79B /* StoryboardEditor.swift */; };
+		5E483AECA40D851DEBFC0562 /* SFXPackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1E5F3ABF27DABCA2D53235 /* SFXPackManager.swift */; };
+		5EC73A546F9E7AEDE057E5D2 /* ExportSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7FBAC4A17C1A13026CB9EA4 /* ExportSystem.swift */; };
+		5F4EB59BA7122524E62A82EF /* VoiceHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44D2F74F474F4F1A1BE82A0B /* VoiceHistory.swift */; };
+		5FDC4DE368EEC58975207A23 /* LocalElevenLabsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60ACEB11DF349A64EAB7A2D0 /* LocalElevenLabsClient.swift */; };
+		5FEC4877C6944563050AC811 /* VoiceTrainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A07EF8BE89459197D50EB1C6 /* VoiceTrainer.swift */; };
+		60AB8241C5D61DDD55737E1F /* MemoryPinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CD0963396C2CFAA9BE2D322 /* MemoryPinning.swift */; };
+		6117E95013AC9F672326A855 /* StealthModeVaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C8ADD111F07E656D43FC3A /* StealthModeVaultManager.swift */; };
+		61675D494DC9BB6E61595E6E /* PreviewSandbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7670B7086B80E1D737718F2 /* PreviewSandbox.swift */; };
+		61A0F830669F332BEFEAD7E3 /* AudioEffectsPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F8366968C34F1A8C6BEEE /* AudioEffectsPipeline.swift */; };
+		61BBC4738BDD848FB72FF582 /* MarkdownLayoutParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8F898A340675C5D40442C0 /* MarkdownLayoutParser.swift */; };
+		62205852EF0BE56791FCA686 /* CoreForgeDNA_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38CE09520864938898DC7DAF /* CoreForgeDNA_MissingFeatures.swift */; };
+		627694E675BC6766FBE373C0 /* LipSyncAdjuster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F2E4E6040C597181994FA5 /* LipSyncAdjuster.swift */; };
+		6281028658E057592620E926 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D63631012B1F3BE16BB67A6 /* MainTabView.swift */; };
+		629F859DC58475BA754240E8 /* FilingsDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C54AA61E51CC4A065C2299 /* FilingsDatabase.swift */; };
+		6321B9451935858BDC9F7188 /* CharacterMemoryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4551CD0E04D733B5006958 /* CharacterMemoryEngine.swift */; };
+		63633D6B236B4031B9DFA58A /* AudiobookCompiler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A994823254578B0F05038459 /* AudiobookCompiler.swift */; };
+		63F9706A93248C189085A173 /* SeriesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D2B745A6A27DD9D08D8ED67 /* SeriesManager.swift */; };
+		64CD31A24A123D9F4FE5E10A /* CoreForgeQuest_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F7A40351A041F032F80D6C /* CoreForgeQuest_MissingFeatures.swift */; };
+		64FB04939F5A34C9C524AEA1 /* StyleEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E03E3E9EF72CAD33EAC37D /* StyleEngine.swift */; };
+		658ABA4961DFEAAD4BE83638 /* SceneGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D5D661ED9186060C17D6514 /* SceneGenerator.swift */; };
+		65B14E574B3A93ADD7D8479B /* MindNSFWModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6A56AED6C3DD44576B2C1 /* MindNSFWModule.swift */; };
+		664FE52CDAB810602FB12894 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DC8B70105F5522A90461F0E /* OpenAIService.swift */; };
+		66AFAAC47917CB7FB8AFB7D0 /* DownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A0346F8BF557F425F0C2D43 /* DownloadQueue.swift */; };
+		670183C1D79443BE4A433E9C /* MultiTrackEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6801066E61EEA234011CFC2 /* MultiTrackEditor.swift */; };
+		68A1AADC824B5662663800A4 /* NSFWEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98B5FB5192283B7BC0D0807 /* NSFWEnhancer.swift */; };
+		6B8ABF516E0E565AC75EEC5F /* LoadTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2109DC44B62D792D8F622714 /* LoadTester.swift */; };
+		6D1FBFA5F6E9530F478F086C /* OnboardingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74F4162594A871B28B1492E /* OnboardingManager.swift */; };
+		6D4264F9B46F3EDA0A77FB02 /* BuildImprovementEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A88ABA46731522F346EAE41 /* BuildImprovementEngine.swift */; };
+		6D510AFB2CBD9118144A960F /* StoryboardPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2272D27E0CDDE1937940C617 /* StoryboardPanel.swift */; };
+		6D8553F2209B6547FFCC476F /* RealTimeImproviserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043AF94B0A72B7B3688CA329 /* RealTimeImproviserService.swift */; };
+		6D8C4381E82852BE696E2AC6 /* CoreForgeMusic_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D871B6A478E6A6D9791CE6 /* CoreForgeMusic_MissingFeatures.swift */; };
+		6DDAD120E6053C5DCD31AE91 /* SettingsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85AFFC99353558BC6B6E822C /* SettingsPanel.swift */; };
+		6E31890BFB75E237A5560580 /* VoiceAdvisorAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FF9959E658158E02E0887D /* VoiceAdvisorAI.swift */; };
+		6E38EA6F8C21289EF2081C0E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688151BBB5C041468DF281E6 /* SettingsView.swift */; };
+		6E895491308A62B2C87FF59D /* NSFWDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BE64A336F24F8FBD2AADA5 /* NSFWDatabase.swift */; };
+		6ED911B39CAD1E3F7F016738 /* AdaptiveReasoner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74707E4A875AC3BF78EB4FB2 /* AdaptiveReasoner.swift */; };
+		6F0A1DA9EF4E1A1794A36619 /* StyleModelTrainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FD29574D3DD33EE0C9B0B9 /* StyleModelTrainer.swift */; };
+		6F57878F8DE01FE00BD6E486 /* CoreForgeAudioIntegrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6134BBD3F575B13E386656 /* CoreForgeAudioIntegrator.swift */; };
+		6F8A86939DE66727AE89EED3 /* ImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5316C14172E77540599D6DB7 /* ImportView.swift */; };
+		7020372E06C222EF0B2A683B /* FavoriteVoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09485334CFE34870AD00F54A /* FavoriteVoiceService.swift */; };
+		712ECC59E406E856E85C7C8D /* NeuralOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F65FECCFA13BFC01E80647 /* NeuralOptimizer.swift */; };
+		71774170AADACAF32C042827 /* LivePresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE1E6FB07F9191AE7502404 /* LivePresence.swift */; };
+		71D0EB2D3D584612C5B3ED67 /* SleepMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7492919D89044D89E65AE54B /* SleepMode.swift */; };
+		72093057B365DB57B639A5E0 /* SceneMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6172A395D01A37E6D6D40585 /* SceneMapper.swift */; };
+		729A166A8A9C82D19C1AE86F /* QuantumSceneLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25799E7FEBCF63A63121D04D /* QuantumSceneLogic.swift */; };
+		72B8428ED9A3DF135561716E /* CameraMotionRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFDC4B86EDF4398F04948AB /* CameraMotionRenderer.swift */; };
+		72C886172D6CD04BAD8A2A22 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED03E27A1ADEC87CC288C040 /* AppSettings.swift */; };
+		72E8C58E01DFBD260DD1ABB2 /* AIVocalProductionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F67A8A49EB883E3F825A94E /* AIVocalProductionEngine.swift */; };
+		7334E73341C2A9FE86CCB9FE /* ReplayAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566F3FF0E231FF8D481B4C93 /* ReplayAnalyticsService.swift */; };
+		74FAAD28CAA5A62ABE093D00 /* MemoryTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934A9009CAD9F5107ABE30A7 /* MemoryTracker.swift */; };
+		7534F2526E44E689ADB0901C /* SceneSoundtrackCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33733AB47BDA4D17CCA4E655 /* SceneSoundtrackCoordinator.swift */; };
+		75E06CDA7EA0B4BF761812D2 /* SceneGapFiller.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27BBBCAE0E53F8A6EF7D9D0 /* SceneGapFiller.swift */; };
+		766A5A72FCFA74C2FB7EF3CF /* NSFWService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D8FE1513763F0742FF5D6E /* NSFWService.swift */; };
+		76B0C31726D637421003253C /* VideoEffectsPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C550F14F6BA637B5867D75 /* VideoEffectsPipeline.swift */; };
+		76C9AAFF840BB9C22008BBDC /* FusionVoiceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A65C59762E110F486CAD9852 /* FusionVoiceController.swift */; };
+		775AE9ACB7AC05DEB9C4997F /* WatchSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85114D6FD55C1EBD6CCD888 /* WatchSyncService.swift */; };
+		79C009AAFED359040F638A85 /* PromptTemplateLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1CC45EF605CC689696EF908 /* PromptTemplateLoader.swift */; };
+		79CC91EBCF06FD7C468F033A /* VisualContextAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C29E7F401479C8111BC44B /* VisualContextAdapter.swift */; };
+		7A295C046F0858D51C899A8B /* SocialMediaManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5983230A954F4CD8198A198 /* SocialMediaManager.swift */; };
+		7B29E8752CA8957E6B134657 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95C843A8084D05B4FB215CE /* Book.swift */; };
+		7BBF8426298903808F7313EF /* CameraStabilizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6E144B78E2CDC068DC6D92 /* CameraStabilizer.swift */; };
+		7C39A0D296D4C270C2AF9C96 /* CharacterVoiceMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B31B3279342EB22EB2C0B90 /* CharacterVoiceMemory.swift */; };
+		7CF884A299F819B6266DB667 /* BlurbGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489D79AC20A4553BA4651C11 /* BlurbGenerator.swift */; };
+		7D32440302B7937768FA9EE4 /* RealTimeFeedManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F9A5C812FD0F7B788FB1ED0 /* RealTimeFeedManager.swift */; };
+		7E2E37F947A0E3401A9456AD /* TraitMemoryPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74918B207D8BE19335C774D9 /* TraitMemoryPersistence.swift */; };
+		7F1CAD7F3C2BFE89C94E3ADE /* StreamAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7543F618A69ABA1DBEE15483 /* StreamAssembler.swift */; };
+		8016D22A9C290000522B3A15 /* ReplayAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6872CF63F9190D32027AEBC2 /* ReplayAnalytics.swift */; };
+		802945F98A9C46C9845B1B7E /* AppleBooksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F64B8A1F2A2643E8ABC972 /* AppleBooksService.swift */; };
+		80512C0CCED929B600D6D1A8 /* QuantumChoicePlottingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F776641FF1110052256EAF1A /* QuantumChoicePlottingService.swift */; };
+		80C8DF88EEE4D0FA06E556E6 /* UserAnnotations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBFF611BD616EAF222B139 /* UserAnnotations.swift */; };
+		80F9B1BE8344D4BA8D8410BE /* CharacterProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2B727FC99F665C3BF1146A /* CharacterProfileManager.swift */; };
+		81457D98058B62932F451E64 /* GlobalVoiceLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D450A334B632E31F1879BE8B /* GlobalVoiceLibrary.swift */; };
+		81CDBE620969C6AC1E087322 /* VoiceCloneTrainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E48CF07457481A35A2A4289 /* VoiceCloneTrainer.swift */; };
+		82937959DECDA99CA1BEF652 /* FaceTrackerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 345D00B6EE6AC6DDD43EFA80 /* FaceTrackerService.swift */; };
+		835B16D4ACB3A93337B8D76E /* CoreForgeWriter_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE123E615D8B72BA238DE4D /* CoreForgeWriter_MissingFeatures.swift */; };
+		83647172614D0C9D959EC174 /* AudioSearchIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B138EB1316963D7145F9AC9 /* AudioSearchIndex.swift */; };
+		8420E109059CCFC919ACBEB4 /* LocalAIEnginePro.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28377ECC266C3B3506D8F9B /* LocalAIEnginePro.swift */; };
+		849BC0B5B81E62C69BF28A9B /* NSFWPhase7.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CA0847F302C163840CC44F /* NSFWPhase7.swift */; };
+		8570986602FDFBA0C942351E /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396D8689DCA55C3C01848D60 /* NetworkMonitor.swift */; };
+		859EC4A0D32208CD39B54508 /* BookScanAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 297C49A41BA986E311210CAA /* BookScanAnalyzer.swift */; };
+		86927019F6A877E45047E100 /* VoiceDNAForge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17975F68102AF33C92A27CFD /* VoiceDNAForge.swift */; };
+		86A0CBACCAD7B9E9E3535FBC /* TTSHumanizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E9C21A164F5F7FEF1B818A /* TTSHumanizer.swift */; };
+		86DF8252364C20B55AA0ECA3 /* ViewerNavigationTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0181ED31E2C2A6A275E92 /* ViewerNavigationTracker.swift */; };
+		86F6D63C2BE6DACDE8BA4134 /* OfflineQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = E06C254410685EE0607DA6C0 /* OfflineQueue.swift */; };
+		876F6A1165736561AAE3AAB4 /* CoreForgeAudio_PlaybackBookmarking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DEB05F6522078A88F5E6894 /* CoreForgeAudio_PlaybackBookmarking.swift */; };
+		8877D4D1EC7E0FAF297D780A /* CreditsHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459EB67C128B19FE9EC18348 /* CreditsHistoryView.swift */; };
+		88A39C1EFB23B2D768E0D357 /* EmotionalArcTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD091E40137E8B2A0FA8681F /* EmotionalArcTracker.swift */; };
+		89CBB257C5075B7B8EBDCCEE /* EmotionArcVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5030CED050FC1AE52E08605B /* EmotionArcVisualizer.swift */; };
+		8BE530D2A1513998D223AF61 /* AIStateTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3398DEEF2660B0EEE799FB44 /* AIStateTracker.swift */; };
+		8C5740F8D3FE81BA1B446813 /* NotificationSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288A770742EB547A89EE98D2 /* NotificationSender.swift */; };
+		8CBD5DF1312CD02F6B9D54D1 /* MultiverseDirectorToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4131EC5C1E781CFFC95EA1BA /* MultiverseDirectorToggle.swift */; };
+		8CEA8B49AFB228AF0A199180 /* LanguageDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A353757CBE8F201B728CDB /* LanguageDetector.swift */; };
+		8D4A18350B9F0B7972640A02 /* ContextualMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA8B7AD3B31F3AABC3EC332 /* ContextualMemory.swift */; };
+		8E491E82D040B3B095DCAF75 /* AutoTranslateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3AD91F5B84E94FECDACBCE /* AutoTranslateService.swift */; };
+		8F0AAB59C82548C24D1FC3E7 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4036FBF4A65F95760BEF0BAC /* PlayerView.swift */; };
+		8F9CB5F76DB24BE931632599 /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F57ECEFF8EA7D9822BE4917 /* UserPreferences.swift */; };
+		908F3438CFF52D23466D1543 /* DecoyScreenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CA022C038682DA150D3BD8 /* DecoyScreenManager.swift */; };
+		90F4E4B7FEC73D54BA0661FE /* NSFWHabitBehaviorSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7889B0A0A744F2AD833993C6 /* NSFWHabitBehaviorSimulator.swift */; };
+		912335D60E11012BC8D67D95 /* ChapterAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768B6A8BC799FC6A26756CF8 /* ChapterAnalyticsService.swift */; };
+		9185712159DDB84E4BEF6E36 /* AppFavoriteVoiceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CB1E0C1033F62930DD2E76 /* AppFavoriteVoiceService.swift */; };
+		9230F3CA6C198795B20CD218 /* MultilingualVoiceBlend.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0FFDDC6057EAC7BCE744F1 /* MultilingualVoiceBlend.swift */; };
+		92D17CC6AEC69593895BC3AD /* LanguageTranslationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA943D45F9857D72075DF719 /* LanguageTranslationManager.swift */; };
+		937ADE6B7C2E9314A6108384 /* AITropeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D540C4399415A1968C6E0F1 /* AITropeDetector.swift */; };
+		94385428478ED4F9A780E9AE /* ConversationalLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F9D03E36D8EEFBB7671391 /* ConversationalLayer.swift */; };
+		9482CD251DE3846DA109873D /* CharacterDossierEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7BF94AD2327257BE8004A0 /* CharacterDossierEngine.swift */; };
+		9494A9BDE1F091910671005F /* CoreForgeLearn_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E37FDE5CC5CC1F4FB0A6C31 /* CoreForgeLearn_MissingFeatures.swift */; };
+		94F919D5DAF55BBE6DFA832A /* FusionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A31E3E669D4C74E61F66D5 /* FusionEngine.swift */; };
+		9524E618BE89DF31974C3302 /* ReferralView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A98A86A33EEE93E97D40EFA /* ReferralView.swift */; };
+		952A39E3F5AF0481E6FF76A8 /* ConsentTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75EDCC6FFC3820CB105B5CDC /* ConsentTracker.swift */; };
+		958C5C8CFEF31D906938537A /* AudioPlaybackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE8E833A5FE75B152742FA1A /* AudioPlaybackController.swift */; };
+		96641113CE3FB4B69B2919EC /* PluginMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CC521A5F2DB549FD7B2BA1 /* PluginMarketplace.swift */; };
+		9684C9CE2E12CDC90912A05F /* DOBCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5D4828887DF8191AD38E1 /* DOBCheck.swift */; };
+		968B43B92838CB996CC51C95 /* ChapterDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5087B6EC9F3C9DDA5C8A1E /* ChapterDetector.swift */; };
+		973D086B8BC577E809F40859 /* InputBindingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F51B1D6FCFADB8FC678665B /* InputBindingEngine.swift */; };
+		973E0B3802AC35FF33866392 /* ComplianceChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B2510F573A42B73A3830DF /* ComplianceChecker.swift */; };
+		97E2C0FC49936C059CE2D168 /* VoiceControlService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B00FD0A7BE982ACC5614B8 /* VoiceControlService.swift */; };
+		97FED7FD575081ABAAFDC1CB /* PromoCodeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4437C9025B4D1F769D01A1F /* PromoCodeManager.swift */; };
+		981124989CFE72AEB34176F4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B99F4C047A0376269AA27A5 /* ContentView.swift */; };
+		983226AC3269E1E980B2DB81 /* EmotionHeatmap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E44276A7FB44E624DF27F1 /* EmotionHeatmap.swift */; };
+		989F2C847FA2C6F273EC6517 /* VersionedExports.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFD9F9946C6E74555B8766E /* VersionedExports.swift */; };
+		98CC0EE09551BC1DAB9026D8 /* AppTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376C1336CCEF26F8F084EC47 /* AppTheme.swift */; };
+		98D517BE7CE95F4752853549 /* AppIdeaGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D14474DF47A474AD3493AF /* AppIdeaGenerator.swift */; };
+		9B0FDBCF51BFA6F3F26063E3 /* MultiLanguageAccentNarrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB14F3EDAF3ACED412A4CDC5 /* MultiLanguageAccentNarrator.swift */; };
+		9B62DBD6875C163F325DE3DC /* CyclePredictor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC64126506BAD241FE7F90E /* CyclePredictor.swift */; };
+		9C86F46B28C1CF65925997C3 /* SecurityScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD6D18CECC7C0C3DACB0EC1 /* SecurityScanner.swift */; };
+		9D52228C054DAC9838A09607 /* HeroSpotlightBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6688954B40BD5ED4841C1BC8 /* HeroSpotlightBackground.swift */; };
+		9DE37BBC406D7B0AD464149D /* LocalVoiceAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE5E0272C630E5A0B347740 /* LocalVoiceAI.swift */; };
+		9F043B122A2AAB70334D35B2 /* ColorGradingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC421B6EAE6C126C01EC55A7 /* ColorGradingEngine.swift */; };
+		9F6797794D608306F7B0F867 /* AuditTrail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034B06DFE7843C53100AD30A /* AuditTrail.swift */; };
+		9F8A724FF65794205C55674A /* DownloadsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1197097692EC4CC00A247E96 /* DownloadsView.swift */; };
+		9FE1CBAC7DF388DF1A962306 /* OfflineMP3Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72BCDD8A11968BF3AABEC97D /* OfflineMP3Downloader.swift */; };
+		A095D86D24671D4E07449FBF /* TTSEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286E7B787291461F91B5C56B /* TTSEngine.swift */; };
+		A0B853870CB3A24EC9DE6C9A /* SpatialAudioSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79918570E9397486BF9530C7 /* SpatialAudioSupport.swift */; };
+		A0EED82AF8570850F3793259 /* PluginLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BA2B64DB508D632FB96114 /* PluginLoader.swift */; };
+		A22D889340D40BDBA4561A16 /* VoiceReactivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D8465318B2DB2FA3F0A365 /* VoiceReactivity.swift */; };
+		A26B3EA5B79F9EDC8AA8205B /* VisualMultiverseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332110419B30B423E6CF2FC8 /* VisualMultiverseManager.swift */; };
+		A3CEE9FDC3E2DF6AF2AED6D9 /* VoiceDNAVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BE4C66AF5CDEB17956F87F /* VoiceDNAVisualizer.swift */; };
+		A4295BF901A0245501CC24BC /* OutlineGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256622C7A271D677080C143F /* OutlineGenerator.swift */; };
+		A48C1D7D9CB1E77E7A332339 /* ExportTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99065F72F26B52517C3A0777 /* ExportTools.swift */; };
+		A56BD8F460AC360AAEA787D7 /* AIStudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36BA9C967CD920704EE6D678 /* AIStudioMode.swift */; };
+		A603E89573FDD305DF558BD7 /* PronunciationDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6504DE864796A7669332A703 /* PronunciationDictionary.swift */; };
+		A6F7D70158061E5AFA32BAF1 /* EmotionAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0767251A8C50311E9BA3ED87 /* EmotionAnalyzer.swift */; };
+		A714B23BAD9DDE32B2273971 /* AdaptiveSceneCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12BF357CB6629B420C87588B /* AdaptiveSceneCompletion.swift */; };
+		A9092B74C32ACB66AFF89E99 /* CharacterQuirkEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B21B362A27F0A4B9B667D8 /* CharacterQuirkEngine.swift */; };
+		A9DE2D74DF6C29417AC34C6D /* CMSampleBuffer+PixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1B87644899B29FB7BB1241 /* CMSampleBuffer+PixelBuffer.swift */; };
+		AA4B0A0D82B1B22E6314A3CD /* NSFWVoiceEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 482665214A77B982A95F091C /* NSFWVoiceEngine.swift */; };
+		AAD76469C8CE866E4C15B790 /* SceneMemorySimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACF71ED80C50A65CD6359C8 /* SceneMemorySimulator.swift */; };
+		AB2670818A42A464F1697AD2 /* CoreForgeAudio_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D9DB76571383C7D6E4E3C3 /* CoreForgeAudio_MissingFeatures.swift */; };
+		AC2117E452E8A3B4A0403B6C /* DataEncryptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C674D00E92E2736DB9A50594 /* DataEncryptionManager.swift */; };
+		ACD5C7E0CF1B783DBC9109C8 /* CoreForgeStudio_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3B9CF5C510002056610EE6 /* CoreForgeStudio_MissingFeatures.swift */; };
+		AD69189A53D19AC94F7CC8F0 /* CommunityMarketplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FFF9E5B564E625D62C0DAC /* CommunityMarketplace.swift */; };
+		ADFA07260D0C380397B56485 /* MemoryAnchorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EA2D7C756F41DFCDE1912A /* MemoryAnchorService.swift */; };
+		AF40C9D2AA22C91A2B179B85 /* TimelineEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41A360C6545BE9236ACC202 /* TimelineEditor.swift */; };
+		AF454060362259283D8CB4F0 /* EbookImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10B0BB76994668D85ED64C7 /* EbookImporter.swift */; };
+		B0102067775E47B3C2DF1ABD /* StealthVault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780B93E12C98CAF9B0375EF8 /* StealthVault.swift */; };
+		B0343FBA184ED1B051B02804 /* LibraryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4CECA69E15E2649986C44B /* LibraryModel.swift */; };
+		B09C015067D6E1C0328F044C /* ProfileTierCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E70D13FCAED04AB4CFE9200 /* ProfileTierCardView.swift */; };
+		B0C2AC690DC6C7DEC621B12E /* UsageStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA328AEA3C24F926CA0F0671 /* UsageStats.swift */; };
+		B27822B29A0EB613FE31792F /* HapticDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EBBF1D3F15B87F4273EDA7C /* HapticDeviceManager.swift */; };
+		B3047FC0C27E733341D22A74 /* PlaybackSpeedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B340A308A6C8ACA4F802C7AF /* PlaybackSpeedControlView.swift */; };
+		B3ACB1A9FC1B2D289C1EDF5E /* TTSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261DCAE0CB5F0B2B2C02821B /* TTSService.swift */; };
+		B3DDCF9B3A36D21E50F3497D /* AdvancedAudioExport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5813B72C9761CC3EB97377 /* AdvancedAudioExport.swift */; };
+		B473CD2896181C102B03F4DF /* PlaybackProgressSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C94A66E278A2346AD11AE0 /* PlaybackProgressSync.swift */; };
+		B4CDAA28B36AAF9BEF3FF384 /* NSFWSFXPackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F90EE8AD6E67847D0C0F5D /* NSFWSFXPackManager.swift */; };
+		B5C25DBB6D3C635198F42935 /* AudioExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66123578CD2B94F343B2B852 /* AudioExporter.swift */; };
+		B5F5043AA2633F5A52397B61 /* HistoricalTimePeriodChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C639EE04EC11DA53066F7290 /* HistoricalTimePeriodChecker.swift */; };
+		B62D367644591F4B0901CAAC /* TierUpgradeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0842B2F85A3BDB1181837A9F /* TierUpgradeView.swift */; };
+		B652B0850A7CE700CC25F367 /* ChapterSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89B42D245BAC109F81B42B0 /* ChapterSegmenter.swift */; };
+		B6A1DB6FBEB7313F2D45B531 /* ReferralProgram.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30E6CD8758A042228F38DEF9 /* ReferralProgram.swift */; };
+		B769A15462431389107B7A2C /* AutoVoiceSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D329FC94B0F4ED60183C8ED /* AutoVoiceSelector.swift */; };
+		B807A4C81324A85A8F22C6A0 /* StealthVaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B9C631B3BA0CB455EC62B9 /* StealthVaultManager.swift */; };
+		B87A4D0013223C5E297E4681 /* FormTemplateLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA98FFC8DBECF99D2A820D6 /* FormTemplateLibrary.swift */; };
+		B9507F3FBE007AE9200DC61E /* VoiceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30013A478AAFE731210DACBA /* VoiceConfig.swift */; };
+		B9FC51F97FCCD8209461C5F1 /* ElevenLabsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C938BA7B0EC7182FB94BFFCD /* ElevenLabsClient.swift */; };
+		BA6C88A1AB1AE2E42E715788 /* FormGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807B06D0F42EA0CA17A0BD8B /* FormGenerator.swift */; };
+		BA8350AC1606B6F3199BC42A /* SelfRepairEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C858269D4CD8177CE659A33B /* SelfRepairEngine.swift */; };
+		BAD27CCE89E630AA7B63C0BE /* TemplateMonetization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F89D3969A047DBDBEE344A6 /* TemplateMonetization.swift */; };
+		BBC3FB8E8BFBD0B52E6EAB1A /* Export360VR.swift in Sources */ = {isa = PBXBuildFile; fileRef = E607C529F6A2EA448D203F8B /* Export360VR.swift */; };
+		BBF3E6AD490FF4BE50CB48D5 /* CreatorPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64DF4CAEE3F09CD51408ACA /* CreatorPanel.swift */; };
+		BC5A22C750E7819F10B2B026 /* VoiceSyncController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFC20E05BF1A9C8779EC4C9 /* VoiceSyncController.swift */; };
+		BCAAB53F8CCF87C37FD49122 /* PromptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9ED59C899B81704ECBC1F3 /* PromptParser.swift */; };
+		BCC6441E215D0BA62ECA4EED /* CharacterDetectionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34988111133A0E5B140F0A83 /* CharacterDetectionEngine.swift */; };
+		BDED3C936287DEC435FDCC87 /* AnalyticsLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FF1D8FD73D72239BC1A6128 /* AnalyticsLogger.swift */; };
+		BE7139FF90B4AEAECD6D594F /* AccessibilityOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B20008621FCE7BD8867906 /* AccessibilityOutput.swift */; };
+		BECA139FF3B2831F0FE2CA7A /* CharacterVisualizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89905EBB29DF34B4BA5A0BEE /* CharacterVisualizer.swift */; };
+		BF893169DF89D32A9B3CD8B0 /* MacroPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B2EB96107B9E9700B5D701 /* MacroPlugin.swift */; };
+		BFFE5B086B61E601CD7B11FB /* AppStoreIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CC90D7BCF411FB19821C913 /* AppStoreIntegration.swift */; };
+		C0383323F36AE29E4D4918DE /* NSFWSceneToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985643EA7FC1985EA392E4A4 /* NSFWSceneToggle.swift */; };
+		C04E34361BB27206545F25B5 /* KindleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4314582A6305C5D5FCA11064 /* KindleView.swift */; };
+		C16FE41603E632D54CED997D /* AmbientPreviewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA1C1D008190A8615A58C63 /* AmbientPreviewer.swift */; };
+		C182A18E4F08A5A30C1C0437 /* GPUVideoRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069772C9701D65CFCFC49881 /* GPUVideoRenderer.swift */; };
+		C2FBC3804F1FE4A82F62D46E /* DocumentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E8749C333D4137941D706A /* DocumentParser.swift */; };
+		C3064E2F5CF9853E93B6D3C3 /* MultiPOVSceneBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916B0C1BA011C68934D8C5BC /* MultiPOVSceneBuilder.swift */; };
+		C3B1CC39D51F10F3BAF19A46 /* NextGenSpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DF5DA58B96CC3863E71AF1 /* NextGenSpeechService.swift */; };
+		C4532D635D0AFB023F14BD2E /* WorldMemoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */; };
+		C57D0B9A561122B5862C9AD6 /* AgeIDVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32008BE2556A8BD0999A1BAE /* AgeIDVerifier.swift */; };
+		C5B2E8ED9D632FA55DFE807C /* SubscriptionCreditSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2589E3499E6573FD89CC55E /* SubscriptionCreditSystem.swift */; };
+		C6AC572D3944E4601B063120 /* ProfanityFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6013D9CE6EB2C0A3BDA1F736 /* ProfanityFilter.swift */; };
+		C6D8B2A279CFEF895472335B /* SoundEffectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1062C217A585825286B48C0 /* SoundEffectManager.swift */; };
+		C7432049ECE24A3528F72AE0 /* SecureStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85CCCC1848614EDB17266186 /* SecureStore.swift */; };
+		C7EDC2C97A1460CE5E076F1A /* OfflineDownloadQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483CDAF40A1599742BB1FBF3 /* OfflineDownloadQueue.swift */; };
+		C928671A023EFF3FEBF2423B /* SubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A9491F58FFB6AAB4F7BEDC /* SubscriptionManager.swift */; };
+		C9914A2C3374576717EDD8A8 /* ExperimentalFX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7417EBD61C3C8D8BBE5DA1CC /* ExperimentalFX.swift */; };
+		CAA99742376AD302B6EF8519 /* SoundLayerEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8397BB4A0AD48935317E7 /* SoundLayerEngine.swift */; };
+		CAB4CC8D9581D9EF90D3312A /* AnimationDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F30C35756E870A3AEBCD593 /* AnimationDashboard.swift */; };
+		CABB53BB8469D46F56CEFAB5 /* OCRScanMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6418A4324EDFAD12529EC847 /* OCRScanMode.swift */; };
+		CB1B9773262EB025BA79FCAA /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E239EC118899F28C0A22D2A2 /* DashboardView.swift */; };
+		CBC0EEFEB7117A648D454E69 /* VoiceFXStackEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3667826427527849ABFD22FA /* VoiceFXStackEditor.swift */; };
+		CC7A53E1926F96648C7006E9 /* AudiobookPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF0F4DB1369829F5204C91E5 /* AudiobookPlayerView.swift */; };
+		CD4F93D52871CABB4FE02BCB /* CommunityReviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AC16A130A2C7DD56B0A650 /* CommunityReviews.swift */; };
+		CD56AEB77A5EA26521FD47AD /* AIUsageTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1364651BE0702DECCDE9FCF /* AIUsageTracker.swift */; };
+		CEB603AA505E7A1BA67BEC35 /* VoiceMultiverseLinker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C659EE7A11D2DD477C57D824 /* VoiceMultiverseLinker.swift */; };
+		CFCE0B1B837CD137B44E057E /* HybridQuantumTradingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B86B6E001F481BA0096925 /* HybridQuantumTradingEngine.swift */; };
+		D10B5BB12B47DB3B678F7073 /* QuantumRealitySwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1696827AA9EF79399799A3A8 /* QuantumRealitySwitcher.swift */; };
+		D275A78CE305245ECFFF0696 /* HighQualityVoiceLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859CD6702F25EA4905A3C593 /* HighQualityVoiceLibrary.swift */; };
+		D2CE452B62C800C4147F2D5D /* AdaptiveDocScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC241B2B39CF92E78D577A7 /* AdaptiveDocScanner.swift */; };
+		D2EED75196C43F8EEA728D66 /* VoiceCloneShare.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C524EC8687E9582AC24DD6 /* VoiceCloneShare.swift */; };
+		D31B0997ABA180E341AE1A7A /* NSFWMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB2AA789238C33D853E5F68 /* NSFWMode.swift */; };
+		D4175B76A01D6EBACA821FA2 /* ExportRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD4F2204C83213AA617411B /* ExportRenderer.swift */; };
+		D4676B2BDCBD183D6CA0D1CA /* MemoryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B463B6F874F77344EFF125BF /* MemoryEngine.swift */; };
+		D491A910D5B5C3504E9C2DC7 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1EF4C3C86AA5CC47D140B /* OnboardingView.swift */; };
+		D60A6534658E63FB93917648 /* NSFWBlurToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD13C41B7E06ED61D50B5AF /* NSFWBlurToggle.swift */; };
+		D6EC862B4611B63416116E1C /* prompts.json in Resources */ = {isa = PBXBuildFile; fileRef = 6324FA4CA2BF4C4F43B85DCE /* prompts.json */; };
+		D72FAEC06AF9F149F2995BA4 /* RenderAnalyticsDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC60BD086CB15D146DE01858 /* RenderAnalyticsDashboard.swift */; };
+		D730D86BDA40D58C99061D39 /* FeaturedCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178B7A1DF14DF5F041D37029 /* FeaturedCarouselView.swift */; };
+		D752FC3E1B169CC78D430DB4 /* CanonMemoryGraph.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1F3AA2B5EC90FC645A27AE /* CanonMemoryGraph.swift */; };
+		D790F4AB36B45D593DE50442 /* ChapterImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D1B6F0AFC931E49E6F1E47 /* ChapterImporter.swift */; };
+		D8294D853B49425AA1CE75FA /* VoiceDNAForker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6951F5A72FBBB88D722D447 /* VoiceDNAForker.swift */; };
+		D84BD994A683067AA11D1D5B /* SceneTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72B70ADA05D88D8D5C88A97 /* SceneTimeline.swift */; };
+		D8B35C8FE12475E120B706E6 /* SceneParserEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1778237C60D0ABE230FF5188 /* SceneParserEngine.swift */; };
+		D92C40823E7BC5807CE616FC /* WatermarkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E750817C5D453940CFE0FBC8 /* WatermarkService.swift */; };
+		DA2DC6E7CF07B847E0AC290A /* FormWizard.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D8E5368A05EC69AF0C05BC /* FormWizard.swift */; };
+		DA6C9EA29B3917E43E7C119D /* NSFWVoiceClipManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD988A209271D3C4F76FECF /* NSFWVoiceClipManager.swift */; };
+		DB71CD6B57F27A6A53E650D0 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380038B5F0E47EA932BA53B7 /* LoginView.swift */; };
+		DBB238E697ABF83E12AB56DD /* DocVideoScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1952DB1BFFDA5141078D0907 /* DocVideoScanner.swift */; };
+		DD7CC520C28E734733DBB3E7 /* EbookConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4348E2B287D544E6CD9BA0EF /* EbookConverter.swift */; };
+		DD82498321C22A4F52217363 /* VersionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58704451C7F68A25DC9B8ED5 /* VersionHistory.swift */; };
+		DD8400EA2F82AACC9AA8AEC2 /* AudioCreditManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF6AFDD60A82A9618BB8E2A /* AudioCreditManager.swift */; };
+		DDBD718018D730A0A7558DA5 /* VisualMemoryEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBC998471C16F2ED738AFED /* VisualMemoryEngine.swift */; };
+		DE55987A2AB9FE12B178451D /* BuildBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF229F46211DF3969186838 /* BuildBridge.swift */; };
+		DE8AE8ED043E51202294DABC /* PersonalizedGreetingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FBC8238D2C9905E87E9B88 /* PersonalizedGreetingService.swift */; };
+		DEFC6B0F1E85797083F17826 /* VoiceReviewSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23A6A876E04D07BC34EE357 /* VoiceReviewSystem.swift */; };
+		DEFE4FCBC077C593B3CB18A6 /* CoreForgeVoiceLab_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33611DA9EB0C693328495EE5 /* CoreForgeVoiceLab_MissingFeatures.swift */; };
+		DF19834B6688177DF7F43ED6 /* CharacterRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD6F7706C4C8C053BEA6995 /* CharacterRecognizer.swift */; };
+		DF6BDA78E8314623A118ADA4 /* AllAppsDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5CC78C00904368CFFFE730 /* AllAppsDashboard.swift */; };
+		DF80B2BED18AE39B1FCE349C /* PropLocalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F50B98DA6F22B05E65330BB /* PropLocalizer.swift */; };
+		DFA6D26A82171EAD124B8602 /* VideoExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D77CCBE9BDB7AF46178F2A /* VideoExportService.swift */; };
+		E0C12DD5DB8F68005F6DBF05 /* FreeSampleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285C084E621E8FD2D074719A /* FreeSampleService.swift */; };
+		E0F9742B9C3CDF98FA2393E5 /* AccentGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35FDAE9A00932D275FBFF66 /* AccentGenerator.swift */; };
+		E139B4CAD4EED01B626FD9AB /* AudioExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9596E92BE97DBDFCB8B7A7AF /* AudioExportService.swift */; };
+		E202136668BB3DC5FE0165A1 /* TimelineBranchAdvisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE07A0E7831074AED4EEDF4 /* TimelineBranchAdvisor.swift */; };
+		E3CEED1FC08306E439071913 /* BookProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A891D2F6408D696F7D5721B /* BookProcessing.swift */; };
+		E3D0306CC4411399D73A7ECF /* BranchingPathsUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A1F3585617CDB4A4BDCBD7 /* BranchingPathsUI.swift */; };
+		E456817B0C101D0AEAE9BFD7 /* CharacterPaletteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95504057F18EBC0A10BF3B69 /* CharacterPaletteManager.swift */; };
+		E4836318D18B413AAEF31419 /* AppleBooksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DE0B41B8590E3E4F1963E81 /* AppleBooksView.swift */; };
+		E5719F3D3454E88D4F6E0DDD /* BatchImportTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A835A2C983CD58DA45BE4C /* BatchImportTool.swift */; };
+		E595D3FE6140DCDCBE30672D /* CommunityFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC4B36E0DA856F5CE849888 /* CommunityFilter.swift */; };
+		E5999F5B9D2A6C8A6EA9E79D /* QuantumAIExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFB56C8A666279514CEC5E /* QuantumAIExtension.swift */; };
+		E59E8880597A9FE0146562CF /* SceneBackgroundGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D187FF25247BB7221E8BBD /* SceneBackgroundGenerator.swift */; };
+		E5C3B60BCBDAA8821CBE4B14 /* AutoBundler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54130A8B07467D418AED9D75 /* AutoBundler.swift */; };
+		E602DA494477F4167EAE18DC /* LightingRecommender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0147E3BD1A1E58D1A7531B54 /* LightingRecommender.swift */; };
+		E6495B5F4650DFC195C33E4B /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995F23AB0F2C71CC32D8E4F4 /* RegisterView.swift */; };
+		E6B8793889BE3039462DD039 /* MockDataGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA4259B15FDD86BA37A4C23 /* MockDataGenerator.swift */; };
+		E6E323287CDBD958ABC2FA62 /* DebuggingAssistant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3889E991CE4DDB6AF5285E /* DebuggingAssistant.swift */; };
+		E7A45BCFB561C6E4322DB0B0 /* NSFWContentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1538637A706040CBDFDFD56 /* NSFWContentManager.swift */; };
+		E7D1C9A5C07DAB1325960C68 /* AppCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7391BCDD59D422CFF18995E /* AppCatalog.swift */; };
+		E83B25FB6427395DEDFE21A4 /* CoreForgeMarket_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786D70D574E10326DB7E36D4 /* CoreForgeMarket_MissingFeatures.swift */; };
+		E8B6AF0B126C55790449DC63 /* InlineEmotionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AADF363B299EE0AFC66C587 /* InlineEmotionEngine.swift */; };
+		EB73CF5395FC3B87F6DE43E7 /* SceneDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A207EF9D84060DEAC036DC /* SceneDetector.swift */; };
+		EC67C1AD06C91C6571FBB513 /* MultiCastAudiobookGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BEC531D5FEB6D6D5D2A44B9 /* MultiCastAudiobookGenerator.swift */; };
+		ECBED3FAFE1AE89434F8BA61 /* ElevenLabsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3623341860254AD8951598FD /* ElevenLabsService.swift */; };
+		ECFB84196D7A4DDE89FCD694 /* VoiceMemoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16BA5F2601F11D9748924BE /* VoiceMemoryManager.swift */; };
+		EDAB8745C7E21E2163E7B639 /* RefactorLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B82DA9533B19FC1B8CC2DD0 /* RefactorLogger.swift */; };
+		EDEF8111B9BC1D53813980CA /* VoiceMultiverseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176731BA9B46CFA88E2569F4 /* VoiceMultiverseManager.swift */; };
+		EDFA581F16184B594F6F6F9A /* TradingLeaderboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD57243BD3ADFDE72DE91F9 /* TradingLeaderboard.swift */; };
+		EE253A21D1B4CAAE09565D09 /* VideoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3287EEC078D149E0F2AE4DB4 /* VideoMetadata.swift */; };
+		EE417B360490139E749F328F /* LogicBlockLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FD07FC5955F5DADAAF5C61 /* LogicBlockLibrary.swift */; };
+		EE6E15E088D46623C1FC0741 /* NextGenAudioGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61763F7B8F99F653484828E4 /* NextGenAudioGenerator.swift */; };
+		EE969D0B9C33D6C81CB35F1B /* KindleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DAD769F0C8E109D82B2145C /* KindleService.swift */; };
+		EED7686326D2B10218E0580A /* GPTChapterNarrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2435B1F1D64856623DEBE5F /* GPTChapterNarrator.swift */; };
+		EEF60293F3F86AC85DBAF07C /* LightingConditioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23AABC289B3ED47C99649B69 /* LightingConditioner.swift */; };
+		EEFDCDE6807345220ACE775D /* StoreKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9E17A8916BCCDA7390D04B8 /* StoreKitManager.swift */; };
+		EF615E2319C82840F9AC37A2 /* SegmentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0071E528D5E984CE36540F9A /* SegmentService.swift */; };
+		EF6D0BFCE086D89AE87061C1 /* UniversalMediaGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950E8746CF5599F796355A08 /* UniversalMediaGenerator.swift */; };
+		EFBBC6CBEDD159C7CEBA4642 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2317C315FCD34E61F9A23834 /* LibraryView.swift */; };
+		EFC95161AD9B757B2E131E76 /* BrailleOutputService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36053CB329CCAB59C66E48F6 /* BrailleOutputService.swift */; };
+		F0B746856AE6B918AC71AF42 /* ARVRPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB60DE21E8B186D341DEFE4 /* ARVRPlayback.swift */; };
+		F0DBFC416617E2955482C65C /* CoreForgeAudio_PlaybackUIController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA17F478B520B6365CDA6FC /* CoreForgeAudio_PlaybackUIController.swift */; };
+		F1140C6E76117B61FAD86009 /* OfflineVideoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C6F0F0E5C5C7D5E722A1A6 /* OfflineVideoManager.swift */; };
+		F18159810A4A904D84EE773A /* SceneSegmenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AA1BFFD8E9EAFF3524CEDE /* SceneSegmenter.swift */; };
+		F1B55EAD8D388FB163774B7D /* FrameRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9708BFD495DAE889462BDEE8 /* FrameRenderer.swift */; };
+		F230890036E90406FACE4D55 /* PluginSandbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9661BEED7C1139AC613B7D97 /* PluginSandbox.swift */; };
+		F268A0F8E6724D580129CBD1 /* CoreForgeAudioApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427013E1DE2C713C0A784592 /* CoreForgeAudioApp.swift */; };
+		F34A6FFEBEB7198EE097571B /* QuantumConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BBE46CD66C4AD31D7E22E5 /* QuantumConnector.swift */; };
+		F3539DC7E3E27120CDCBF67D /* BackendScaffolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8759B8F8BE04671CBEEB389A /* BackendScaffolder.swift */; };
+		F35DBA9F53FCF6A0C08BD843 /* LoggingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D7429B72B40934AB4BCF90 /* LoggingPlugin.swift */; };
+		F4200B0C2CB2057997D9B6E4 /* QuantumEditMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3E7F70433B298637FD77E2 /* QuantumEditMode.swift */; };
+		F4D613D190546E8A415690D5 /* CoreForgeLeads_MissingFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCEBF0416C516EC30261D5C /* CoreForgeLeads_MissingFeatures.swift */; };
+		F62CAA8A71C6B527A4209886 /* AdvancedSkipImport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CAD0F7DBCD988BCA9568E9 /* AdvancedSkipImport.swift */; };
+		F76BBC4CF867998006647842 /* VoiceCastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48694577E932D0822A51A74 /* VoiceCastView.swift */; };
+		F8104D2538E6E116499A67F3 /* CreatorDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9166209A9787659630316FEB /* CreatorDashboard.swift */; };
+		F92E58A0AB829468A29884C2 /* VoicePolls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D32DB67900FDFB66F91F531 /* VoicePolls.swift */; };
+		F95D50886B2EE1172AC19D63 /* BuildPreviewEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE3B9EE048970DA9B63C049 /* BuildPreviewEngine.swift */; };
+		FADF3C57FCA359251EEFC063 /* OfflineAudioManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F740E917C5B7ADF295B97D /* OfflineAudioManager.swift */; };
+		FAF46C6D0F4B4AE4F7146535 /* PlaybackAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2DD85884FF03F0F3AF761D /* PlaybackAnalytics.swift */; };
+		FC19D809FB7D75D27C4E6924 /* SmartAmbientMixer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922DE1B2B943E583A401BECB /* SmartAmbientMixer.swift */; };
+		FE9703584FDB6904569C2C51 /* VoiceMappingEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F5AE641106BC67B043A103 /* VoiceMappingEngine.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		0023E73BFB52710BF1A285F7 /* EbookImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EbookImporter.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/EbookImporter.swift; sourceTree = "<group>"; };
+		0071E528D5E984CE36540F9A /* SegmentService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SegmentService.swift; path = Sources/CreatorCoreForge/SegmentService.swift; sourceTree = "<group>"; };
+		00C6F0F0E5C5C7D5E722A1A6 /* OfflineVideoManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineVideoManager.swift; path = Sources/CreatorCoreForge/OfflineVideoManager.swift; sourceTree = "<group>"; };
+		010B81D3017528F5422D5FE3 /* SceneIndexGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneIndexGenerator.swift; path = Sources/CreatorCoreForge/SceneIndexGenerator.swift; sourceTree = "<group>"; };
+		0129C2D3610E506BC0C45C37 /* EmotionGraph.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionGraph.swift; path = Sources/CreatorCoreForge/EmotionGraph.swift; sourceTree = "<group>"; };
+		0147E3BD1A1E58D1A7531B54 /* LightingRecommender.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LightingRecommender.swift; path = Sources/CreatorCoreForge/LightingRecommender.swift; sourceTree = "<group>"; };
+		0230221C41C6E4462406AE10 /* CharacterTics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterTics.swift; path = Sources/CreatorCoreForge/CharacterTics.swift; sourceTree = "<group>"; };
+		034B06DFE7843C53100AD30A /* AuditTrail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuditTrail.swift; path = Sources/CreatorCoreForge/AuditTrail.swift; sourceTree = "<group>"; };
+		03C93628622D7887535CA998 /* LivePreviewPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LivePreviewPane.swift; path = Sources/CreatorCoreForge/LivePreviewPane.swift; sourceTree = "<group>"; };
+		043AF94B0A72B7B3688CA329 /* RealTimeImproviserService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RealTimeImproviserService.swift; path = Sources/CreatorCoreForge/RealTimeImproviserService.swift; sourceTree = "<group>"; };
+		04A9491F58FFB6AAB4F7BEDC /* SubscriptionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionManager.swift; path = Sources/CreatorCoreForge/SubscriptionManager.swift; sourceTree = "<group>"; };
+		052363B577A2D281EEB502DE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		05EA2D7C756F41DFCDE1912A /* MemoryAnchorService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MemoryAnchorService.swift; path = Sources/CreatorCoreForge/MemoryAnchorService.swift; sourceTree = "<group>"; };
+		069772C9701D65CFCFC49881 /* GPUVideoRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GPUVideoRenderer.swift; path = Sources/CreatorCoreForge/GPUVideoRenderer.swift; sourceTree = "<group>"; };
+		073C2FC8529E554738DC84D9 /* PronunciationEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PronunciationEditor.swift; path = Sources/CreatorCoreForge/PronunciationEditor.swift; sourceTree = "<group>"; };
+		0767251A8C50311E9BA3ED87 /* EmotionAnalyzer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionAnalyzer.swift; path = Sources/CreatorCoreForge/EmotionAnalyzer.swift; sourceTree = "<group>"; };
+		07CAFCC016F61DC70CCF5ED2 /* AppStoreMetadataConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppStoreMetadataConfig.swift; path = Sources/CreatorCoreForge/AppStoreMetadataConfig.swift; sourceTree = "<group>"; };
+		0842B2F85A3BDB1181837A9F /* TierUpgradeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TierUpgradeView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/TierUpgradeView.swift; sourceTree = "<group>"; };
+		08F5AE641106BC67B043A103 /* VoiceMappingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceMappingEngine.swift; path = Sources/CreatorCoreForge/VoiceMappingEngine.swift; sourceTree = "<group>"; };
+		09485334CFE34870AD00F54A /* FavoriteVoiceService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FavoriteVoiceService.swift; path = Sources/CreatorCoreForge/FavoriteVoiceService.swift; sourceTree = "<group>"; };
+		0A98DB4F56393A3CF1517889 /* PerformanceModeSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PerformanceModeSelector.swift; path = Sources/CreatorCoreForge/PerformanceModeSelector.swift; sourceTree = "<group>"; };
+		0AD13C41B7E06ED61D50B5AF /* NSFWBlurToggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWBlurToggle.swift; path = Sources/CreatorCoreForge/NSFWBlurToggle.swift; sourceTree = "<group>"; };
+		0B138EB1316963D7145F9AC9 /* AudioSearchIndex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioSearchIndex.swift; path = Sources/CreatorCoreForge/AudioSearchIndex.swift; sourceTree = "<group>"; };
+		0CCEBF0416C516EC30261D5C /* CoreForgeLeads_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeLeads_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeLeads_MissingFeatures.swift; sourceTree = "<group>"; };
+		0D5C320DA7D9BC6667E9412A /* PluginDependencyGraph.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginDependencyGraph.swift; path = Sources/CreatorCoreForge/PluginDependencyGraph.swift; sourceTree = "<group>"; };
+		0DC8B70105F5522A90461F0E /* OpenAIService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenAIService.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/OpenAIService.swift; sourceTree = "<group>"; };
+		0DEB05F6522078A88F5E6894 /* CoreForgeAudio_PlaybackBookmarking.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeAudio_PlaybackBookmarking.swift; path = Sources/CreatorCoreForge/CoreForgeAudio_PlaybackBookmarking.swift; sourceTree = "<group>"; };
+		0E84D291AF2D77836623295C /* AudioPlaybackEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioPlaybackEngine.swift; path = Sources/CreatorCoreForge/AudioPlaybackEngine.swift; sourceTree = "<group>"; };
+		0EE1E6FB07F9191AE7502404 /* LivePresence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LivePresence.swift; path = Sources/CreatorCoreForge/LivePresence.swift; sourceTree = "<group>"; };
+		0F57ECEFF8EA7D9822BE4917 /* UserPreferences.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserPreferences.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/UserPreferences.swift; sourceTree = "<group>"; };
+		10D23F8A37F8D2031AFA05D6 /* ContentPolicyManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentPolicyManager.swift; path = Sources/CreatorCoreForge/ContentPolicyManager.swift; sourceTree = "<group>"; };
+		1197097692EC4CC00A247E96 /* DownloadsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownloadsView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/DownloadsView.swift; sourceTree = "<group>"; };
+		11E653A5ED88CD1D3E765779 /* SceneAtmosphereBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneAtmosphereBuilder.swift; path = Sources/CreatorCoreForge/SceneAtmosphereBuilder.swift; sourceTree = "<group>"; };
+		11F28ADB2CDF1CD1272AB215 /* EnhancedTTSPlayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedTTSPlayer.swift; path = Sources/CreatorCoreForge/EnhancedTTSPlayer.swift; sourceTree = "<group>"; };
+		1286FD3C857E8347C19E6398 /* AdvancedTimelineEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdvancedTimelineEditor.swift; path = Sources/CreatorCoreForge/AdvancedTimelineEditor.swift; sourceTree = "<group>"; };
+		12BF357CB6629B420C87588B /* AdaptiveSceneCompletion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdaptiveSceneCompletion.swift; path = Sources/CreatorCoreForge/AdaptiveSceneCompletion.swift; sourceTree = "<group>"; };
+		130CDCFA23BE887A6E2D6F38 /* BranchService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BranchService.swift; path = Sources/CreatorCoreForge/BranchService.swift; sourceTree = "<group>"; };
+		14CAF1A1236C35BB882B4F51 /* RealTimeEmotionAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RealTimeEmotionAdapter.swift; path = Sources/CreatorCoreForge/RealTimeEmotionAdapter.swift; sourceTree = "<group>"; };
+		16114D30715AA6A6067E5456 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Info.plist; sourceTree = "<group>"; };
+		1696827AA9EF79399799A3A8 /* QuantumRealitySwitcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumRealitySwitcher.swift; path = Sources/CreatorCoreForge/QuantumRealitySwitcher.swift; sourceTree = "<group>"; };
+		16A5964D3482688509443A89 /* CRUDGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CRUDGenerator.swift; path = Sources/CreatorCoreForge/CRUDGenerator.swift; sourceTree = "<group>"; };
+		176731BA9B46CFA88E2569F4 /* VoiceMultiverseManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceMultiverseManager.swift; path = Sources/CreatorCoreForge/VoiceMultiverseManager.swift; sourceTree = "<group>"; };
+		1778237C60D0ABE230FF5188 /* SceneParserEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneParserEngine.swift; path = Sources/CreatorCoreForge/SceneParserEngine.swift; sourceTree = "<group>"; };
+		178B7A1DF14DF5F041D37029 /* FeaturedCarouselView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FeaturedCarouselView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/FeaturedCarouselView.swift; sourceTree = "<group>"; };
+		17975F68102AF33C92A27CFD /* VoiceDNAForge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceDNAForge.swift; path = Sources/CreatorCoreForge/VoiceDNAForge.swift; sourceTree = "<group>"; };
+		17CC521A5F2DB549FD7B2BA1 /* PluginMarketplace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginMarketplace.swift; path = Sources/CreatorCoreForge/PluginMarketplace.swift; sourceTree = "<group>"; };
+		1952DB1BFFDA5141078D0907 /* DocVideoScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocVideoScanner.swift; path = Sources/CreatorCoreForge/DocVideoScanner.swift; sourceTree = "<group>"; };
+		1A3AD91F5B84E94FECDACBCE /* AutoTranslateService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoTranslateService.swift; path = Sources/CreatorCoreForge/AutoTranslateService.swift; sourceTree = "<group>"; };
+		1A98A86A33EEE93E97D40EFA /* ReferralView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReferralView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ReferralView.swift; sourceTree = "<group>"; };
+		1AADF363B299EE0AFC66C587 /* InlineEmotionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InlineEmotionEngine.swift; path = Sources/CreatorCoreForge/InlineEmotionEngine.swift; sourceTree = "<group>"; };
+		1BEC531D5FEB6D6D5D2A44B9 /* MultiCastAudiobookGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiCastAudiobookGenerator.swift; path = Sources/CreatorCoreForge/MultiCastAudiobookGenerator.swift; sourceTree = "<group>"; };
+		1C27C9C4BFBF2B9CF24D31FB /* CommentSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommentSystem.swift; path = Sources/CreatorCoreForge/CommentSystem.swift; sourceTree = "<group>"; };
+		1C2B9D383958760603556680 /* AIPlotBooster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIPlotBooster.swift; path = Sources/CreatorCoreForge/AIPlotBooster.swift; sourceTree = "<group>"; };
+		1D32DB67900FDFB66F91F531 /* VoicePolls.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoicePolls.swift; path = Sources/CreatorCoreForge/VoicePolls.swift; sourceTree = "<group>"; };
+		1D540C4399415A1968C6E0F1 /* AITropeDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AITropeDetector.swift; path = Sources/CreatorCoreForge/AITropeDetector.swift; sourceTree = "<group>"; };
+		20A207EF9D84060DEAC036DC /* SceneDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneDetector.swift; path = Sources/CreatorCoreForge/SceneDetector.swift; sourceTree = "<group>"; };
+		2109DC44B62D792D8F622714 /* LoadTester.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoadTester.swift; path = Sources/CreatorCoreForge/LoadTester.swift; sourceTree = "<group>"; };
+		2272D27E0CDDE1937940C617 /* StoryboardPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoryboardPanel.swift; path = Sources/CreatorCoreForge/StoryboardPanel.swift; sourceTree = "<group>"; };
+		2274C8CE9C3215CC6A2440E5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		2317C315FCD34E61F9A23834 /* LibraryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibraryView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryView.swift; sourceTree = "<group>"; };
+		23AABC289B3ED47C99649B69 /* LightingConditioner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LightingConditioner.swift; path = Sources/CreatorCoreForge/LightingConditioner.swift; sourceTree = "<group>"; };
+		24DB57BD4D83F13CBFA1AECC /* ElevenLabsRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElevenLabsRenderer.swift; path = Sources/CreatorCoreForge/ElevenLabsRenderer.swift; sourceTree = "<group>"; };
+		24E44276A7FB44E624DF27F1 /* EmotionHeatmap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionHeatmap.swift; path = Sources/CreatorCoreForge/EmotionHeatmap.swift; sourceTree = "<group>"; };
+		256622C7A271D677080C143F /* OutlineGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OutlineGenerator.swift; path = Sources/CreatorCoreForge/OutlineGenerator.swift; sourceTree = "<group>"; };
+		25799E7FEBCF63A63121D04D /* QuantumSceneLogic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumSceneLogic.swift; path = Sources/CreatorCoreForge/QuantumSceneLogic.swift; sourceTree = "<group>"; };
+		261DCAE0CB5F0B2B2C02821B /* TTSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TTSService.swift; path = Sources/CreatorCoreForge/TTSService.swift; sourceTree = "<group>"; };
+		262AC36574561A21F69BD318 /* NSFWAddonManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWAddonManager.swift; path = Sources/CreatorCoreForge/NSFWAddonManager.swift; sourceTree = "<group>"; };
+		26BE64A336F24F8FBD2AADA5 /* NSFWDatabase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWDatabase.swift; path = Sources/CreatorCoreForge/NSFWDatabase.swift; sourceTree = "<group>"; };
+		26E1EF4C3C86AA5CC47D140B /* OnboardingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OnboardingView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/OnboardingView.swift; sourceTree = "<group>"; };
+		27CAD0F7DBCD988BCA9568E9 /* AdvancedSkipImport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdvancedSkipImport.swift; path = Sources/CreatorCoreForge/AdvancedSkipImport.swift; sourceTree = "<group>"; };
+		27CF2B9F06DCFD9CA4CC9887 /* AutoCastingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoCastingEngine.swift; path = Sources/CreatorCoreForge/AutoCastingEngine.swift; sourceTree = "<group>"; };
+		285C084E621E8FD2D074719A /* FreeSampleService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FreeSampleService.swift; path = Sources/CreatorCoreForge/FreeSampleService.swift; sourceTree = "<group>"; };
+		286E7B787291461F91B5C56B /* TTSEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TTSEngine.swift; path = Sources/CreatorCoreForge/TTS/TTSEngine.swift; sourceTree = "<group>"; };
+		288A770742EB547A89EE98D2 /* NotificationSender.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NotificationSender.swift; path = Sources/CreatorCoreForge/NotificationSender.swift; sourceTree = "<group>"; };
+		296C40B9AB0CD38DF85AAF27 /* UniversalVideoGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UniversalVideoGenerator.swift; path = Sources/CreatorCoreForge/UniversalVideoGenerator.swift; sourceTree = "<group>"; };
+		297C49A41BA986E311210CAA /* BookScanAnalyzer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookScanAnalyzer.swift; path = Sources/CreatorCoreForge/BookScanAnalyzer.swift; sourceTree = "<group>"; };
+		2A045866BEC81060ACA13C13 /* WaveformView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WaveformView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/WaveformView.swift; sourceTree = "<group>"; };
+		2AD6D18CECC7C0C3DACB0EC1 /* SecurityScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecurityScanner.swift; path = Sources/CreatorCoreForge/SecurityScanner.swift; sourceTree = "<group>"; };
+		2C2B727FC99F665C3BF1146A /* CharacterProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterProfileManager.swift; path = Sources/CreatorCoreForge/CharacterProfileManager.swift; sourceTree = "<group>"; };
+		2C5CC78C00904368CFFFE730 /* AllAppsDashboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllAppsDashboard.swift; path = Sources/CreatorCoreForge/AllAppsDashboard.swift; sourceTree = "<group>"; };
+		2C9ED59C899B81704ECBC1F3 /* PromptParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PromptParser.swift; path = Sources/CreatorCoreForge/PromptParser.swift; sourceTree = "<group>"; };
+		2CC241B2B39CF92E78D577A7 /* AdaptiveDocScanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdaptiveDocScanner.swift; path = Sources/CreatorCoreForge/AdaptiveDocScanner.swift; sourceTree = "<group>"; };
+		2D329FC94B0F4ED60183C8ED /* AutoVoiceSelector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoVoiceSelector.swift; path = Sources/CreatorCoreForge/AutoVoiceSelector.swift; sourceTree = "<group>"; };
+		2E37FDE5CC5CC1F4FB0A6C31 /* CoreForgeLearn_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeLearn_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeLearn_MissingFeatures.swift; sourceTree = "<group>"; };
+		2F67A8A49EB883E3F825A94E /* AIVocalProductionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIVocalProductionEngine.swift; path = Sources/CreatorCoreForge/AIVocalProductionEngine.swift; sourceTree = "<group>"; };
+		2F89D3969A047DBDBEE344A6 /* TemplateMonetization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TemplateMonetization.swift; path = Sources/CreatorCoreForge/TemplateMonetization.swift; sourceTree = "<group>"; };
+		2FD4F2204C83213AA617411B /* ExportRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportRenderer.swift; path = Sources/CreatorCoreForge/ExportRenderer.swift; sourceTree = "<group>"; };
+		2FD76308D7454FC90EC2E514 /* VoiceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceManager.swift; path = Sources/CreatorCoreForge/VoiceManager.swift; sourceTree = "<group>"; };
+		2FE3B9EE048970DA9B63C049 /* BuildPreviewEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildPreviewEngine.swift; path = Sources/CreatorCoreForge/BuildPreviewEngine.swift; sourceTree = "<group>"; };
+		30013A478AAFE731210DACBA /* VoiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceConfig.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceConfig.swift; sourceTree = "<group>"; };
+		30720037E358F98EB2294275 /* SettingsSync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsSync.swift; path = Sources/CreatorCoreForge/SettingsSync.swift; sourceTree = "<group>"; };
+		30B2510F573A42B73A3830DF /* ComplianceChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ComplianceChecker.swift; path = Sources/CreatorCoreForge/ComplianceChecker.swift; sourceTree = "<group>"; };
+		30E6CD8758A042228F38DEF9 /* ReferralProgram.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReferralProgram.swift; path = Sources/CreatorCoreForge/ReferralProgram.swift; sourceTree = "<group>"; };
+		31D871B6A478E6A6D9791CE6 /* CoreForgeMusic_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeMusic_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeMusic_MissingFeatures.swift; sourceTree = "<group>"; };
+		32008BE2556A8BD0999A1BAE /* AgeIDVerifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AgeIDVerifier.swift; path = Sources/CreatorCoreForge/AgeIDVerifier.swift; sourceTree = "<group>"; };
+		3257ADE7857F17CCD511FAC4 /* AudiobookMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudiobookMetadata.swift; path = Sources/CreatorCoreForge/AudiobookMetadata.swift; sourceTree = "<group>"; };
+		327E6E8DE0D3C53AC4B5CDF8 /* ThumbnailGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThumbnailGenerator.swift; path = Sources/CreatorCoreForge/ThumbnailGenerator.swift; sourceTree = "<group>"; };
+		3287EEC078D149E0F2AE4DB4 /* VideoMetadata.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoMetadata.swift; path = Sources/CreatorCoreForge/VideoMetadata.swift; sourceTree = "<group>"; };
+		332110419B30B423E6CF2FC8 /* VisualMultiverseManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualMultiverseManager.swift; path = Sources/CreatorCoreForge/VisualMultiverseManager.swift; sourceTree = "<group>"; };
+		33611DA9EB0C693328495EE5 /* CoreForgeVoiceLab_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeVoiceLab_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeVoiceLab_MissingFeatures.swift; sourceTree = "<group>"; };
+		33733AB47BDA4D17CCA4E655 /* SceneSoundtrackCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneSoundtrackCoordinator.swift; path = Sources/CreatorCoreForge/SceneSoundtrackCoordinator.swift; sourceTree = "<group>"; };
+		3398DEEF2660B0EEE799FB44 /* AIStateTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIStateTracker.swift; path = Sources/CreatorCoreForge/AIStateTracker.swift; sourceTree = "<group>"; };
+		33A353757CBE8F201B728CDB /* LanguageDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LanguageDetector.swift; path = Sources/CreatorCoreForge/LanguageDetector.swift; sourceTree = "<group>"; };
+		345D00B6EE6AC6DDD43EFA80 /* FaceTrackerService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FaceTrackerService.swift; path = Sources/CreatorCoreForge/FaceTrackerService.swift; sourceTree = "<group>"; };
+		34988111133A0E5B140F0A83 /* CharacterDetectionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterDetectionEngine.swift; path = Sources/CreatorCoreForge/CharacterDetectionEngine.swift; sourceTree = "<group>"; };
+		34F7A40351A041F032F80D6C /* CoreForgeQuest_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeQuest_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeQuest_MissingFeatures.swift; sourceTree = "<group>"; };
+		35F90EE8AD6E67847D0C0F5D /* NSFWSFXPackManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWSFXPackManager.swift; path = Sources/CreatorCoreForge/NSFWSFXPackManager.swift; sourceTree = "<group>"; };
+		36053CB329CCAB59C66E48F6 /* BrailleOutputService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BrailleOutputService.swift; path = Sources/CreatorCoreForge/BrailleOutputService.swift; sourceTree = "<group>"; };
+		3623341860254AD8951598FD /* ElevenLabsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElevenLabsService.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ElevenLabsService.swift; sourceTree = "<group>"; };
+		3667826427527849ABFD22FA /* VoiceFXStackEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceFXStackEditor.swift; path = Sources/CreatorCoreForge/VoiceFXStackEditor.swift; sourceTree = "<group>"; };
+		36BA9C967CD920704EE6D678 /* AIStudioMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIStudioMode.swift; path = Sources/CreatorCoreForge/AIStudioMode.swift; sourceTree = "<group>"; };
+		36D1B6F0AFC931E49E6F1E47 /* ChapterImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChapterImporter.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ChapterImporter.swift; sourceTree = "<group>"; };
+		376C1336CCEF26F8F084EC47 /* AppTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppTheme.swift; path = Sources/CreatorCoreForge/AppTheme.swift; sourceTree = "<group>"; };
+		380038B5F0E47EA932BA53B7 /* LoginView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoginView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LoginView.swift; sourceTree = "<group>"; };
+		38CE09520864938898DC7DAF /* CoreForgeDNA_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeDNA_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeDNA_MissingFeatures.swift; sourceTree = "<group>"; };
+		396D8689DCA55C3C01848D60 /* NetworkMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkMonitor.swift; path = Sources/CreatorCoreForge/NetworkMonitor.swift; sourceTree = "<group>"; };
+		39B06F23CDEF3916D1894050 /* ParticleFXLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParticleFXLayer.swift; path = Sources/CreatorCoreForge/ParticleFXLayer.swift; sourceTree = "<group>"; };
+		3A0A1EE74ACA6D03C7F1D8D7 /* AdaptiveLearningEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdaptiveLearningEngine.swift; path = Sources/CreatorCoreForge/AdaptiveLearningEngine.swift; sourceTree = "<group>"; };
+		3A1E5F3ABF27DABCA2D53235 /* SFXPackManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SFXPackManager.swift; path = Sources/CreatorCoreForge/SFXPackManager.swift; sourceTree = "<group>"; };
+		3A3B9CF5C510002056610EE6 /* CoreForgeStudio_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeStudio_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeStudio_MissingFeatures.swift; sourceTree = "<group>"; };
+		3A98C8C2B8DD8570DAF75073 /* SceneHeatmapManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneHeatmapManager.swift; path = Sources/CreatorCoreForge/SceneHeatmapManager.swift; sourceTree = "<group>"; };
+		3AFC20E05BF1A9C8779EC4C9 /* VoiceSyncController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceSyncController.swift; path = Sources/CreatorCoreForge/VoiceSyncController.swift; sourceTree = "<group>"; };
+		3BE123E615D8B72BA238DE4D /* CoreForgeWriter_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeWriter_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeWriter_MissingFeatures.swift; sourceTree = "<group>"; };
+		3D63631012B1F3BE16BB67A6 /* MainTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainTabView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/MainTabView.swift; sourceTree = "<group>"; };
+		3DAF719FD6FF9E39702A6851 /* StoryboardImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoryboardImporter.swift; path = Sources/CreatorCoreForge/StoryboardImporter.swift; sourceTree = "<group>"; };
+		3E70D13FCAED04AB4CFE9200 /* ProfileTierCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileTierCardView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ProfileTierCardView.swift; sourceTree = "<group>"; };
+		3E7EAD009805221D97DBC64C /* PromptParserEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PromptParserEngine.swift; path = Sources/CreatorCoreForge/PromptParserEngine.swift; sourceTree = "<group>"; };
+		3EA503E4EE3E1AFE4021F9B2 /* CrossPlatformVideoGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrossPlatformVideoGenerator.swift; path = Sources/CreatorCoreForge/CrossPlatformVideoGenerator.swift; sourceTree = "<group>"; };
+		3F1B87644899B29FB7BB1241 /* CMSampleBuffer+PixelBuffer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CMSampleBuffer+PixelBuffer.swift"; path = "Sources/CreatorCoreForge/CMSampleBuffer+PixelBuffer.swift"; sourceTree = "<group>"; };
+		3F3889E991CE4DDB6AF5285E /* DebuggingAssistant.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DebuggingAssistant.swift; path = Sources/CreatorCoreForge/DebuggingAssistant.swift; sourceTree = "<group>"; };
+		3F9720FBF067DDFCBFF29D98 /* Ebook2AudiobookBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ebook2AudiobookBridge.swift; path = Sources/CreatorCoreForge/Ebook2AudiobookBridge.swift; sourceTree = "<group>"; };
+		4036FBF4A65F95760BEF0BAC /* PlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlayerView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlayerView.swift; sourceTree = "<group>"; };
+		4131EC5C1E781CFFC95EA1BA /* MultiverseDirectorToggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiverseDirectorToggle.swift; path = Sources/CreatorCoreForge/MultiverseDirectorToggle.swift; sourceTree = "<group>"; };
+		425D20F2474733935AE6ACB4 /* FirebaseAudioService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FirebaseAudioService.swift; path = Sources/CreatorCoreForge/FirebaseAudioService.swift; sourceTree = "<group>"; };
+		427013E1DE2C713C0A784592 /* CoreForgeAudioApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeAudioApp.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CoreForgeAudioApp.swift; sourceTree = "<group>"; };
+		4314582A6305C5D5FCA11064 /* KindleView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KindleView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleView.swift; sourceTree = "<group>"; };
+		4348E2B287D544E6CD9BA0EF /* EbookConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EbookConverter.swift; path = Sources/CreatorCoreForge/EbookConverter.swift; sourceTree = "<group>"; };
+		43F2E4E6040C597181994FA5 /* LipSyncAdjuster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LipSyncAdjuster.swift; path = Sources/CreatorCoreForge/LipSyncAdjuster.swift; sourceTree = "<group>"; };
+		44374A80D782947B93F54D9F /* AIEmotionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIEmotionEngine.swift; path = Sources/CreatorCoreForge/AIEmotionEngine.swift; sourceTree = "<group>"; };
+		44D2F74F474F4F1A1BE82A0B /* VoiceHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceHistory.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceHistory.swift; sourceTree = "<group>"; };
+		4562748BF16196492E753927 /* BannerCarouselView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BannerCarouselView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BannerCarouselView.swift; sourceTree = "<group>"; };
+		459EB67C128B19FE9EC18348 /* CreditsHistoryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreditsHistoryView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CreditsHistoryView.swift; sourceTree = "<group>"; };
+		46B80322224D366705B84E81 /* ConnectView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ConnectView.swift; sourceTree = "<group>"; };
+		47B451741F5165402D4B3164 /* ReferralManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReferralManager.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ReferralManager.swift; sourceTree = "<group>"; };
+		482665214A77B982A95F091C /* NSFWVoiceEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWVoiceEngine.swift; path = Sources/CreatorCoreForge/NSFWVoiceEngine.swift; sourceTree = "<group>"; };
+		482D62F635C01DD83AB31C3A /* BreathingLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreathingLayer.swift; path = Sources/CreatorCoreForge/TTS/BreathingLayer.swift; sourceTree = "<group>"; };
+		483CDAF40A1599742BB1FBF3 /* OfflineDownloadQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineDownloadQueue.swift; path = Sources/CreatorCoreForge/OfflineDownloadQueue.swift; sourceTree = "<group>"; };
+		489D79AC20A4553BA4651C11 /* BlurbGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlurbGenerator.swift; path = Sources/CreatorCoreForge/BlurbGenerator.swift; sourceTree = "<group>"; };
+		4A7104A997CAD2F933C45288 /* ThemeManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThemeManager.swift; path = Sources/CreatorCoreForge/ThemeManager.swift; sourceTree = "<group>"; };
+		4AB60DE21E8B186D341DEFE4 /* ARVRPlayback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ARVRPlayback.swift; path = Sources/CreatorCoreForge/ARVRPlayback.swift; sourceTree = "<group>"; };
+		4B31B3279342EB22EB2C0B90 /* CharacterVoiceMemory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterVoiceMemory.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CharacterVoiceMemory.swift; sourceTree = "<group>"; };
+		4C312AE303C709A1F2D3EC11 /* FrameInterpolationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FrameInterpolationService.swift; path = Sources/CreatorCoreForge/FrameInterpolationService.swift; sourceTree = "<group>"; };
+		4CC90D7BCF411FB19821C913 /* AppStoreIntegration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppStoreIntegration.swift; path = Sources/CreatorCoreForge/AppStoreIntegration.swift; sourceTree = "<group>"; };
+		4D2B745A6A27DD9D08D8ED67 /* SeriesManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SeriesManager.swift; path = Sources/CreatorCoreForge/SeriesManager.swift; sourceTree = "<group>"; };
+		4D39E3C0B4A19A654E86F113 /* FirebaseService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FirebaseService.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/FirebaseService.swift; sourceTree = "<group>"; };
+		4DB2833FAD412F2E644C779F /* DynamicChapterTransitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DynamicChapterTransitions.swift; path = Sources/CreatorCoreForge/DynamicChapterTransitions.swift; sourceTree = "<group>"; };
+		4DD6F7706C4C8C053BEA6995 /* CharacterRecognizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterRecognizer.swift; path = Sources/CreatorCoreForge/CharacterRecognizer.swift; sourceTree = "<group>"; };
+		4F30C35756E870A3AEBCD593 /* AnimationDashboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnimationDashboard.swift; path = Sources/CreatorCoreForge/AnimationDashboard.swift; sourceTree = "<group>"; };
+		4FE6A56AED6C3DD44576B2C1 /* MindNSFWModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MindNSFWModule.swift; path = Sources/CreatorCoreForge/MindNSFWModule.swift; sourceTree = "<group>"; };
+		5030CED050FC1AE52E08605B /* EmotionArcVisualizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionArcVisualizer.swift; path = Sources/CreatorCoreForge/EmotionArcVisualizer.swift; sourceTree = "<group>"; };
+		50B21B362A27F0A4B9B667D8 /* CharacterQuirkEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterQuirkEngine.swift; path = Sources/CreatorCoreForge/CharacterQuirkEngine.swift; sourceTree = "<group>"; };
+		51CB1E0C1033F62930DD2E76 /* AppFavoriteVoiceService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppFavoriteVoiceService.swift; path = Sources/CreatorCoreForge/AppFavoriteVoiceService.swift; sourceTree = "<group>"; };
+		5316C14172E77540599D6DB7 /* ImportView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImportView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ImportView.swift; sourceTree = "<group>"; };
+		54130A8B07467D418AED9D75 /* AutoBundler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoBundler.swift; path = Sources/CreatorCoreForge/AutoBundler.swift; sourceTree = "<group>"; };
+		5491195D61E0DFF72DC0800B /* BestsellerStructureEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BestsellerStructureEngine.swift; path = Sources/CreatorCoreForge/BestsellerStructureEngine.swift; sourceTree = "<group>"; };
+		566F3FF0E231FF8D481B4C93 /* ReplayAnalyticsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReplayAnalyticsService.swift; path = Sources/CreatorCoreForge/ReplayAnalyticsService.swift; sourceTree = "<group>"; };
+		56BBA11B70AAC041D49BE4B9 /* MultiTrackProductionSuite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiTrackProductionSuite.swift; path = Sources/CreatorCoreForge/MultiTrackProductionSuite.swift; sourceTree = "<group>"; };
+		56E03E3E9EF72CAD33EAC37D /* StyleEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StyleEngine.swift; path = Sources/CreatorCoreForge/StyleEngine.swift; sourceTree = "<group>"; };
+		56FCDA66A3E18824091BD044 /* ListeningStatsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ListeningStatsView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ListeningStatsView.swift; sourceTree = "<group>"; };
+		5701CCD3DDFFCAE74BE3CC66 /* UnlockableVoiceSkins.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnlockableVoiceSkins.swift; path = Sources/CreatorCoreForge/UnlockableVoiceSkins.swift; sourceTree = "<group>"; };
+		585F251F558DB5C37996FC73 /* AudioImperfectionFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioImperfectionFilter.swift; path = Sources/CreatorCoreForge/TTS/AudioImperfectionFilter.swift; sourceTree = "<group>"; };
+		58704451C7F68A25DC9B8ED5 /* VersionHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VersionHistory.swift; path = Sources/CreatorCoreForge/VersionHistory.swift; sourceTree = "<group>"; };
+		59AC16A130A2C7DD56B0A650 /* CommunityReviews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommunityReviews.swift; path = Sources/CreatorCoreForge/CommunityReviews.swift; sourceTree = "<group>"; };
+		5AD65F111609989C32F44B75 /* AICoPilot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AICoPilot.swift; path = Sources/CreatorCoreForge/AICoPilot.swift; sourceTree = "<group>"; };
+		5B210E7725846EA64F8D879B /* VideoShareManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoShareManager.swift; path = Sources/CreatorCoreForge/VideoShareManager.swift; sourceTree = "<group>"; };
+		5BC1F3482E6F4842815C9E84 /* CreditStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreditStore.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/CreditStore.swift; sourceTree = "<group>"; };
+		5C553F7F7F652A0FD7ED0CE4 /* AuthorAudiobookCreator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthorAudiobookCreator.swift; path = Sources/CreatorCoreForge/AuthorAudiobookCreator.swift; sourceTree = "<group>"; };
+		5CA73F11AB22EA5DF4E7D6BB /* SceneDramatization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneDramatization.swift; path = Sources/CreatorCoreForge/SceneDramatization.swift; sourceTree = "<group>"; };
+		5D33BD12089472D2B36DF821 /* DashboardTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardTabView.swift; path = Sources/CreatorCoreForge/DashboardTabView.swift; sourceTree = "<group>"; };
+		5D5D661ED9186060C17D6514 /* SceneGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneGenerator.swift; path = Sources/CreatorCoreForge/SceneGenerator.swift; sourceTree = "<group>"; };
+		5DAADFE407D11A43D434EA07 /* SearchView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SearchView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SearchView.swift; sourceTree = "<group>"; };
+		5E48CF07457481A35A2A4289 /* VoiceCloneTrainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceCloneTrainer.swift; path = Sources/CreatorCoreForge/VoiceCloneTrainer.swift; sourceTree = "<group>"; };
+		5E5813B72C9761CC3EB97377 /* AdvancedAudioExport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdvancedAudioExport.swift; path = Sources/CreatorCoreForge/AdvancedAudioExport.swift; sourceTree = "<group>"; };
+		5EB1AEC86E271F31DD5814AA /* ParentReportManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParentReportManager.swift; path = Sources/CreatorCoreForge/ParentReportManager.swift; sourceTree = "<group>"; };
+		5EC4B36E0DA856F5CE849888 /* CommunityFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommunityFilter.swift; path = Sources/CreatorCoreForge/CommunityFilter.swift; sourceTree = "<group>"; };
+		5EF229F46211DF3969186838 /* BuildBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildBridge.swift; path = Sources/CreatorCoreForge/BuildBridge.swift; sourceTree = "<group>"; };
+		5F3EE3A96932C7E03F27CBDA /* CustomCodeInjector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomCodeInjector.swift; path = Sources/CreatorCoreForge/CustomCodeInjector.swift; sourceTree = "<group>"; };
+		5F40E5E7DDDCA6651A380385 /* CodeGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CodeGenerator.swift; path = Sources/CreatorCoreForge/CodeGenerator.swift; sourceTree = "<group>"; };
+		5F9A5C812FD0F7B788FB1ED0 /* RealTimeFeedManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RealTimeFeedManager.swift; path = Sources/CreatorCoreForge/RealTimeFeedManager.swift; sourceTree = "<group>"; };
+		5FB2AA789238C33D853E5F68 /* NSFWMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWMode.swift; path = Sources/CreatorCoreForge/NSFWMode.swift; sourceTree = "<group>"; };
+		6013D9CE6EB2C0A3BDA1F736 /* ProfanityFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfanityFilter.swift; path = Sources/CreatorCoreForge/ProfanityFilter.swift; sourceTree = "<group>"; };
+		60A271A03D265C19B76FB936 /* AISummaryChatService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AISummaryChatService.swift; path = Sources/CreatorCoreForge/AISummaryChatService.swift; sourceTree = "<group>"; };
+		60A31E3E669D4C74E61F66D5 /* FusionEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FusionEngine.swift; path = Sources/CreatorCoreForge/FusionEngine.swift; sourceTree = "<group>"; };
+		60ACEB11DF349A64EAB7A2D0 /* LocalElevenLabsClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalElevenLabsClient.swift; path = Sources/CreatorCoreForge/LocalElevenLabsClient.swift; sourceTree = "<group>"; };
+		60FF9959E658158E02E0887D /* VoiceAdvisorAI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceAdvisorAI.swift; path = Sources/CreatorCoreForge/VoiceAdvisorAI.swift; sourceTree = "<group>"; };
+		614ABCDA49920304A3A31259 /* FormTemplate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormTemplate.swift; path = Sources/CreatorCoreForge/FormTemplate.swift; sourceTree = "<group>"; };
+		6172A395D01A37E6D6D40585 /* SceneMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneMapper.swift; path = Sources/CreatorCoreForge/SceneMapper.swift; sourceTree = "<group>"; };
+		61763F7B8F99F653484828E4 /* NextGenAudioGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NextGenAudioGenerator.swift; path = Sources/CreatorCoreForge/NextGenAudioGenerator.swift; sourceTree = "<group>"; };
+		62BA2B64DB508D632FB96114 /* PluginLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginLoader.swift; path = Sources/CreatorCoreForge/PluginLoader.swift; sourceTree = "<group>"; };
+		6324FA4CA2BF4C4F43B85DCE /* prompts.json */ = {isa = PBXFileReference; includeInIndex = 1; name = prompts.json; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/prompts.json; sourceTree = "<group>"; };
+		640CE93D2F0ED1998B5F88B6 /* SemanticSegmenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SemanticSegmenter.swift; path = Sources/CreatorCoreForge/SemanticSegmenter.swift; sourceTree = "<group>"; };
+		6418A4324EDFAD12529EC847 /* OCRScanMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OCRScanMode.swift; path = Sources/CreatorCoreForge/OCRScanMode.swift; sourceTree = "<group>"; };
+		64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorldMemoryService.swift; path = Sources/CreatorCoreForge/WorldMemoryService.swift; sourceTree = "<group>"; };
+		64D8465318B2DB2FA3F0A365 /* VoiceReactivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceReactivity.swift; path = Sources/CreatorCoreForge/VoiceReactivity.swift; sourceTree = "<group>"; };
+		6504DE864796A7669332A703 /* PronunciationDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PronunciationDictionary.swift; path = Sources/CreatorCoreForge/PronunciationDictionary.swift; sourceTree = "<group>"; };
+		654E8C9E07A92A5C533F7B53 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Assets.xcassets; sourceTree = "<group>"; };
+		66123578CD2B94F343B2B852 /* AudioExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioExporter.swift; path = Sources/CreatorCoreForge/AudioExporter.swift; sourceTree = "<group>"; };
+		6644AA983C29271472FA74C4 /* CharacterTrackManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterTrackManager.swift; path = Sources/CreatorCoreForge/CharacterTrackManager.swift; sourceTree = "<group>"; };
+		6688954B40BD5ED4841C1BC8 /* HeroSpotlightBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeroSpotlightBackground.swift; path = Sources/CreatorCoreForge/HeroSpotlightBackground.swift; sourceTree = "<group>"; };
+		66B6039E241918FFEF4DA79B /* StoryboardEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoryboardEditor.swift; path = Sources/CreatorCoreForge/StoryboardEditor.swift; sourceTree = "<group>"; };
+		67661206A60D2E343C101723 /* FileManager+ZipFallback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "FileManager+ZipFallback.swift"; path = "Sources/CreatorCoreForge/FileManager+ZipFallback.swift"; sourceTree = "<group>"; };
+		6872CF63F9190D32027AEBC2 /* ReplayAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReplayAnalytics.swift; path = Sources/CreatorCoreForge/ReplayAnalytics.swift; sourceTree = "<group>"; };
+		688151BBB5C041468DF281E6 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SettingsView.swift; sourceTree = "<group>"; };
+		69597CF80BB66D8310398AA3 /* LibrarySync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibrarySync.swift; path = Sources/CreatorCoreForge/LibrarySync.swift; sourceTree = "<group>"; };
+		6A0346F8BF557F425F0C2D43 /* DownloadQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownloadQueue.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/DownloadQueue.swift; sourceTree = "<group>"; };
+		6A0DB4E15F3772BECF41011A /* CrowdSimulator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrowdSimulator.swift; path = Sources/CreatorCoreForge/CrowdSimulator.swift; sourceTree = "<group>"; };
+		6A88ABA46731522F346EAE41 /* BuildImprovementEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildImprovementEngine.swift; path = Sources/CreatorCoreForge/BuildImprovementEngine.swift; sourceTree = "<group>"; };
+		6A9384F21460309992B8F505 /* DramatizedAudiobookProducer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DramatizedAudiobookProducer.swift; path = Sources/CreatorCoreForge/DramatizedAudiobookProducer.swift; sourceTree = "<group>"; };
+		6C1E8FB0E527703A9FDD133C /* ExportQueueManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportQueueManager.swift; path = Sources/CreatorCoreForge/ExportQueueManager.swift; sourceTree = "<group>"; };
+		6C645B303664D65B664D563C /* AIEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIEngine.swift; path = Sources/CreatorCoreForge/AIEngine.swift; sourceTree = "<group>"; };
+		6CD0963396C2CFAA9BE2D322 /* MemoryPinning.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MemoryPinning.swift; path = Sources/CreatorCoreForge/MemoryPinning.swift; sourceTree = "<group>"; };
+		6DD988A209271D3C4F76FECF /* NSFWVoiceClipManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWVoiceClipManager.swift; path = Sources/CreatorCoreForge/NSFWVoiceClipManager.swift; sourceTree = "<group>"; };
+		6E6435C3BDA69052484BCE25 /* SceneFXPresets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneFXPresets.swift; path = Sources/CreatorCoreForge/SceneFXPresets.swift; sourceTree = "<group>"; };
+		6E66F6D5DB93E03B517B68C7 /* ExportProduction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportProduction.swift; path = Sources/CreatorCoreForge/ExportProduction.swift; sourceTree = "<group>"; };
+		6F50B98DA6F22B05E65330BB /* PropLocalizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PropLocalizer.swift; path = Sources/CreatorCoreForge/PropLocalizer.swift; sourceTree = "<group>"; };
+		6FF1D8FD73D72239BC1A6128 /* AnalyticsLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnalyticsLogger.swift; path = Sources/CreatorCoreForge/AnalyticsLogger.swift; sourceTree = "<group>"; };
+		70B96E45436AE08041AA47AE /* AutoRemixMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoRemixMode.swift; path = Sources/CreatorCoreForge/AutoRemixMode.swift; sourceTree = "<group>"; };
+		72BCDD8A11968BF3AABEC97D /* OfflineMP3Downloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineMP3Downloader.swift; path = Sources/CreatorCoreForge/OfflineMP3Downloader.swift; sourceTree = "<group>"; };
+		72C8ADD111F07E656D43FC3A /* StealthModeVaultManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StealthModeVaultManager.swift; path = Sources/CreatorCoreForge/StealthModeVaultManager.swift; sourceTree = "<group>"; };
+		7417EBD61C3C8D8BBE5DA1CC /* ExperimentalFX.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExperimentalFX.swift; path = Sources/CreatorCoreForge/ExperimentalFX.swift; sourceTree = "<group>"; };
+		74707E4A875AC3BF78EB4FB2 /* AdaptiveReasoner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdaptiveReasoner.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AdaptiveReasoner.swift; sourceTree = "<group>"; };
+		74918B207D8BE19335C774D9 /* TraitMemoryPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TraitMemoryPersistence.swift; path = Sources/CreatorCoreForge/TraitMemoryPersistence.swift; sourceTree = "<group>"; };
+		7492919D89044D89E65AE54B /* SleepMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SleepMode.swift; path = Sources/CreatorCoreForge/SleepMode.swift; sourceTree = "<group>"; };
+		7543F618A69ABA1DBEE15483 /* StreamAssembler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamAssembler.swift; path = Sources/CreatorCoreForge/StreamAssembler.swift; sourceTree = "<group>"; };
+		75AA1BFFD8E9EAFF3524CEDE /* SceneSegmenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneSegmenter.swift; path = Sources/CreatorCoreForge/SceneSegmenter.swift; sourceTree = "<group>"; };
+		75EDCC6FFC3820CB105B5CDC /* ConsentTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConsentTracker.swift; path = Sources/CreatorCoreForge/ConsentTracker.swift; sourceTree = "<group>"; };
+		75FD22EB6AFBE06E054DBD48 /* ViralEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViralEngine.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ViralEngine.swift; sourceTree = "<group>"; };
+		768B6A8BC799FC6A26756CF8 /* ChapterAnalyticsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChapterAnalyticsService.swift; path = Sources/CreatorCoreForge/ChapterAnalyticsService.swift; sourceTree = "<group>"; };
+		77148A0159522A538C086BB9 /* FXLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FXLibrary.swift; path = Sources/CreatorCoreForge/FXLibrary.swift; sourceTree = "<group>"; };
+		780B93E12C98CAF9B0375EF8 /* StealthVault.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StealthVault.swift; path = Sources/CreatorCoreForge/StealthVault.swift; sourceTree = "<group>"; };
+		786D70D574E10326DB7E36D4 /* CoreForgeMarket_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeMarket_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeMarket_MissingFeatures.swift; sourceTree = "<group>"; };
+		7889B0A0A744F2AD833993C6 /* NSFWHabitBehaviorSimulator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWHabitBehaviorSimulator.swift; path = Sources/CreatorCoreForge/NSFWHabitBehaviorSimulator.swift; sourceTree = "<group>"; };
+		78CA022C038682DA150D3BD8 /* DecoyScreenManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DecoyScreenManager.swift; path = Sources/CreatorCoreForge/DecoyScreenManager.swift; sourceTree = "<group>"; };
+		792D4FBDFF7FCDAF2D4DDB3E /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AuthManager.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AuthManager.swift; sourceTree = "<group>"; };
+		79918570E9397486BF9530C7 /* SpatialAudioSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SpatialAudioSupport.swift; path = Sources/CreatorCoreForge/SpatialAudioSupport.swift; sourceTree = "<group>"; };
+		79B20008621FCE7BD8867906 /* AccessibilityOutput.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccessibilityOutput.swift; path = Sources/CreatorCoreForge/AccessibilityOutput.swift; sourceTree = "<group>"; };
+		79FBFF611BD616EAF222B139 /* UserAnnotations.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UserAnnotations.swift; path = Sources/CreatorCoreForge/UserAnnotations.swift; sourceTree = "<group>"; };
+		7A891D2F6408D696F7D5721B /* BookProcessing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookProcessing.swift; path = Sources/CreatorCoreForge/BookProcessing.swift; sourceTree = "<group>"; };
+		7B23E77D8BF76D7F024565AD /* EnhancedReasoner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EnhancedReasoner.swift; path = Sources/CreatorCoreForge/EnhancedReasoner.swift; sourceTree = "<group>"; };
+		7B50B6DF825CA069E55C4952 /* ExportService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportService.swift; path = Sources/CreatorCoreForge/ExportService.swift; sourceTree = "<group>"; };
+		7C4CECA69E15E2649986C44B /* LibraryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LibraryModel.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel.swift; sourceTree = "<group>"; };
+		7C9F8DEAA4CACE814341BFC3 /* TimelineForkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TimelineForkManager.swift; path = Sources/CreatorCoreForge/TimelineForkManager.swift; sourceTree = "<group>"; };
+		7DAD769F0C8E109D82B2145C /* KindleService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = KindleService.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/KindleService.swift; sourceTree = "<group>"; };
+		7FA1C1D008190A8615A58C63 /* AmbientPreviewer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AmbientPreviewer.swift; path = Sources/CreatorCoreForge/AmbientPreviewer.swift; sourceTree = "<group>"; };
+		807B06D0F42EA0CA17A0BD8B /* FormGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormGenerator.swift; path = Sources/CreatorCoreForge/FormGenerator.swift; sourceTree = "<group>"; };
+		81B4A85A42A59233CA305BBB /* SupportedLanguages.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SupportedLanguages.swift; path = Sources/CreatorCoreForge/SupportedLanguages.swift; sourceTree = "<group>"; };
+		81FD07FC5955F5DADAAF5C61 /* LogicBlockLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LogicBlockLibrary.swift; path = Sources/CreatorCoreForge/LogicBlockLibrary.swift; sourceTree = "<group>"; };
+		83F16CBBBF86D1D0410B6C31 /* OfflineTTSCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineTTSCache.swift; path = Sources/CreatorCoreForge/OfflineTTSCache.swift; sourceTree = "<group>"; };
+		8426CF7BA23103C0341B1672 /* CoreForgeAudioApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CoreForgeAudioApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		84AFB03B784E27ED1284F70D /* GenesisModeEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GenesisModeEngine.swift; path = Sources/CreatorCoreForge/GenesisModeEngine.swift; sourceTree = "<group>"; };
+		84CB1E14EBB82C7398FE5E8D /* HeatmapAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeatmapAnalytics.swift; path = Sources/CreatorCoreForge/HeatmapAnalytics.swift; sourceTree = "<group>"; };
+		859CD6702F25EA4905A3C593 /* HighQualityVoiceLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HighQualityVoiceLibrary.swift; path = Sources/CreatorCoreForge/HighQualityVoiceLibrary.swift; sourceTree = "<group>"; };
+		85AFFC99353558BC6B6E822C /* SettingsPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SettingsPanel.swift; path = Sources/CreatorCoreForge/SettingsPanel.swift; sourceTree = "<group>"; };
+		85B2EB96107B9E9700B5D701 /* MacroPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MacroPlugin.swift; path = Sources/CreatorCoreForge/MacroPlugin.swift; sourceTree = "<group>"; };
+		85CCCC1848614EDB17266186 /* SecureStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SecureStore.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SecureStore.swift; sourceTree = "<group>"; };
+		86F3B9D54CC0DC563D658DED /* AutoUpdater.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoUpdater.swift; path = Sources/CreatorCoreForge/AutoUpdater.swift; sourceTree = "<group>"; };
+		8759B8F8BE04671CBEEB389A /* BackendScaffolder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BackendScaffolder.swift; path = Sources/CreatorCoreForge/BackendScaffolder.swift; sourceTree = "<group>"; };
+		88B9C631B3BA0CB455EC62B9 /* StealthVaultManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StealthVaultManager.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/StealthVaultManager.swift; sourceTree = "<group>"; };
+		89905EBB29DF34B4BA5A0BEE /* CharacterVisualizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterVisualizer.swift; path = Sources/CreatorCoreForge/CharacterVisualizer.swift; sourceTree = "<group>"; };
+		89D637554812FCC8D2881BF5 /* BookDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookDetailView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookDetailView.swift; sourceTree = "<group>"; };
+		8A8F3D19A68CF7269767A81B /* MacroWorkflowEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MacroWorkflowEngine.swift; path = Sources/CreatorCoreForge/MacroWorkflowEngine.swift; sourceTree = "<group>"; };
+		8B82DA9533B19FC1B8CC2DD0 /* RefactorLogger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RefactorLogger.swift; path = Sources/CreatorCoreForge/RefactorLogger.swift; sourceTree = "<group>"; };
+		8B99F4C047A0376269AA27A5 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ContentView.swift; sourceTree = "<group>"; };
+		8C8A3E0B5D31FA53115229E4 /* AdaptiveMusicGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdaptiveMusicGenerator.swift; path = Sources/CreatorCoreForge/AdaptiveMusicGenerator.swift; sourceTree = "<group>"; };
+		8DC64126506BAD241FE7F90E /* CyclePredictor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CyclePredictor.swift; path = Sources/CreatorCoreForge/CyclePredictor.swift; sourceTree = "<group>"; };
+		8DD57243BD3ADFDE72DE91F9 /* TradingLeaderboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TradingLeaderboard.swift; path = Sources/CreatorCoreForge/TradingLeaderboard.swift; sourceTree = "<group>"; };
+		8DE0B41B8590E3E4F1963E81 /* AppleBooksView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppleBooksView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksView.swift; sourceTree = "<group>"; };
+		8DE5E0272C630E5A0B347740 /* LocalVoiceAI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalVoiceAI.swift; path = Sources/CreatorCoreForge/LocalVoiceAI.swift; sourceTree = "<group>"; };
+		8DFA23D5D6EE5EFD659F02C1 /* ArchitectureDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ArchitectureDetector.swift; path = Sources/CreatorCoreForge/ArchitectureDetector.swift; sourceTree = "<group>"; };
+		8EDABB0B7AD9DE841A39C505 /* PluginBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginBuilder.swift; path = Sources/CreatorCoreForge/PluginBuilder.swift; sourceTree = "<group>"; };
+		8F51B1D6FCFADB8FC678665B /* InputBindingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InputBindingEngine.swift; path = Sources/CreatorCoreForge/InputBindingEngine.swift; sourceTree = "<group>"; };
+		8F76E0FA9C08DD631B53BE43 /* PluginManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginManifest.swift; path = Sources/CreatorCoreForge/PluginManifest.swift; sourceTree = "<group>"; };
+		8FBC998471C16F2ED738AFED /* VisualMemoryEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualMemoryEngine.swift; path = Sources/CreatorCoreForge/VisualMemoryEngine.swift; sourceTree = "<group>"; };
+		902F471013932BDB24F0ED3F /* VisualDescriptionExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualDescriptionExtractor.swift; path = Sources/CreatorCoreForge/VisualDescriptionExtractor.swift; sourceTree = "<group>"; };
+		90E48CC58DD2F58B715F7EAA /* VisualFXEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualFXEngine.swift; path = Sources/CreatorCoreForge/VisualFXEngine.swift; sourceTree = "<group>"; };
+		9166209A9787659630316FEB /* CreatorDashboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreatorDashboard.swift; path = Sources/CreatorCoreForge/CreatorDashboard.swift; sourceTree = "<group>"; };
+		916B0C1BA011C68934D8C5BC /* MultiPOVSceneBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiPOVSceneBuilder.swift; path = Sources/CreatorCoreForge/MultiPOVSceneBuilder.swift; sourceTree = "<group>"; };
+		91EFB03DAACD1E8F124C7775 /* ChapterManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChapterManager.swift; path = Sources/CreatorCoreForge/ChapterManager.swift; sourceTree = "<group>"; };
+		922DE1B2B943E583A401BECB /* SmartAmbientMixer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SmartAmbientMixer.swift; path = Sources/CreatorCoreForge/SmartAmbientMixer.swift; sourceTree = "<group>"; };
+		92D5D4828887DF8191AD38E1 /* DOBCheck.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DOBCheck.swift; path = Sources/CreatorCoreForge/DOBCheck.swift; sourceTree = "<group>"; };
+		934A9009CAD9F5107ABE30A7 /* MemoryTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MemoryTracker.swift; path = Sources/CreatorCoreForge/MemoryTracker.swift; sourceTree = "<group>"; };
+		93A1F3585617CDB4A4BDCBD7 /* BranchingPathsUI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BranchingPathsUI.swift; path = Sources/CreatorCoreForge/BranchingPathsUI.swift; sourceTree = "<group>"; };
+		9420E998989C4918D6FDAAC0 /* RealisticVoiceoverEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RealisticVoiceoverEngine.swift; path = Sources/CreatorCoreForge/RealisticVoiceoverEngine.swift; sourceTree = "<group>"; };
+		94DF5DA58B96CC3863E71AF1 /* NextGenSpeechService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NextGenSpeechService.swift; path = Sources/CreatorCoreForge/NextGenSpeechService.swift; sourceTree = "<group>"; };
+		950E8746CF5599F796355A08 /* UniversalMediaGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UniversalMediaGenerator.swift; path = Sources/CreatorCoreForge/UniversalMediaGenerator.swift; sourceTree = "<group>"; };
+		95504057F18EBC0A10BF3B69 /* CharacterPaletteManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterPaletteManager.swift; path = Sources/CreatorCoreForge/CharacterPaletteManager.swift; sourceTree = "<group>"; };
+		9596E92BE97DBDFCB8B7A7AF /* AudioExportService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioExportService.swift; path = Sources/CreatorCoreForge/AudioExportService.swift; sourceTree = "<group>"; };
+		95F4FDA89478DA3C6805290E /* ForgotPasswordView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ForgotPasswordView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/ForgotPasswordView.swift; sourceTree = "<group>"; };
+		95F69196BC094B0872D9D436 /* UnifiedAudioEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnifiedAudioEngine.swift; path = Sources/CreatorCoreForge/UnifiedAudioEngine.swift; sourceTree = "<group>"; };
+		9661BEED7C1139AC613B7D97 /* PluginSandbox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginSandbox.swift; path = Sources/CreatorCoreForge/PluginSandbox.swift; sourceTree = "<group>"; };
+		9708BFD495DAE889462BDEE8 /* FrameRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FrameRenderer.swift; path = Sources/CreatorCoreForge/FrameRenderer.swift; sourceTree = "<group>"; };
+		978103783A50D41B8F4E1EAB /* ACXComplianceChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ACXComplianceChecker.swift; path = Sources/CreatorCoreForge/ACXComplianceChecker.swift; sourceTree = "<group>"; };
+		97A835A2C983CD58DA45BE4C /* BatchImportTool.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BatchImportTool.swift; path = Sources/CreatorCoreForge/BatchImportTool.swift; sourceTree = "<group>"; };
+		97FFF9E5B564E625D62C0DAC /* CommunityMarketplace.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CommunityMarketplace.swift; path = Sources/CreatorCoreForge/CommunityMarketplace.swift; sourceTree = "<group>"; };
+		985643EA7FC1985EA392E4A4 /* NSFWSceneToggle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWSceneToggle.swift; path = Sources/CreatorCoreForge/NSFWSceneToggle.swift; sourceTree = "<group>"; };
+		98A76BF19D0DB57116A1329C /* MultilingualEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultilingualEngine.swift; path = Sources/CreatorCoreForge/MultilingualEngine.swift; sourceTree = "<group>"; };
+		99065F72F26B52517C3A0777 /* ExportTools.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportTools.swift; path = Sources/CreatorCoreForge/ExportTools.swift; sourceTree = "<group>"; };
+		995F23AB0F2C71CC32D8E4F4 /* RegisterView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RegisterView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/RegisterView.swift; sourceTree = "<group>"; };
+		9AE626FBE2C669B1B1FFDF34 /* SubtitleGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubtitleGenerator.swift; path = Sources/CreatorCoreForge/SubtitleGenerator.swift; sourceTree = "<group>"; };
+		9BB886D3C6FEDFDCB3799211 /* UnifiedVideoEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UnifiedVideoEngine.swift; path = Sources/CreatorCoreForge/UnifiedVideoEngine.swift; sourceTree = "<group>"; };
+		9C1F3AA2B5EC90FC645A27AE /* CanonMemoryGraph.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CanonMemoryGraph.swift; path = Sources/CreatorCoreForge/CanonMemoryGraph.swift; sourceTree = "<group>"; };
+		9CF6AFDD60A82A9618BB8E2A /* AudioCreditManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioCreditManager.swift; path = Sources/CreatorCoreForge/AudioCreditManager.swift; sourceTree = "<group>"; };
+		9DEA77D495BDAAFD0953DAE5 /* MultivoiceCharacterMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultivoiceCharacterMode.swift; path = Sources/CreatorCoreForge/MultivoiceCharacterMode.swift; sourceTree = "<group>"; };
+		9EBBF1D3F15B87F4273EDA7C /* HapticDeviceManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HapticDeviceManager.swift; path = Sources/CreatorCoreForge/HapticDeviceManager.swift; sourceTree = "<group>"; };
+		9F26E6D6500600637F6932C0 /* FormExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormExporter.swift; path = Sources/CreatorCoreForge/FormExporter.swift; sourceTree = "<group>"; };
+		A07EF8BE89459197D50EB1C6 /* VoiceTrainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceTrainer.swift; path = Sources/CreatorCoreForge/VoiceTrainer.swift; sourceTree = "<group>"; };
+		A19E5225D2FC6FC3E81088D3 /* AutoFormatDialogue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AutoFormatDialogue.swift; path = Sources/CreatorCoreForge/AutoFormatDialogue.swift; sourceTree = "<group>"; };
+		A1BE4C66AF5CDEB17956F87F /* VoiceDNAVisualizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceDNAVisualizer.swift; path = Sources/CreatorCoreForge/VoiceDNAVisualizer.swift; sourceTree = "<group>"; };
+		A1FB6F75388832B6BF354513 /* GlowingButtonStyle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlowingButtonStyle.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/GlowingButtonStyle.swift; sourceTree = "<group>"; };
+		A2154293C3749017C0F1B6DC /* NetworkInfoProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkInfoProvider.swift; path = Sources/CreatorCoreForge/NetworkInfoProvider.swift; sourceTree = "<group>"; };
+		A2EE858F6FE475D4AEFC4882 /* NSFWGate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWGate.swift; path = Sources/CreatorCoreForge/NSFWGate.swift; sourceTree = "<group>"; };
+		A65C59762E110F486CAD9852 /* FusionVoiceController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FusionVoiceController.swift; path = Sources/CreatorCoreForge/FusionVoiceController.swift; sourceTree = "<group>"; };
+		A7E5C97E4D9835EE8984DAA5 /* CoreForgeBuild_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeBuild_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeBuild_MissingFeatures.swift; sourceTree = "<group>"; };
+		A7FBAC4A17C1A13026CB9EA4 /* ExportSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportSystem.swift; path = Sources/CreatorCoreForge/ExportSystem.swift; sourceTree = "<group>"; };
+		A8A65E5668CD586ACD6AAE05 /* NarrationScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NarrationScheduler.swift; path = Sources/CreatorCoreForge/NarrationScheduler.swift; sourceTree = "<group>"; };
+		A994823254578B0F05038459 /* AudiobookCompiler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudiobookCompiler.swift; path = Sources/CreatorCoreForge/AudiobookCompiler.swift; sourceTree = "<group>"; };
+		A9B86B6E001F481BA0096925 /* HybridQuantumTradingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HybridQuantumTradingEngine.swift; path = Sources/CreatorCoreForge/HybridQuantumTradingEngine.swift; sourceTree = "<group>"; };
+		A9D4230D1EBE552B9A70A57E /* BuildQueueController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildQueueController.swift; path = Sources/CreatorCoreForge/BuildQueueController.swift; sourceTree = "<group>"; };
+		A9DDDA205B31498D838389E3 /* EmotionPacingEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionPacingEditor.swift; path = Sources/CreatorCoreForge/EmotionPacingEditor.swift; sourceTree = "<group>"; };
+		AA328AEA3C24F926CA0F0671 /* UsageStats.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = UsageStats.swift; path = apps/CoreForgeAudio/models/UsageStats.swift; sourceTree = "<group>"; };
+		AA943D45F9857D72075DF719 /* LanguageTranslationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LanguageTranslationManager.swift; path = Sources/CreatorCoreForge/LanguageTranslationManager.swift; sourceTree = "<group>"; };
+		AAA8B7AD3B31F3AABC3EC332 /* ContextualMemory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContextualMemory.swift; path = Sources/CreatorCoreForge/ContextualMemory.swift; sourceTree = "<group>"; };
+		AAB5C2F2CDF9124C6B05D8D7 /* VoiceRatingSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceRatingSystem.swift; path = Sources/CreatorCoreForge/VoiceRatingSystem.swift; sourceTree = "<group>"; };
+		AAE726ABED1D4B4CDD2649B3 /* BuildMonetizationManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildMonetizationManager.swift; path = Sources/CreatorCoreForge/BuildMonetizationManager.swift; sourceTree = "<group>"; };
+		AAFDC4B86EDF4398F04948AB /* CameraMotionRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraMotionRenderer.swift; path = Sources/CreatorCoreForge/CameraMotionRenderer.swift; sourceTree = "<group>"; };
+		ABA6C2DB886BEE4830CDF9ED /* SignUpView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SignUpView.swift; path = Sources/CreatorCoreForge/SignUpView.swift; sourceTree = "<group>"; };
+		AC3E7F70433B298637FD77E2 /* QuantumEditMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumEditMode.swift; path = Sources/CreatorCoreForge/QuantumEditMode.swift; sourceTree = "<group>"; };
+		AC421B6EAE6C126C01EC55A7 /* ColorGradingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ColorGradingEngine.swift; path = Sources/CreatorCoreForge/ColorGradingEngine.swift; sourceTree = "<group>"; };
+		AC60BD086CB15D146DE01858 /* RenderAnalyticsDashboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RenderAnalyticsDashboard.swift; path = Sources/CreatorCoreForge/RenderAnalyticsDashboard.swift; sourceTree = "<group>"; };
+		AC8068A4FD738BF29D093A78 /* FigmaUIBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FigmaUIBuilder.swift; path = Sources/CreatorCoreForge/FigmaUIBuilder.swift; sourceTree = "<group>"; };
+		ACB95763F871B4D7E8537B05 /* FormFlowchartRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormFlowchartRenderer.swift; path = Sources/CreatorCoreForge/FormFlowchartRenderer.swift; sourceTree = "<group>"; };
+		ADA98FFC8DBECF99D2A820D6 /* FormTemplateLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormTemplateLibrary.swift; path = Sources/CreatorCoreForge/FormTemplateLibrary.swift; sourceTree = "<group>"; };
+		AF468B5A961CACF766F59B98 /* CharacterVoiceMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterVoiceMapper.swift; path = Sources/CreatorCoreForge/CharacterVoiceMapper.swift; sourceTree = "<group>"; };
+		AF8288792AF0910E5822F0D0 /* CinematicComposer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CinematicComposer.swift; path = Sources/CreatorCoreForge/CinematicComposer.swift; sourceTree = "<group>"; };
+		B243FDEE24E5561C8A25F2C1 /* NSFWToneSyncer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWToneSyncer.swift; path = Sources/CreatorCoreForge/NSFWToneSyncer.swift; sourceTree = "<group>"; };
+		B27BBBCAE0E53F8A6EF7D9D0 /* SceneGapFiller.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneGapFiller.swift; path = Sources/CreatorCoreForge/SceneGapFiller.swift; sourceTree = "<group>"; };
+		B340A308A6C8ACA4F802C7AF /* PlaybackSpeedControlView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlaybackSpeedControlView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PlaybackSpeedControlView.swift; sourceTree = "<group>"; };
+		B3F65FECCFA13BFC01E80647 /* NeuralOptimizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NeuralOptimizer.swift; path = Sources/CreatorCoreForge/NeuralOptimizer.swift; sourceTree = "<group>"; };
+		B41A360C6545BE9236ACC202 /* TimelineEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TimelineEditor.swift; path = Sources/CreatorCoreForge/TimelineEditor.swift; sourceTree = "<group>"; };
+		B4437C9025B4D1F769D01A1F /* PromoCodeManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PromoCodeManager.swift; path = Sources/CreatorCoreForge/PromoCodeManager.swift; sourceTree = "<group>"; };
+		B463B6F874F77344EFF125BF /* MemoryEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MemoryEngine.swift; path = Sources/CreatorCoreForge/MemoryEngine.swift; sourceTree = "<group>"; };
+		B543380551D15B6DA9113424 /* SleepReadMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SleepReadMode.swift; path = Sources/CreatorCoreForge/SleepReadMode.swift; sourceTree = "<group>"; };
+		B6127557E6047EE304ED0E93 /* EmotionDatabase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionDatabase.swift; path = Sources/CreatorCoreForge/EmotionDatabase.swift; sourceTree = "<group>"; };
+		B6951F5A72FBBB88D722D447 /* VoiceDNAForker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceDNAForker.swift; path = Sources/CreatorCoreForge/VoiceDNAForker.swift; sourceTree = "<group>"; };
+		B72B70ADA05D88D8D5C88A97 /* SceneTimeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneTimeline.swift; path = Sources/CreatorCoreForge/SceneTimeline.swift; sourceTree = "<group>"; };
+		B7B00FD0A7BE982ACC5614B8 /* VoiceControlService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceControlService.swift; path = Sources/CreatorCoreForge/VoiceControlService.swift; sourceTree = "<group>"; };
+		B7BBE46CD66C4AD31D7E22E5 /* QuantumConnector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumConnector.swift; path = Sources/CreatorCoreForge/QuantumConnector.swift; sourceTree = "<group>"; };
+		BB14F3EDAF3ACED412A4CDC5 /* MultiLanguageAccentNarrator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiLanguageAccentNarrator.swift; path = Sources/CreatorCoreForge/MultiLanguageAccentNarrator.swift; sourceTree = "<group>"; };
+		BC6134BBD3F575B13E386656 /* CoreForgeAudioIntegrator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeAudioIntegrator.swift; path = Sources/CreatorCoreForge/CoreForgeAudioIntegrator.swift; sourceTree = "<group>"; };
+		BCCDE787B9A7CEEAE11BEA49 /* CrossAppModuleManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrossAppModuleManager.swift; path = Sources/CreatorCoreForge/CrossAppModuleManager.swift; sourceTree = "<group>"; };
+		BD1CF1AEB6ADFED00BCD9A6A /* LongFormPacingEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LongFormPacingEngine.swift; path = Sources/CreatorCoreForge/LongFormPacingEngine.swift; sourceTree = "<group>"; };
+		BDB8397BB4A0AD48935317E7 /* SoundLayerEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SoundLayerEngine.swift; path = Sources/CreatorCoreForge/SoundLayerEngine.swift; sourceTree = "<group>"; };
+		BF1E5306332FF1A52998ED49 /* DAWSessionExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DAWSessionExporter.swift; path = Sources/CreatorCoreForge/DAWSessionExporter.swift; sourceTree = "<group>"; };
+		BF513DCF4365BB974657167B /* ExportManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExportManager.swift; path = Sources/CreatorCoreForge/ExportManager.swift; sourceTree = "<group>"; };
+		C001074AA0EE06F2B8CF218F /* NSFWSoundFXEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWSoundFXEngine.swift; path = Sources/CreatorCoreForge/NSFWSoundFXEngine.swift; sourceTree = "<group>"; };
+		C0FFB56C8A666279514CEC5E /* QuantumAIExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumAIExtension.swift; path = Sources/CreatorCoreForge/QuantumAIExtension.swift; sourceTree = "<group>"; };
+		C1538637A706040CBDFDFD56 /* NSFWContentManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWContentManager.swift; path = Sources/CreatorCoreForge/NSFWContentManager.swift; sourceTree = "<group>"; };
+		C2589E3499E6573FD89CC55E /* SubscriptionCreditSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionCreditSystem.swift; path = Sources/CreatorCoreForge/SubscriptionCreditSystem.swift; sourceTree = "<group>"; };
+		C3C524EC8687E9582AC24DD6 /* VoiceCloneShare.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceCloneShare.swift; path = Sources/CreatorCoreForge/VoiceCloneShare.swift; sourceTree = "<group>"; };
+		C3C54AA61E51CC4A065C2299 /* FilingsDatabase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilingsDatabase.swift; path = Sources/CreatorCoreForge/FilingsDatabase.swift; sourceTree = "<group>"; };
+		C45DC1419B293D4E6E0D8CE8 /* FusionEnginePlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FusionEnginePlugin.swift; path = Sources/CreatorCoreForge/FusionEnginePlugin.swift; sourceTree = "<group>"; };
+		C4A0ECF9FA27D4114DC739A9 /* PreviewKeyManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreviewKeyManager.swift; path = Sources/CreatorCoreForge/PreviewKeyManager.swift; sourceTree = "<group>"; };
+		C4CA0847F302C163840CC44F /* NSFWPhase7.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWPhase7.swift; path = Sources/CreatorCoreForge/NSFWPhase7.swift; sourceTree = "<group>"; };
+		C4D8FE1513763F0742FF5D6E /* NSFWService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWService.swift; path = Sources/CreatorCoreForge/NSFWService.swift; sourceTree = "<group>"; };
+		C5F740E917C5B7ADF295B97D /* OfflineAudioManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineAudioManager.swift; path = Sources/CreatorCoreForge/OfflineAudioManager.swift; sourceTree = "<group>"; };
+		C639EE04EC11DA53066F7290 /* HistoricalTimePeriodChecker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoricalTimePeriodChecker.swift; path = Sources/CreatorCoreForge/HistoricalTimePeriodChecker.swift; sourceTree = "<group>"; };
+		C659EE7A11D2DD477C57D824 /* VoiceMultiverseLinker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceMultiverseLinker.swift; path = Sources/CreatorCoreForge/VoiceMultiverseLinker.swift; sourceTree = "<group>"; };
+		C674D00E92E2736DB9A50594 /* DataEncryptionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DataEncryptionManager.swift; path = Sources/CreatorCoreForge/DataEncryptionManager.swift; sourceTree = "<group>"; };
+		C74F4162594A871B28B1492E /* OnboardingManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OnboardingManager.swift; path = Sources/CreatorCoreForge/OnboardingManager.swift; sourceTree = "<group>"; };
+		C7BC4DD6FF9C73FB21B1B80F /* OpenAIService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpenAIService.swift; path = Sources/CreatorCoreForge/OpenAIService.swift; sourceTree = "<group>"; };
+		C7D8E5368A05EC69AF0C05BC /* FormWizard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FormWizard.swift; path = Sources/CreatorCoreForge/FormWizard.swift; sourceTree = "<group>"; };
+		C858269D4CD8177CE659A33B /* SelfRepairEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SelfRepairEngine.swift; path = Sources/CreatorCoreForge/SelfRepairEngine.swift; sourceTree = "<group>"; };
+		C89B42D245BAC109F81B42B0 /* ChapterSegmenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChapterSegmenter.swift; path = Sources/CreatorCoreForge/ChapterSegmenter.swift; sourceTree = "<group>"; };
+		C8F9D03E36D8EEFBB7671391 /* ConversationalLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationalLayer.swift; path = Sources/CreatorCoreForge/TTS/ConversationalLayer.swift; sourceTree = "<group>"; };
+		C938BA7B0EC7182FB94BFFCD /* ElevenLabsClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElevenLabsClient.swift; path = Sources/CreatorCoreForge/ElevenLabsClient.swift; sourceTree = "<group>"; };
+		CADF87F5506C3142180CA951 /* CoreForgeBloom_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeBloom_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeBloom_MissingFeatures.swift; sourceTree = "<group>"; };
+		CC931C47DFA210D36DCF0CD9 /* SoundEffectsDatabase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SoundEffectsDatabase.swift; path = Sources/CreatorCoreForge/SoundEffectsDatabase.swift; sourceTree = "<group>"; };
+		CD091E40137E8B2A0FA8681F /* EmotionalArcTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionalArcTracker.swift; path = Sources/CreatorCoreForge/EmotionalArcTracker.swift; sourceTree = "<group>"; };
+		CE05A6173FDA18CAA4E7EF42 /* LiveEnsembleRoom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LiveEnsembleRoom.swift; path = Sources/CreatorCoreForge/LiveEnsembleRoom.swift; sourceTree = "<group>"; };
+		CF250F3D0B79FD1924F4EA65 /* AmbientFXEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AmbientFXEngine.swift; path = Sources/CreatorCoreForge/AmbientFXEngine.swift; sourceTree = "<group>"; };
+		CF409B58DBB0D3A0340C5A49 /* CoreForgeVisual_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeVisual_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeVisual_MissingFeatures.swift; sourceTree = "<group>"; };
+		CF6E144B78E2CDC068DC6D92 /* CameraStabilizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CameraStabilizer.swift; path = Sources/CreatorCoreForge/CameraStabilizer.swift; sourceTree = "<group>"; };
+		D04127A4EC76BA7118A1ECF7 /* BookCardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookCardView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/BookCardView.swift; sourceTree = "<group>"; };
+		D12F8366968C34F1A8C6BEEE /* AudioEffectsPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioEffectsPipeline.swift; path = Sources/CreatorCoreForge/AudioEffectsPipeline.swift; sourceTree = "<group>"; };
+		D16BA5F2601F11D9748924BE /* VoiceMemoryManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceMemoryManager.swift; path = Sources/CreatorCoreForge/VoiceMemoryManager.swift; sourceTree = "<group>"; };
+		D1CC45EF605CC689696EF908 /* PromptTemplateLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PromptTemplateLoader.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/PromptTemplateLoader.swift; sourceTree = "<group>"; };
+		D23A6A876E04D07BC34EE357 /* VoiceReviewSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceReviewSystem.swift; path = Sources/CreatorCoreForge/VoiceReviewSystem.swift; sourceTree = "<group>"; };
+		D28377ECC266C3B3506D8F9B /* LocalAIEnginePro.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LocalAIEnginePro.swift; path = Sources/CreatorCoreForge/LocalAIEnginePro.swift; sourceTree = "<group>"; };
+		D2E9C21A164F5F7FEF1B818A /* TTSHumanizer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TTSHumanizer.swift; path = Sources/CreatorCoreForge/TTS/TTSHumanizer.swift; sourceTree = "<group>"; };
+		D450A334B632E31F1879BE8B /* GlobalVoiceLibrary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GlobalVoiceLibrary.swift; path = Sources/CreatorCoreForge/GlobalVoiceLibrary.swift; sourceTree = "<group>"; };
+		D4C94A66E278A2346AD11AE0 /* PlaybackProgressSync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlaybackProgressSync.swift; path = Sources/CreatorCoreForge/PlaybackProgressSync.swift; sourceTree = "<group>"; };
+		D4E8749C333D4137941D706A /* DocumentParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DocumentParser.swift; path = Sources/CreatorCoreForge/DocumentParser.swift; sourceTree = "<group>"; };
+		D5B61769BC6D4AA59CA2C882 /* AmbientMixer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AmbientMixer.swift; path = Sources/CreatorCoreForge/AmbientMixer.swift; sourceTree = "<group>"; };
+		D6801066E61EEA234011CFC2 /* MultiTrackEditor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiTrackEditor.swift; path = Sources/CreatorCoreForge/MultiTrackEditor.swift; sourceTree = "<group>"; };
+		D714071AC559756B977C227A /* ProsodyCurveManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProsodyCurveManager.swift; path = Sources/CreatorCoreForge/TTS/ProsodyCurveManager.swift; sourceTree = "<group>"; };
+		D7391BCDD59D422CFF18995E /* AppCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppCatalog.swift; path = Sources/CreatorCoreForge/AppCatalog.swift; sourceTree = "<group>"; };
+		D8273D9EC0EBFB0EDE40DADE /* GitSync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GitSync.swift; path = Sources/CreatorCoreForge/GitSync.swift; sourceTree = "<group>"; };
+		D85114D6FD55C1EBD6CCD888 /* WatchSyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WatchSyncService.swift; path = Sources/CreatorCoreForge/WatchSyncService.swift; sourceTree = "<group>"; };
+		D8F64B8A1F2A2643E8ABC972 /* AppleBooksService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppleBooksService.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AppleBooksService.swift; sourceTree = "<group>"; };
+		D8FBC8238D2C9905E87E9B88 /* PersonalizedGreetingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PersonalizedGreetingService.swift; path = Sources/CreatorCoreForge/PersonalizedGreetingService.swift; sourceTree = "<group>"; };
+		D9E17A8916BCCDA7390D04B8 /* StoreKitManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StoreKitManager.swift; path = Sources/CreatorCoreForge/StoreKitManager.swift; sourceTree = "<group>"; };
+		DACF71ED80C50A65CD6359C8 /* SceneMemorySimulator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneMemorySimulator.swift; path = Sources/CreatorCoreForge/SceneMemorySimulator.swift; sourceTree = "<group>"; };
+		DAE07A0E7831074AED4EEDF4 /* TimelineBranchAdvisor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TimelineBranchAdvisor.swift; path = Sources/CreatorCoreForge/TimelineBranchAdvisor.swift; sourceTree = "<group>"; };
+		DB6EED8EA5142FD4BD3FB001 /* NSFWToneStyler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWToneStyler.swift; path = Sources/CreatorCoreForge/NSFWToneStyler.swift; sourceTree = "<group>"; };
+		DC5FEF75764864C9A9C94002 /* BuildDeploymentEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuildDeploymentEngine.swift; path = Sources/CreatorCoreForge/BuildDeploymentEngine.swift; sourceTree = "<group>"; };
+		DC7BF94AD2327257BE8004A0 /* CharacterDossierEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterDossierEngine.swift; path = Sources/CreatorCoreForge/CharacterDossierEngine.swift; sourceTree = "<group>"; };
+		DC9B497F82D0E4692AC6CA21 /* WelcomeSplashView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WelcomeSplashView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/WelcomeSplashView.swift; sourceTree = "<group>"; };
+		DDA17F478B520B6365CDA6FC /* CoreForgeAudio_PlaybackUIController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeAudio_PlaybackUIController.swift; path = Sources/CreatorCoreForge/CoreForgeAudio_PlaybackUIController.swift; sourceTree = "<group>"; };
+		DE4551CD0E04D733B5006958 /* CharacterMemoryEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterMemoryEngine.swift; path = Sources/CreatorCoreForge/CharacterMemoryEngine.swift; sourceTree = "<group>"; };
+		DE8E833A5FE75B152742FA1A /* AudioPlaybackController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudioPlaybackController.swift; path = Sources/CreatorCoreForge/AudioPlaybackController.swift; sourceTree = "<group>"; };
+		DF7053C5A7232290849E7805 /* HeartRateAdaptiveAudio.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HeartRateAdaptiveAudio.swift; path = Sources/CreatorCoreForge/HeartRateAdaptiveAudio.swift; sourceTree = "<group>"; };
+		DFA4259B15FDD86BA37A4C23 /* MockDataGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MockDataGenerator.swift; path = Sources/CreatorCoreForge/MockDataGenerator.swift; sourceTree = "<group>"; };
+		E06C254410685EE0607DA6C0 /* OfflineQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineQueue.swift; path = Sources/CreatorCoreForge/OfflineQueue.swift; sourceTree = "<group>"; };
+		E1062C217A585825286B48C0 /* SoundEffectManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SoundEffectManager.swift; path = Sources/CreatorCoreForge/SoundEffectManager.swift; sourceTree = "<group>"; };
+		E10B0BB76994668D85ED64C7 /* EbookImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EbookImporter.swift; path = Sources/CreatorCoreForge/EbookImporter.swift; sourceTree = "<group>"; };
+		E1364651BE0702DECCDE9FCF /* AIUsageTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AIUsageTracker.swift; path = Sources/CreatorCoreForge/AIUsageTracker.swift; sourceTree = "<group>"; };
+		E18C38C02AF14F176063F3A1 /* VoiceForkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceForkManager.swift; path = Sources/CreatorCoreForge/VoiceForkManager.swift; sourceTree = "<group>"; };
+		E1FF61CD74066715BAE0549A /* CrossBookNarration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrossBookNarration.swift; path = Sources/CreatorCoreForge/CrossBookNarration.swift; sourceTree = "<group>"; };
+		E210C8E620AC0CAD48EFA95B /* VoiceTimbreModulator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceTimbreModulator.swift; path = Sources/CreatorCoreForge/VoiceTimbreModulator.swift; sourceTree = "<group>"; };
+		E239EC118899F28C0A22D2A2 /* DashboardView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DashboardView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/DashboardView.swift; sourceTree = "<group>"; };
+		E24D75BDD390E8729F346721 /* NSFWMoodHeatmap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWMoodHeatmap.swift; path = Sources/CreatorCoreForge/NSFWMoodHeatmap.swift; sourceTree = "<group>"; };
+		E2D9DB76571383C7D6E4E3C3 /* CoreForgeAudio_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeAudio_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeAudio_MissingFeatures.swift; sourceTree = "<group>"; };
+		E4D14474DF47A474AD3493AF /* AppIdeaGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppIdeaGenerator.swift; path = Sources/CreatorCoreForge/AppIdeaGenerator.swift; sourceTree = "<group>"; };
+		E5983230A954F4CD8198A198 /* SocialMediaManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SocialMediaManager.swift; path = Sources/CreatorCoreForge/SocialMediaManager.swift; sourceTree = "<group>"; };
+		E607C529F6A2EA448D203F8B /* Export360VR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Export360VR.swift; path = Sources/CreatorCoreForge/Export360VR.swift; sourceTree = "<group>"; };
+		E6088A773D9B94000391EF32 /* NSFWPaywallManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWPaywallManager.swift; path = Sources/CreatorCoreForge/NSFWPaywallManager.swift; sourceTree = "<group>"; };
+		E657C6292CA7FADB3A535124 /* MiniPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MiniPlayerView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/MiniPlayerView.swift; sourceTree = "<group>"; };
+		E65D800B682C218999B0BEF1 /* VoiceToneMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceToneMatcher.swift; path = Sources/CreatorCoreForge/VoiceToneMatcher.swift; sourceTree = "<group>"; };
+		E6D7429B72B40934AB4BCF90 /* LoggingPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LoggingPlugin.swift; path = Sources/CreatorCoreForge/LoggingPlugin.swift; sourceTree = "<group>"; };
+		E750817C5D453940CFE0FBC8 /* WatermarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WatermarkService.swift; path = Sources/CreatorCoreForge/WatermarkService.swift; sourceTree = "<group>"; };
+		E7C1D135E6C13268742F1D9D /* VoiceBookmarkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceBookmarkService.swift; path = Sources/CreatorCoreForge/VoiceBookmarkService.swift; sourceTree = "<group>"; };
+		E8207E1404A6427ED22E0169 /* BasicAuthService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BasicAuthService.swift; path = Sources/CreatorCoreForge/BasicAuthService.swift; sourceTree = "<group>"; };
+		E8C29E7F401479C8111BC44B /* VisualContextAdapter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualContextAdapter.swift; path = Sources/CreatorCoreForge/VisualContextAdapter.swift; sourceTree = "<group>"; };
+		E98B5FB5192283B7BC0D0807 /* NSFWEnhancer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NSFWEnhancer.swift; path = Sources/CreatorCoreForge/NSFWEnhancer.swift; sourceTree = "<group>"; };
+		E9F90FB13A14B307B0BF1C5D /* CharacterVoiceAging.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CharacterVoiceAging.swift; path = Sources/CreatorCoreForge/CharacterVoiceAging.swift; sourceTree = "<group>"; };
+		EA37D30F139C74EA5AF0EA96 /* VoiceAssigner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceAssigner.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceAssigner.swift; sourceTree = "<group>"; };
+		EA54D0E4E5B683C958E116E1 /* EPUBParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EPUBParser.swift; path = Sources/CreatorCoreForge/EPUBParser.swift; sourceTree = "<group>"; };
+		EB5087B6EC9F3C9DDA5C8A1E /* ChapterDetector.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ChapterDetector.swift; path = Sources/CreatorCoreForge/ChapterDetector.swift; sourceTree = "<group>"; };
+		EBFD9F9946C6E74555B8766E /* VersionedExports.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VersionedExports.swift; path = Sources/CreatorCoreForge/VersionedExports.swift; sourceTree = "<group>"; };
+		ECB3DAECE635BA7241D837DB /* SpeechHighlighter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SpeechHighlighter.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/SpeechHighlighter.swift; sourceTree = "<group>"; };
+		ED03E27A1ADEC87CC288C040 /* AppSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppSettings.swift; path = Sources/CreatorCoreForge/AppSettings.swift; sourceTree = "<group>"; };
+		EDE0181ED31E2C2A6A275E92 /* ViewerNavigationTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViewerNavigationTracker.swift; path = Sources/CreatorCoreForge/ViewerNavigationTracker.swift; sourceTree = "<group>"; };
+		EF0F4DB1369829F5204C91E5 /* AudiobookPlayerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AudiobookPlayerView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AudiobookPlayerView.swift; sourceTree = "<group>"; };
+		EF0FFDDC6057EAC7BCE744F1 /* MultilingualVoiceBlend.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultilingualVoiceBlend.swift; path = Sources/CreatorCoreForge/MultilingualVoiceBlend.swift; sourceTree = "<group>"; };
+		EF2555BAFC6776433B59A2C9 /* ReferralDashboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReferralDashboard.swift; path = Sources/CreatorCoreForge/ReferralDashboard.swift; sourceTree = "<group>"; };
+		EF3C0B714AFE525C0C300173 /* AgeVerificationView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AgeVerificationView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/AgeVerificationView.swift; sourceTree = "<group>"; };
+		F0359EC4A0BEA93DF81DA560 /* SegmentEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SegmentEngine.swift; path = Sources/CreatorCoreForge/SegmentEngine.swift; sourceTree = "<group>"; };
+		F172C449F889BD693E5974B6 /* DownloadableAudiobookCreator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DownloadableAudiobookCreator.swift; path = Sources/CreatorCoreForge/DownloadableAudiobookCreator.swift; sourceTree = "<group>"; };
+		F1CE9A4C9987508E4D127839 /* ViralityEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ViralityEngine.swift; path = Sources/CreatorCoreForge/ViralityEngine.swift; sourceTree = "<group>"; };
+		F2029007383BCC8D4C67827C /* MultiverseVoiceSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MultiverseVoiceSystem.swift; path = Sources/CreatorCoreForge/MultiverseVoiceSystem.swift; sourceTree = "<group>"; };
+		F21C024DF50250A5812F54AD /* VisualFeatureEnhancer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VisualFeatureEnhancer.swift; path = Sources/CreatorCoreForge/VisualFeatureEnhancer.swift; sourceTree = "<group>"; };
+		F2435B1F1D64856623DEBE5F /* GPTChapterNarrator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GPTChapterNarrator.swift; path = Sources/CreatorCoreForge/GPTChapterNarrator.swift; sourceTree = "<group>"; };
+		F35FDAE9A00932D275FBFF66 /* AccentGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AccentGenerator.swift; path = Sources/CreatorCoreForge/AccentGenerator.swift; sourceTree = "<group>"; };
+		F48694577E932D0822A51A74 /* VoiceCastView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceCastView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/VoiceCastView.swift; sourceTree = "<group>"; };
+		F4C550F14F6BA637B5867D75 /* VideoEffectsPipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoEffectsPipeline.swift; path = Sources/CreatorCoreForge/VideoEffectsPipeline.swift; sourceTree = "<group>"; };
+		F4F45AE4843DA80AD5DC4498 /* BookImporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BookImporter.swift; path = Sources/CreatorCoreForge/BookImporter.swift; sourceTree = "<group>"; };
+		F5D77CCBE9BDB7AF46178F2A /* VideoExportService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VideoExportService.swift; path = Sources/CreatorCoreForge/VideoExportService.swift; sourceTree = "<group>"; };
+		F64DF4CAEE3F09CD51408ACA /* CreatorPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CreatorPanel.swift; path = Sources/CreatorCoreForge/CreatorPanel.swift; sourceTree = "<group>"; };
+		F6B3C0E0AA374C1118BBF90A /* VaultService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VaultService.swift; path = Sources/CreatorCoreForge/VaultService.swift; sourceTree = "<group>"; };
+		F6C0668F32F4C366E27BB183 /* EmotionShiftTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EmotionShiftTracker.swift; path = Sources/CreatorCoreForge/EmotionShiftTracker.swift; sourceTree = "<group>"; };
+		F6D187FF25247BB7221E8BBD /* SceneBackgroundGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SceneBackgroundGenerator.swift; path = Sources/CreatorCoreForge/SceneBackgroundGenerator.swift; sourceTree = "<group>"; };
+		F7670B7086B80E1D737718F2 /* PreviewSandbox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PreviewSandbox.swift; path = Sources/CreatorCoreForge/PreviewSandbox.swift; sourceTree = "<group>"; };
+		F776641FF1110052256EAF1A /* QuantumChoicePlottingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuantumChoicePlottingService.swift; path = Sources/CreatorCoreForge/QuantumChoicePlottingService.swift; sourceTree = "<group>"; };
+		F7FD29574D3DD33EE0C9B0B9 /* StyleModelTrainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StyleModelTrainer.swift; path = Sources/CreatorCoreForge/StyleModelTrainer.swift; sourceTree = "<group>"; };
+		F95C843A8084D05B4FB215CE /* Book.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Book.swift; path = apps/CoreForgeAudio/models/Book.swift; sourceTree = "<group>"; };
+		F9C346D4550D0D80C9E0D5F7 /* SyncServiceProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncServiceProtocol.swift; path = Sources/CreatorCoreForge/SyncServiceProtocol.swift; sourceTree = "<group>"; };
+		FC72C79B42D5A99BDF4CBE04 /* CustomVoiceUploads.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CustomVoiceUploads.swift; path = Sources/CreatorCoreForge/CustomVoiceUploads.swift; sourceTree = "<group>"; };
+		FC99EC025507285FC39297C6 /* OfflineContentManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OfflineContentManager.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/OfflineContentManager.swift; sourceTree = "<group>"; };
+		FD2DD85884FF03F0F3AF761D /* PlaybackAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PlaybackAnalytics.swift; path = Sources/CreatorCoreForge/PlaybackAnalytics.swift; sourceTree = "<group>"; };
+		FD8F898A340675C5D40442C0 /* MarkdownLayoutParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MarkdownLayoutParser.swift; path = Sources/CreatorCoreForge/MarkdownLayoutParser.swift; sourceTree = "<group>"; };
+		FF53738AFABE76D096CEA2D0 /* VoiceRevisionManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceRevisionManager.swift; path = Sources/CreatorCoreForge/VoiceRevisionManager.swift; sourceTree = "<group>"; };
+		FF9226EC17D7FF286BFBB579 /* FavoritesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FavoritesView.swift; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/FavoritesView.swift; sourceTree = "<group>"; };
+		FFA3ACCA478C63DEFE8B4B40 /* ProjectSharing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProjectSharing.swift; path = Sources/CreatorCoreForge/ProjectSharing.swift; sourceTree = "<group>"; };
+		FFDF6D29E2478B5A5AA627DC /* CoreForgeMind_MissingFeatures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CoreForgeMind_MissingFeatures.swift; path = Sources/CreatorCoreForge/CoreForgeMind_MissingFeatures.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C489D003A21DBBAAD52349C8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2592B7447DA8DDE071668FE2 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2108731472899347EFEDBE46 = {
+			isa = PBXGroup;
+			children = (
+				B1865267B0B18A894A6B6DF3 /* Products */,
+				D71D1207BE8F641129675E1E /* Frameworks */,
+				74707E4A875AC3BF78EB4FB2 /* AdaptiveReasoner.swift */,
+				EF3C0B714AFE525C0C300173 /* AgeVerificationView.swift */,
+				D8F64B8A1F2A2643E8ABC972 /* AppleBooksService.swift */,
+				8DE0B41B8590E3E4F1963E81 /* AppleBooksView.swift */,
+				EF0F4DB1369829F5204C91E5 /* AudiobookPlayerView.swift */,
+				792D4FBDFF7FCDAF2D4DDB3E /* AuthManager.swift */,
+				4562748BF16196492E753927 /* BannerCarouselView.swift */,
+				D04127A4EC76BA7118A1ECF7 /* BookCardView.swift */,
+				89D637554812FCC8D2881BF5 /* BookDetailView.swift */,
+				36D1B6F0AFC931E49E6F1E47 /* ChapterImporter.swift */,
+				4B31B3279342EB22EB2C0B90 /* CharacterVoiceMemory.swift */,
+				46B80322224D366705B84E81 /* ConnectView.swift */,
+				8B99F4C047A0376269AA27A5 /* ContentView.swift */,
+				427013E1DE2C713C0A784592 /* CoreForgeAudioApp.swift */,
+				5BC1F3482E6F4842815C9E84 /* CreditStore.swift */,
+				459EB67C128B19FE9EC18348 /* CreditsHistoryView.swift */,
+				E239EC118899F28C0A22D2A2 /* DashboardView.swift */,
+				6A0346F8BF557F425F0C2D43 /* DownloadQueue.swift */,
+				1197097692EC4CC00A247E96 /* DownloadsView.swift */,
+				0023E73BFB52710BF1A285F7 /* EbookImporter.swift */,
+				3623341860254AD8951598FD /* ElevenLabsService.swift */,
+				FF9226EC17D7FF286BFBB579 /* FavoritesView.swift */,
+				178B7A1DF14DF5F041D37029 /* FeaturedCarouselView.swift */,
+				4D39E3C0B4A19A654E86F113 /* FirebaseService.swift */,
+				95F4FDA89478DA3C6805290E /* ForgotPasswordView.swift */,
+				A1FB6F75388832B6BF354513 /* GlowingButtonStyle.swift */,
+				5316C14172E77540599D6DB7 /* ImportView.swift */,
+				7DAD769F0C8E109D82B2145C /* KindleService.swift */,
+				4314582A6305C5D5FCA11064 /* KindleView.swift */,
+				7C4CECA69E15E2649986C44B /* LibraryModel.swift */,
+				2317C315FCD34E61F9A23834 /* LibraryView.swift */,
+				56FCDA66A3E18824091BD044 /* ListeningStatsView.swift */,
+				380038B5F0E47EA932BA53B7 /* LoginView.swift */,
+				3D63631012B1F3BE16BB67A6 /* MainTabView.swift */,
+				E657C6292CA7FADB3A535124 /* MiniPlayerView.swift */,
+				FC99EC025507285FC39297C6 /* OfflineContentManager.swift */,
+				26E1EF4C3C86AA5CC47D140B /* OnboardingView.swift */,
+				0DC8B70105F5522A90461F0E /* OpenAIService.swift */,
+				B340A308A6C8ACA4F802C7AF /* PlaybackSpeedControlView.swift */,
+				4036FBF4A65F95760BEF0BAC /* PlayerView.swift */,
+				3E70D13FCAED04AB4CFE9200 /* ProfileTierCardView.swift */,
+				D1CC45EF605CC689696EF908 /* PromptTemplateLoader.swift */,
+				47B451741F5165402D4B3164 /* ReferralManager.swift */,
+				1A98A86A33EEE93E97D40EFA /* ReferralView.swift */,
+				995F23AB0F2C71CC32D8E4F4 /* RegisterView.swift */,
+				5DAADFE407D11A43D434EA07 /* SearchView.swift */,
+				85CCCC1848614EDB17266186 /* SecureStore.swift */,
+				688151BBB5C041468DF281E6 /* SettingsView.swift */,
+				ECB3DAECE635BA7241D837DB /* SpeechHighlighter.swift */,
+				88B9C631B3BA0CB455EC62B9 /* StealthVaultManager.swift */,
+				0842B2F85A3BDB1181837A9F /* TierUpgradeView.swift */,
+				0F57ECEFF8EA7D9822BE4917 /* UserPreferences.swift */,
+				75FD22EB6AFBE06E054DBD48 /* ViralEngine.swift */,
+				EA37D30F139C74EA5AF0EA96 /* VoiceAssigner.swift */,
+				F48694577E932D0822A51A74 /* VoiceCastView.swift */,
+				30013A478AAFE731210DACBA /* VoiceConfig.swift */,
+				44D2F74F474F4F1A1BE82A0B /* VoiceHistory.swift */,
+				2A045866BEC81060ACA13C13 /* WaveformView.swift */,
+				DC9B497F82D0E4692AC6CA21 /* WelcomeSplashView.swift */,
+				16114D30715AA6A6067E5456 /* Info.plist */,
+				654E8C9E07A92A5C533F7B53 /* Assets.xcassets */,
+				052363B577A2D281EEB502DE /* LaunchScreen.storyboard */,
+				6324FA4CA2BF4C4F43B85DCE /* prompts.json */,
+				978103783A50D41B8F4E1EAB /* ACXComplianceChecker.swift */,
+				5AD65F111609989C32F44B75 /* AICoPilot.swift */,
+				44374A80D782947B93F54D9F /* AIEmotionEngine.swift */,
+				6C645B303664D65B664D563C /* AIEngine.swift */,
+				1C2B9D383958760603556680 /* AIPlotBooster.swift */,
+				3398DEEF2660B0EEE799FB44 /* AIStateTracker.swift */,
+				36BA9C967CD920704EE6D678 /* AIStudioMode.swift */,
+				60A271A03D265C19B76FB936 /* AISummaryChatService.swift */,
+				1D540C4399415A1968C6E0F1 /* AITropeDetector.swift */,
+				E1364651BE0702DECCDE9FCF /* AIUsageTracker.swift */,
+				2F67A8A49EB883E3F825A94E /* AIVocalProductionEngine.swift */,
+				4AB60DE21E8B186D341DEFE4 /* ARVRPlayback.swift */,
+				F35FDAE9A00932D275FBFF66 /* AccentGenerator.swift */,
+				79B20008621FCE7BD8867906 /* AccessibilityOutput.swift */,
+				2CC241B2B39CF92E78D577A7 /* AdaptiveDocScanner.swift */,
+				3A0A1EE74ACA6D03C7F1D8D7 /* AdaptiveLearningEngine.swift */,
+				8C8A3E0B5D31FA53115229E4 /* AdaptiveMusicGenerator.swift */,
+				12BF357CB6629B420C87588B /* AdaptiveSceneCompletion.swift */,
+				5E5813B72C9761CC3EB97377 /* AdvancedAudioExport.swift */,
+				27CAD0F7DBCD988BCA9568E9 /* AdvancedSkipImport.swift */,
+				1286FD3C857E8347C19E6398 /* AdvancedTimelineEditor.swift */,
+				32008BE2556A8BD0999A1BAE /* AgeIDVerifier.swift */,
+				2C5CC78C00904368CFFFE730 /* AllAppsDashboard.swift */,
+				CF250F3D0B79FD1924F4EA65 /* AmbientFXEngine.swift */,
+				D5B61769BC6D4AA59CA2C882 /* AmbientMixer.swift */,
+				7FA1C1D008190A8615A58C63 /* AmbientPreviewer.swift */,
+				6FF1D8FD73D72239BC1A6128 /* AnalyticsLogger.swift */,
+				4F30C35756E870A3AEBCD593 /* AnimationDashboard.swift */,
+				D7391BCDD59D422CFF18995E /* AppCatalog.swift */,
+				51CB1E0C1033F62930DD2E76 /* AppFavoriteVoiceService.swift */,
+				E4D14474DF47A474AD3493AF /* AppIdeaGenerator.swift */,
+				ED03E27A1ADEC87CC288C040 /* AppSettings.swift */,
+				4CC90D7BCF411FB19821C913 /* AppStoreIntegration.swift */,
+				07CAFCC016F61DC70CCF5ED2 /* AppStoreMetadataConfig.swift */,
+				376C1336CCEF26F8F084EC47 /* AppTheme.swift */,
+				8DFA23D5D6EE5EFD659F02C1 /* ArchitectureDetector.swift */,
+				9CF6AFDD60A82A9618BB8E2A /* AudioCreditManager.swift */,
+				D12F8366968C34F1A8C6BEEE /* AudioEffectsPipeline.swift */,
+				9596E92BE97DBDFCB8B7A7AF /* AudioExportService.swift */,
+				66123578CD2B94F343B2B852 /* AudioExporter.swift */,
+				DE8E833A5FE75B152742FA1A /* AudioPlaybackController.swift */,
+				0E84D291AF2D77836623295C /* AudioPlaybackEngine.swift */,
+				0B138EB1316963D7145F9AC9 /* AudioSearchIndex.swift */,
+				A994823254578B0F05038459 /* AudiobookCompiler.swift */,
+				3257ADE7857F17CCD511FAC4 /* AudiobookMetadata.swift */,
+				034B06DFE7843C53100AD30A /* AuditTrail.swift */,
+				5C553F7F7F652A0FD7ED0CE4 /* AuthorAudiobookCreator.swift */,
+				54130A8B07467D418AED9D75 /* AutoBundler.swift */,
+				27CF2B9F06DCFD9CA4CC9887 /* AutoCastingEngine.swift */,
+				A19E5225D2FC6FC3E81088D3 /* AutoFormatDialogue.swift */,
+				70B96E45436AE08041AA47AE /* AutoRemixMode.swift */,
+				1A3AD91F5B84E94FECDACBCE /* AutoTranslateService.swift */,
+				86F3B9D54CC0DC563D658DED /* AutoUpdater.swift */,
+				2D329FC94B0F4ED60183C8ED /* AutoVoiceSelector.swift */,
+				8759B8F8BE04671CBEEB389A /* BackendScaffolder.swift */,
+				E8207E1404A6427ED22E0169 /* BasicAuthService.swift */,
+				97A835A2C983CD58DA45BE4C /* BatchImportTool.swift */,
+				5491195D61E0DFF72DC0800B /* BestsellerStructureEngine.swift */,
+				489D79AC20A4553BA4651C11 /* BlurbGenerator.swift */,
+				F4F45AE4843DA80AD5DC4498 /* BookImporter.swift */,
+				7A891D2F6408D696F7D5721B /* BookProcessing.swift */,
+				297C49A41BA986E311210CAA /* BookScanAnalyzer.swift */,
+				36053CB329CCAB59C66E48F6 /* BrailleOutputService.swift */,
+				130CDCFA23BE887A6E2D6F38 /* BranchService.swift */,
+				93A1F3585617CDB4A4BDCBD7 /* BranchingPathsUI.swift */,
+				5EF229F46211DF3969186838 /* BuildBridge.swift */,
+				DC5FEF75764864C9A9C94002 /* BuildDeploymentEngine.swift */,
+				6A88ABA46731522F346EAE41 /* BuildImprovementEngine.swift */,
+				AAE726ABED1D4B4CDD2649B3 /* BuildMonetizationManager.swift */,
+				2FE3B9EE048970DA9B63C049 /* BuildPreviewEngine.swift */,
+				A9D4230D1EBE552B9A70A57E /* BuildQueueController.swift */,
+				3F1B87644899B29FB7BB1241 /* CMSampleBuffer+PixelBuffer.swift */,
+				16A5964D3482688509443A89 /* CRUDGenerator.swift */,
+				AAFDC4B86EDF4398F04948AB /* CameraMotionRenderer.swift */,
+				CF6E144B78E2CDC068DC6D92 /* CameraStabilizer.swift */,
+				9C1F3AA2B5EC90FC645A27AE /* CanonMemoryGraph.swift */,
+				768B6A8BC799FC6A26756CF8 /* ChapterAnalyticsService.swift */,
+				EB5087B6EC9F3C9DDA5C8A1E /* ChapterDetector.swift */,
+				91EFB03DAACD1E8F124C7775 /* ChapterManager.swift */,
+				C89B42D245BAC109F81B42B0 /* ChapterSegmenter.swift */,
+				34988111133A0E5B140F0A83 /* CharacterDetectionEngine.swift */,
+				DC7BF94AD2327257BE8004A0 /* CharacterDossierEngine.swift */,
+				DE4551CD0E04D733B5006958 /* CharacterMemoryEngine.swift */,
+				95504057F18EBC0A10BF3B69 /* CharacterPaletteManager.swift */,
+				2C2B727FC99F665C3BF1146A /* CharacterProfileManager.swift */,
+				50B21B362A27F0A4B9B667D8 /* CharacterQuirkEngine.swift */,
+				4DD6F7706C4C8C053BEA6995 /* CharacterRecognizer.swift */,
+				0230221C41C6E4462406AE10 /* CharacterTics.swift */,
+				6644AA983C29271472FA74C4 /* CharacterTrackManager.swift */,
+				89905EBB29DF34B4BA5A0BEE /* CharacterVisualizer.swift */,
+				E9F90FB13A14B307B0BF1C5D /* CharacterVoiceAging.swift */,
+				AF468B5A961CACF766F59B98 /* CharacterVoiceMapper.swift */,
+				AF8288792AF0910E5822F0D0 /* CinematicComposer.swift */,
+				5F40E5E7DDDCA6651A380385 /* CodeGenerator.swift */,
+				AC421B6EAE6C126C01EC55A7 /* ColorGradingEngine.swift */,
+				1C27C9C4BFBF2B9CF24D31FB /* CommentSystem.swift */,
+				5EC4B36E0DA856F5CE849888 /* CommunityFilter.swift */,
+				97FFF9E5B564E625D62C0DAC /* CommunityMarketplace.swift */,
+				59AC16A130A2C7DD56B0A650 /* CommunityReviews.swift */,
+				30B2510F573A42B73A3830DF /* ComplianceChecker.swift */,
+				75EDCC6FFC3820CB105B5CDC /* ConsentTracker.swift */,
+				10D23F8A37F8D2031AFA05D6 /* ContentPolicyManager.swift */,
+				AAA8B7AD3B31F3AABC3EC332 /* ContextualMemory.swift */,
+				BC6134BBD3F575B13E386656 /* CoreForgeAudioIntegrator.swift */,
+				E2D9DB76571383C7D6E4E3C3 /* CoreForgeAudio_MissingFeatures.swift */,
+				0DEB05F6522078A88F5E6894 /* CoreForgeAudio_PlaybackBookmarking.swift */,
+				DDA17F478B520B6365CDA6FC /* CoreForgeAudio_PlaybackUIController.swift */,
+				CADF87F5506C3142180CA951 /* CoreForgeBloom_MissingFeatures.swift */,
+				A7E5C97E4D9835EE8984DAA5 /* CoreForgeBuild_MissingFeatures.swift */,
+				38CE09520864938898DC7DAF /* CoreForgeDNA_MissingFeatures.swift */,
+				0CCEBF0416C516EC30261D5C /* CoreForgeLeads_MissingFeatures.swift */,
+				2E37FDE5CC5CC1F4FB0A6C31 /* CoreForgeLearn_MissingFeatures.swift */,
+				786D70D574E10326DB7E36D4 /* CoreForgeMarket_MissingFeatures.swift */,
+				FFDF6D29E2478B5A5AA627DC /* CoreForgeMind_MissingFeatures.swift */,
+				31D871B6A478E6A6D9791CE6 /* CoreForgeMusic_MissingFeatures.swift */,
+				34F7A40351A041F032F80D6C /* CoreForgeQuest_MissingFeatures.swift */,
+				3A3B9CF5C510002056610EE6 /* CoreForgeStudio_MissingFeatures.swift */,
+				CF409B58DBB0D3A0340C5A49 /* CoreForgeVisual_MissingFeatures.swift */,
+				33611DA9EB0C693328495EE5 /* CoreForgeVoiceLab_MissingFeatures.swift */,
+				3BE123E615D8B72BA238DE4D /* CoreForgeWriter_MissingFeatures.swift */,
+				9166209A9787659630316FEB /* CreatorDashboard.swift */,
+				F64DF4CAEE3F09CD51408ACA /* CreatorPanel.swift */,
+				BCCDE787B9A7CEEAE11BEA49 /* CrossAppModuleManager.swift */,
+				E1FF61CD74066715BAE0549A /* CrossBookNarration.swift */,
+				3EA503E4EE3E1AFE4021F9B2 /* CrossPlatformVideoGenerator.swift */,
+				6A0DB4E15F3772BECF41011A /* CrowdSimulator.swift */,
+				5F3EE3A96932C7E03F27CBDA /* CustomCodeInjector.swift */,
+				FC72C79B42D5A99BDF4CBE04 /* CustomVoiceUploads.swift */,
+				8DC64126506BAD241FE7F90E /* CyclePredictor.swift */,
+				BF1E5306332FF1A52998ED49 /* DAWSessionExporter.swift */,
+				92D5D4828887DF8191AD38E1 /* DOBCheck.swift */,
+				5D33BD12089472D2B36DF821 /* DashboardTabView.swift */,
+				C674D00E92E2736DB9A50594 /* DataEncryptionManager.swift */,
+				3F3889E991CE4DDB6AF5285E /* DebuggingAssistant.swift */,
+				78CA022C038682DA150D3BD8 /* DecoyScreenManager.swift */,
+				1952DB1BFFDA5141078D0907 /* DocVideoScanner.swift */,
+				D4E8749C333D4137941D706A /* DocumentParser.swift */,
+				F172C449F889BD693E5974B6 /* DownloadableAudiobookCreator.swift */,
+				6A9384F21460309992B8F505 /* DramatizedAudiobookProducer.swift */,
+				4DB2833FAD412F2E644C779F /* DynamicChapterTransitions.swift */,
+				EA54D0E4E5B683C958E116E1 /* EPUBParser.swift */,
+				3F9720FBF067DDFCBFF29D98 /* Ebook2AudiobookBridge.swift */,
+				4348E2B287D544E6CD9BA0EF /* EbookConverter.swift */,
+				E10B0BB76994668D85ED64C7 /* EbookImporter.swift */,
+				C938BA7B0EC7182FB94BFFCD /* ElevenLabsClient.swift */,
+				24DB57BD4D83F13CBFA1AECC /* ElevenLabsRenderer.swift */,
+				0767251A8C50311E9BA3ED87 /* EmotionAnalyzer.swift */,
+				5030CED050FC1AE52E08605B /* EmotionArcVisualizer.swift */,
+				B6127557E6047EE304ED0E93 /* EmotionDatabase.swift */,
+				0129C2D3610E506BC0C45C37 /* EmotionGraph.swift */,
+				24E44276A7FB44E624DF27F1 /* EmotionHeatmap.swift */,
+				A9DDDA205B31498D838389E3 /* EmotionPacingEditor.swift */,
+				F6C0668F32F4C366E27BB183 /* EmotionShiftTracker.swift */,
+				CD091E40137E8B2A0FA8681F /* EmotionalArcTracker.swift */,
+				7B23E77D8BF76D7F024565AD /* EnhancedReasoner.swift */,
+				11F28ADB2CDF1CD1272AB215 /* EnhancedTTSPlayer.swift */,
+				7417EBD61C3C8D8BBE5DA1CC /* ExperimentalFX.swift */,
+				E607C529F6A2EA448D203F8B /* Export360VR.swift */,
+				BF513DCF4365BB974657167B /* ExportManager.swift */,
+				6E66F6D5DB93E03B517B68C7 /* ExportProduction.swift */,
+				6C1E8FB0E527703A9FDD133C /* ExportQueueManager.swift */,
+				2FD4F2204C83213AA617411B /* ExportRenderer.swift */,
+				7B50B6DF825CA069E55C4952 /* ExportService.swift */,
+				A7FBAC4A17C1A13026CB9EA4 /* ExportSystem.swift */,
+				99065F72F26B52517C3A0777 /* ExportTools.swift */,
+				77148A0159522A538C086BB9 /* FXLibrary.swift */,
+				345D00B6EE6AC6DDD43EFA80 /* FaceTrackerService.swift */,
+				09485334CFE34870AD00F54A /* FavoriteVoiceService.swift */,
+				AC8068A4FD738BF29D093A78 /* FigmaUIBuilder.swift */,
+				67661206A60D2E343C101723 /* FileManager+ZipFallback.swift */,
+				C3C54AA61E51CC4A065C2299 /* FilingsDatabase.swift */,
+				425D20F2474733935AE6ACB4 /* FirebaseAudioService.swift */,
+				9F26E6D6500600637F6932C0 /* FormExporter.swift */,
+				ACB95763F871B4D7E8537B05 /* FormFlowchartRenderer.swift */,
+				807B06D0F42EA0CA17A0BD8B /* FormGenerator.swift */,
+				614ABCDA49920304A3A31259 /* FormTemplate.swift */,
+				ADA98FFC8DBECF99D2A820D6 /* FormTemplateLibrary.swift */,
+				C7D8E5368A05EC69AF0C05BC /* FormWizard.swift */,
+				4C312AE303C709A1F2D3EC11 /* FrameInterpolationService.swift */,
+				9708BFD495DAE889462BDEE8 /* FrameRenderer.swift */,
+				285C084E621E8FD2D074719A /* FreeSampleService.swift */,
+				60A31E3E669D4C74E61F66D5 /* FusionEngine.swift */,
+				C45DC1419B293D4E6E0D8CE8 /* FusionEnginePlugin.swift */,
+				A65C59762E110F486CAD9852 /* FusionVoiceController.swift */,
+				F2435B1F1D64856623DEBE5F /* GPTChapterNarrator.swift */,
+				069772C9701D65CFCFC49881 /* GPUVideoRenderer.swift */,
+				84AFB03B784E27ED1284F70D /* GenesisModeEngine.swift */,
+				D8273D9EC0EBFB0EDE40DADE /* GitSync.swift */,
+				D450A334B632E31F1879BE8B /* GlobalVoiceLibrary.swift */,
+				9EBBF1D3F15B87F4273EDA7C /* HapticDeviceManager.swift */,
+				DF7053C5A7232290849E7805 /* HeartRateAdaptiveAudio.swift */,
+				84CB1E14EBB82C7398FE5E8D /* HeatmapAnalytics.swift */,
+				6688954B40BD5ED4841C1BC8 /* HeroSpotlightBackground.swift */,
+				859CD6702F25EA4905A3C593 /* HighQualityVoiceLibrary.swift */,
+				C639EE04EC11DA53066F7290 /* HistoricalTimePeriodChecker.swift */,
+				A9B86B6E001F481BA0096925 /* HybridQuantumTradingEngine.swift */,
+				1AADF363B299EE0AFC66C587 /* InlineEmotionEngine.swift */,
+				8F51B1D6FCFADB8FC678665B /* InputBindingEngine.swift */,
+				33A353757CBE8F201B728CDB /* LanguageDetector.swift */,
+				AA943D45F9857D72075DF719 /* LanguageTranslationManager.swift */,
+				69597CF80BB66D8310398AA3 /* LibrarySync.swift */,
+				23AABC289B3ED47C99649B69 /* LightingConditioner.swift */,
+				0147E3BD1A1E58D1A7531B54 /* LightingRecommender.swift */,
+				43F2E4E6040C597181994FA5 /* LipSyncAdjuster.swift */,
+				CE05A6173FDA18CAA4E7EF42 /* LiveEnsembleRoom.swift */,
+				0EE1E6FB07F9191AE7502404 /* LivePresence.swift */,
+				03C93628622D7887535CA998 /* LivePreviewPane.swift */,
+				2109DC44B62D792D8F622714 /* LoadTester.swift */,
+				D28377ECC266C3B3506D8F9B /* LocalAIEnginePro.swift */,
+				60ACEB11DF349A64EAB7A2D0 /* LocalElevenLabsClient.swift */,
+				8DE5E0272C630E5A0B347740 /* LocalVoiceAI.swift */,
+				E6D7429B72B40934AB4BCF90 /* LoggingPlugin.swift */,
+				81FD07FC5955F5DADAAF5C61 /* LogicBlockLibrary.swift */,
+				BD1CF1AEB6ADFED00BCD9A6A /* LongFormPacingEngine.swift */,
+				85B2EB96107B9E9700B5D701 /* MacroPlugin.swift */,
+				8A8F3D19A68CF7269767A81B /* MacroWorkflowEngine.swift */,
+				FD8F898A340675C5D40442C0 /* MarkdownLayoutParser.swift */,
+				05EA2D7C756F41DFCDE1912A /* MemoryAnchorService.swift */,
+				B463B6F874F77344EFF125BF /* MemoryEngine.swift */,
+				6CD0963396C2CFAA9BE2D322 /* MemoryPinning.swift */,
+				934A9009CAD9F5107ABE30A7 /* MemoryTracker.swift */,
+				4FE6A56AED6C3DD44576B2C1 /* MindNSFWModule.swift */,
+				DFA4259B15FDD86BA37A4C23 /* MockDataGenerator.swift */,
+				1BEC531D5FEB6D6D5D2A44B9 /* MultiCastAudiobookGenerator.swift */,
+				BB14F3EDAF3ACED412A4CDC5 /* MultiLanguageAccentNarrator.swift */,
+				916B0C1BA011C68934D8C5BC /* MultiPOVSceneBuilder.swift */,
+				D6801066E61EEA234011CFC2 /* MultiTrackEditor.swift */,
+				56BBA11B70AAC041D49BE4B9 /* MultiTrackProductionSuite.swift */,
+				98A76BF19D0DB57116A1329C /* MultilingualEngine.swift */,
+				EF0FFDDC6057EAC7BCE744F1 /* MultilingualVoiceBlend.swift */,
+				4131EC5C1E781CFFC95EA1BA /* MultiverseDirectorToggle.swift */,
+				F2029007383BCC8D4C67827C /* MultiverseVoiceSystem.swift */,
+				9DEA77D495BDAAFD0953DAE5 /* MultivoiceCharacterMode.swift */,
+				262AC36574561A21F69BD318 /* NSFWAddonManager.swift */,
+				0AD13C41B7E06ED61D50B5AF /* NSFWBlurToggle.swift */,
+				C1538637A706040CBDFDFD56 /* NSFWContentManager.swift */,
+				26BE64A336F24F8FBD2AADA5 /* NSFWDatabase.swift */,
+				E98B5FB5192283B7BC0D0807 /* NSFWEnhancer.swift */,
+				A2EE858F6FE475D4AEFC4882 /* NSFWGate.swift */,
+				7889B0A0A744F2AD833993C6 /* NSFWHabitBehaviorSimulator.swift */,
+				5FB2AA789238C33D853E5F68 /* NSFWMode.swift */,
+				E24D75BDD390E8729F346721 /* NSFWMoodHeatmap.swift */,
+				E6088A773D9B94000391EF32 /* NSFWPaywallManager.swift */,
+				C4CA0847F302C163840CC44F /* NSFWPhase7.swift */,
+				35F90EE8AD6E67847D0C0F5D /* NSFWSFXPackManager.swift */,
+				985643EA7FC1985EA392E4A4 /* NSFWSceneToggle.swift */,
+				C4D8FE1513763F0742FF5D6E /* NSFWService.swift */,
+				C001074AA0EE06F2B8CF218F /* NSFWSoundFXEngine.swift */,
+				DB6EED8EA5142FD4BD3FB001 /* NSFWToneStyler.swift */,
+				B243FDEE24E5561C8A25F2C1 /* NSFWToneSyncer.swift */,
+				6DD988A209271D3C4F76FECF /* NSFWVoiceClipManager.swift */,
+				482665214A77B982A95F091C /* NSFWVoiceEngine.swift */,
+				A8A65E5668CD586ACD6AAE05 /* NarrationScheduler.swift */,
+				A2154293C3749017C0F1B6DC /* NetworkInfoProvider.swift */,
+				396D8689DCA55C3C01848D60 /* NetworkMonitor.swift */,
+				B3F65FECCFA13BFC01E80647 /* NeuralOptimizer.swift */,
+				61763F7B8F99F653484828E4 /* NextGenAudioGenerator.swift */,
+				94DF5DA58B96CC3863E71AF1 /* NextGenSpeechService.swift */,
+				288A770742EB547A89EE98D2 /* NotificationSender.swift */,
+				6418A4324EDFAD12529EC847 /* OCRScanMode.swift */,
+				C5F740E917C5B7ADF295B97D /* OfflineAudioManager.swift */,
+				483CDAF40A1599742BB1FBF3 /* OfflineDownloadQueue.swift */,
+				72BCDD8A11968BF3AABEC97D /* OfflineMP3Downloader.swift */,
+				E06C254410685EE0607DA6C0 /* OfflineQueue.swift */,
+				83F16CBBBF86D1D0410B6C31 /* OfflineTTSCache.swift */,
+				00C6F0F0E5C5C7D5E722A1A6 /* OfflineVideoManager.swift */,
+				C74F4162594A871B28B1492E /* OnboardingManager.swift */,
+				C7BC4DD6FF9C73FB21B1B80F /* OpenAIService.swift */,
+				256622C7A271D677080C143F /* OutlineGenerator.swift */,
+				5EB1AEC86E271F31DD5814AA /* ParentReportManager.swift */,
+				39B06F23CDEF3916D1894050 /* ParticleFXLayer.swift */,
+				0A98DB4F56393A3CF1517889 /* PerformanceModeSelector.swift */,
+				D8FBC8238D2C9905E87E9B88 /* PersonalizedGreetingService.swift */,
+				FD2DD85884FF03F0F3AF761D /* PlaybackAnalytics.swift */,
+				D4C94A66E278A2346AD11AE0 /* PlaybackProgressSync.swift */,
+				8EDABB0B7AD9DE841A39C505 /* PluginBuilder.swift */,
+				0D5C320DA7D9BC6667E9412A /* PluginDependencyGraph.swift */,
+				62BA2B64DB508D632FB96114 /* PluginLoader.swift */,
+				8F76E0FA9C08DD631B53BE43 /* PluginManifest.swift */,
+				17CC521A5F2DB549FD7B2BA1 /* PluginMarketplace.swift */,
+				9661BEED7C1139AC613B7D97 /* PluginSandbox.swift */,
+				C4A0ECF9FA27D4114DC739A9 /* PreviewKeyManager.swift */,
+				F7670B7086B80E1D737718F2 /* PreviewSandbox.swift */,
+				6013D9CE6EB2C0A3BDA1F736 /* ProfanityFilter.swift */,
+				FFA3ACCA478C63DEFE8B4B40 /* ProjectSharing.swift */,
+				B4437C9025B4D1F769D01A1F /* PromoCodeManager.swift */,
+				2C9ED59C899B81704ECBC1F3 /* PromptParser.swift */,
+				3E7EAD009805221D97DBC64C /* PromptParserEngine.swift */,
+				6504DE864796A7669332A703 /* PronunciationDictionary.swift */,
+				073C2FC8529E554738DC84D9 /* PronunciationEditor.swift */,
+				6F50B98DA6F22B05E65330BB /* PropLocalizer.swift */,
+				C0FFB56C8A666279514CEC5E /* QuantumAIExtension.swift */,
+				F776641FF1110052256EAF1A /* QuantumChoicePlottingService.swift */,
+				B7BBE46CD66C4AD31D7E22E5 /* QuantumConnector.swift */,
+				AC3E7F70433B298637FD77E2 /* QuantumEditMode.swift */,
+				1696827AA9EF79399799A3A8 /* QuantumRealitySwitcher.swift */,
+				25799E7FEBCF63A63121D04D /* QuantumSceneLogic.swift */,
+				14CAF1A1236C35BB882B4F51 /* RealTimeEmotionAdapter.swift */,
+				5F9A5C812FD0F7B788FB1ED0 /* RealTimeFeedManager.swift */,
+				043AF94B0A72B7B3688CA329 /* RealTimeImproviserService.swift */,
+				9420E998989C4918D6FDAAC0 /* RealisticVoiceoverEngine.swift */,
+				8B82DA9533B19FC1B8CC2DD0 /* RefactorLogger.swift */,
+				EF2555BAFC6776433B59A2C9 /* ReferralDashboard.swift */,
+				30E6CD8758A042228F38DEF9 /* ReferralProgram.swift */,
+				AC60BD086CB15D146DE01858 /* RenderAnalyticsDashboard.swift */,
+				6872CF63F9190D32027AEBC2 /* ReplayAnalytics.swift */,
+				566F3FF0E231FF8D481B4C93 /* ReplayAnalyticsService.swift */,
+				3A1E5F3ABF27DABCA2D53235 /* SFXPackManager.swift */,
+				11E653A5ED88CD1D3E765779 /* SceneAtmosphereBuilder.swift */,
+				F6D187FF25247BB7221E8BBD /* SceneBackgroundGenerator.swift */,
+				20A207EF9D84060DEAC036DC /* SceneDetector.swift */,
+				5CA73F11AB22EA5DF4E7D6BB /* SceneDramatization.swift */,
+				6E6435C3BDA69052484BCE25 /* SceneFXPresets.swift */,
+				B27BBBCAE0E53F8A6EF7D9D0 /* SceneGapFiller.swift */,
+				5D5D661ED9186060C17D6514 /* SceneGenerator.swift */,
+				3A98C8C2B8DD8570DAF75073 /* SceneHeatmapManager.swift */,
+				010B81D3017528F5422D5FE3 /* SceneIndexGenerator.swift */,
+				6172A395D01A37E6D6D40585 /* SceneMapper.swift */,
+				DACF71ED80C50A65CD6359C8 /* SceneMemorySimulator.swift */,
+				1778237C60D0ABE230FF5188 /* SceneParserEngine.swift */,
+				75AA1BFFD8E9EAFF3524CEDE /* SceneSegmenter.swift */,
+				33733AB47BDA4D17CCA4E655 /* SceneSoundtrackCoordinator.swift */,
+				B72B70ADA05D88D8D5C88A97 /* SceneTimeline.swift */,
+				2AD6D18CECC7C0C3DACB0EC1 /* SecurityScanner.swift */,
+				F0359EC4A0BEA93DF81DA560 /* SegmentEngine.swift */,
+				0071E528D5E984CE36540F9A /* SegmentService.swift */,
+				C858269D4CD8177CE659A33B /* SelfRepairEngine.swift */,
+				640CE93D2F0ED1998B5F88B6 /* SemanticSegmenter.swift */,
+				4D2B745A6A27DD9D08D8ED67 /* SeriesManager.swift */,
+				85AFFC99353558BC6B6E822C /* SettingsPanel.swift */,
+				30720037E358F98EB2294275 /* SettingsSync.swift */,
+				ABA6C2DB886BEE4830CDF9ED /* SignUpView.swift */,
+				7492919D89044D89E65AE54B /* SleepMode.swift */,
+				B543380551D15B6DA9113424 /* SleepReadMode.swift */,
+				922DE1B2B943E583A401BECB /* SmartAmbientMixer.swift */,
+				E5983230A954F4CD8198A198 /* SocialMediaManager.swift */,
+				E1062C217A585825286B48C0 /* SoundEffectManager.swift */,
+				CC931C47DFA210D36DCF0CD9 /* SoundEffectsDatabase.swift */,
+				BDB8397BB4A0AD48935317E7 /* SoundLayerEngine.swift */,
+				79918570E9397486BF9530C7 /* SpatialAudioSupport.swift */,
+				72C8ADD111F07E656D43FC3A /* StealthModeVaultManager.swift */,
+				780B93E12C98CAF9B0375EF8 /* StealthVault.swift */,
+				D9E17A8916BCCDA7390D04B8 /* StoreKitManager.swift */,
+				66B6039E241918FFEF4DA79B /* StoryboardEditor.swift */,
+				3DAF719FD6FF9E39702A6851 /* StoryboardImporter.swift */,
+				2272D27E0CDDE1937940C617 /* StoryboardPanel.swift */,
+				7543F618A69ABA1DBEE15483 /* StreamAssembler.swift */,
+				56E03E3E9EF72CAD33EAC37D /* StyleEngine.swift */,
+				F7FD29574D3DD33EE0C9B0B9 /* StyleModelTrainer.swift */,
+				C2589E3499E6573FD89CC55E /* SubscriptionCreditSystem.swift */,
+				04A9491F58FFB6AAB4F7BEDC /* SubscriptionManager.swift */,
+				9AE626FBE2C669B1B1FFDF34 /* SubtitleGenerator.swift */,
+				81B4A85A42A59233CA305BBB /* SupportedLanguages.swift */,
+				F9C346D4550D0D80C9E0D5F7 /* SyncServiceProtocol.swift */,
+				585F251F558DB5C37996FC73 /* AudioImperfectionFilter.swift */,
+				482D62F635C01DD83AB31C3A /* BreathingLayer.swift */,
+				C8F9D03E36D8EEFBB7671391 /* ConversationalLayer.swift */,
+				D714071AC559756B977C227A /* ProsodyCurveManager.swift */,
+				286E7B787291461F91B5C56B /* TTSEngine.swift */,
+				D2E9C21A164F5F7FEF1B818A /* TTSHumanizer.swift */,
+				261DCAE0CB5F0B2B2C02821B /* TTSService.swift */,
+				2F89D3969A047DBDBEE344A6 /* TemplateMonetization.swift */,
+				4A7104A997CAD2F933C45288 /* ThemeManager.swift */,
+				327E6E8DE0D3C53AC4B5CDF8 /* ThumbnailGenerator.swift */,
+				DAE07A0E7831074AED4EEDF4 /* TimelineBranchAdvisor.swift */,
+				B41A360C6545BE9236ACC202 /* TimelineEditor.swift */,
+				7C9F8DEAA4CACE814341BFC3 /* TimelineForkManager.swift */,
+				8DD57243BD3ADFDE72DE91F9 /* TradingLeaderboard.swift */,
+				74918B207D8BE19335C774D9 /* TraitMemoryPersistence.swift */,
+				95F69196BC094B0872D9D436 /* UnifiedAudioEngine.swift */,
+				9BB886D3C6FEDFDCB3799211 /* UnifiedVideoEngine.swift */,
+				950E8746CF5599F796355A08 /* UniversalMediaGenerator.swift */,
+				296C40B9AB0CD38DF85AAF27 /* UniversalVideoGenerator.swift */,
+				5701CCD3DDFFCAE74BE3CC66 /* UnlockableVoiceSkins.swift */,
+				79FBFF611BD616EAF222B139 /* UserAnnotations.swift */,
+				F6B3C0E0AA374C1118BBF90A /* VaultService.swift */,
+				58704451C7F68A25DC9B8ED5 /* VersionHistory.swift */,
+				EBFD9F9946C6E74555B8766E /* VersionedExports.swift */,
+				F4C550F14F6BA637B5867D75 /* VideoEffectsPipeline.swift */,
+				F5D77CCBE9BDB7AF46178F2A /* VideoExportService.swift */,
+				3287EEC078D149E0F2AE4DB4 /* VideoMetadata.swift */,
+				5B210E7725846EA64F8D879B /* VideoShareManager.swift */,
+				EDE0181ED31E2C2A6A275E92 /* ViewerNavigationTracker.swift */,
+				F1CE9A4C9987508E4D127839 /* ViralityEngine.swift */,
+				E8C29E7F401479C8111BC44B /* VisualContextAdapter.swift */,
+				902F471013932BDB24F0ED3F /* VisualDescriptionExtractor.swift */,
+				90E48CC58DD2F58B715F7EAA /* VisualFXEngine.swift */,
+				F21C024DF50250A5812F54AD /* VisualFeatureEnhancer.swift */,
+				8FBC998471C16F2ED738AFED /* VisualMemoryEngine.swift */,
+				332110419B30B423E6CF2FC8 /* VisualMultiverseManager.swift */,
+				60FF9959E658158E02E0887D /* VoiceAdvisorAI.swift */,
+				E7C1D135E6C13268742F1D9D /* VoiceBookmarkService.swift */,
+				C3C524EC8687E9582AC24DD6 /* VoiceCloneShare.swift */,
+				5E48CF07457481A35A2A4289 /* VoiceCloneTrainer.swift */,
+				B7B00FD0A7BE982ACC5614B8 /* VoiceControlService.swift */,
+				17975F68102AF33C92A27CFD /* VoiceDNAForge.swift */,
+				B6951F5A72FBBB88D722D447 /* VoiceDNAForker.swift */,
+				A1BE4C66AF5CDEB17956F87F /* VoiceDNAVisualizer.swift */,
+				3667826427527849ABFD22FA /* VoiceFXStackEditor.swift */,
+				E18C38C02AF14F176063F3A1 /* VoiceForkManager.swift */,
+				2FD76308D7454FC90EC2E514 /* VoiceManager.swift */,
+				08F5AE641106BC67B043A103 /* VoiceMappingEngine.swift */,
+				D16BA5F2601F11D9748924BE /* VoiceMemoryManager.swift */,
+				C659EE7A11D2DD477C57D824 /* VoiceMultiverseLinker.swift */,
+				176731BA9B46CFA88E2569F4 /* VoiceMultiverseManager.swift */,
+				1D32DB67900FDFB66F91F531 /* VoicePolls.swift */,
+				AAB5C2F2CDF9124C6B05D8D7 /* VoiceRatingSystem.swift */,
+				64D8465318B2DB2FA3F0A365 /* VoiceReactivity.swift */,
+				D23A6A876E04D07BC34EE357 /* VoiceReviewSystem.swift */,
+				FF53738AFABE76D096CEA2D0 /* VoiceRevisionManager.swift */,
+				3AFC20E05BF1A9C8779EC4C9 /* VoiceSyncController.swift */,
+				E210C8E620AC0CAD48EFA95B /* VoiceTimbreModulator.swift */,
+				E65D800B682C218999B0BEF1 /* VoiceToneMatcher.swift */,
+				A07EF8BE89459197D50EB1C6 /* VoiceTrainer.swift */,
+				D85114D6FD55C1EBD6CCD888 /* WatchSyncService.swift */,
+				E750817C5D453940CFE0FBC8 /* WatermarkService.swift */,
+				64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */,
+				F95C843A8084D05B4FB215CE /* Book.swift */,
+				AA328AEA3C24F926CA0F0671 /* UsageStats.swift */,
+			);
+			sourceTree = "<group>";
+		};
+		77B954AA566C1C7B99DC787B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				2274C8CE9C3215CC6A2440E5 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		B1865267B0B18A894A6B6DF3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8426CF7BA23103C0341B1672 /* CoreForgeAudioApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D71D1207BE8F641129675E1E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				77B954AA566C1C7B99DC787B /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6AFD65D93E47D2535C2FF0A7 /* CoreForgeAudioApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AF6BECAF43DCC877C62E12C7 /* Build configuration list for PBXNativeTarget "CoreForgeAudioApp" */;
+			buildPhases = (
+				D6B5C26D797BAC58485B8291 /* Sources */,
+				C489D003A21DBBAAD52349C8 /* Frameworks */,
+				63E4AF0BB5FA50695E8D0774 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreForgeAudioApp;
+			productName = CoreForgeAudioApp;
+			productReference = 8426CF7BA23103C0341B1672 /* CoreForgeAudioApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4639F30234D6E86D72F43B3C /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+			};
+			buildConfigurationList = 206F7FDB6839C1E667FA7C27 /* Build configuration list for PBXProject "CoreForgeAudio" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 2108731472899347EFEDBE46;
+			minimizedProjectReferenceProxies = 0;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = B1865267B0B18A894A6B6DF3 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6AFD65D93E47D2535C2FF0A7 /* CoreForgeAudioApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		63E4AF0BB5FA50695E8D0774 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2B64FA87540D332C5BF2D739 /* Assets.xcassets in Resources */,
+				2B6E49DD6827B56D0E97511A /* LaunchScreen.storyboard in Resources */,
+				D6EC862B4611B63416116E1C /* prompts.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D6B5C26D797BAC58485B8291 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6ED911B39CAD1E3F7F016738 /* AdaptiveReasoner.swift in Sources */,
+				199997C1AAEBC8CF9C165C4F /* AgeVerificationView.swift in Sources */,
+				802945F98A9C46C9845B1B7E /* AppleBooksService.swift in Sources */,
+				E4836318D18B413AAEF31419 /* AppleBooksView.swift in Sources */,
+				CC7A53E1926F96648C7006E9 /* AudiobookPlayerView.swift in Sources */,
+				3A25DBA687CF96843EAF0858 /* AuthManager.swift in Sources */,
+				1CB19CA70DA23611AA6952A5 /* BannerCarouselView.swift in Sources */,
+				4C92322F14BCD6FC88A4D23E /* BookCardView.swift in Sources */,
+				56B7307A0336A3BA84A80C2C /* BookDetailView.swift in Sources */,
+				D790F4AB36B45D593DE50442 /* ChapterImporter.swift in Sources */,
+				7C39A0D296D4C270C2AF9C96 /* CharacterVoiceMemory.swift in Sources */,
+				0681005BCAE4DA682F64F125 /* ConnectView.swift in Sources */,
+				981124989CFE72AEB34176F4 /* ContentView.swift in Sources */,
+				F268A0F8E6724D580129CBD1 /* CoreForgeAudioApp.swift in Sources */,
+				47B3D019B8F084BFC0DEE478 /* CreditStore.swift in Sources */,
+				8877D4D1EC7E0FAF297D780A /* CreditsHistoryView.swift in Sources */,
+				CB1B9773262EB025BA79FCAA /* DashboardView.swift in Sources */,
+				66AFAAC47917CB7FB8AFB7D0 /* DownloadQueue.swift in Sources */,
+				9F8A724FF65794205C55674A /* DownloadsView.swift in Sources */,
+				1B46A74636D5700A1A29CA8D /* EbookImporter.swift in Sources */,
+				ECBED3FAFE1AE89434F8BA61 /* ElevenLabsService.swift in Sources */,
+				1B6F5A34E2EF61583FAA6327 /* FavoritesView.swift in Sources */,
+				D730D86BDA40D58C99061D39 /* FeaturedCarouselView.swift in Sources */,
+				09ED3FD10CE7470576D932D8 /* FirebaseService.swift in Sources */,
+				19AAFB3E1413212DEE4CBF2D /* ForgotPasswordView.swift in Sources */,
+				33A29DA511971DD062671DB7 /* GlowingButtonStyle.swift in Sources */,
+				6F8A86939DE66727AE89EED3 /* ImportView.swift in Sources */,
+				EE969D0B9C33D6C81CB35F1B /* KindleService.swift in Sources */,
+				C04E34361BB27206545F25B5 /* KindleView.swift in Sources */,
+				B0343FBA184ED1B051B02804 /* LibraryModel.swift in Sources */,
+				EFBBC6CBEDD159C7CEBA4642 /* LibraryView.swift in Sources */,
+				505A2E13EFA2628627643505 /* ListeningStatsView.swift in Sources */,
+				DB71CD6B57F27A6A53E650D0 /* LoginView.swift in Sources */,
+				6281028658E057592620E926 /* MainTabView.swift in Sources */,
+				5067F2E73E685F8D5D3A7880 /* MiniPlayerView.swift in Sources */,
+				30DF042D2448A39AD6F1A217 /* OfflineContentManager.swift in Sources */,
+				D491A910D5B5C3504E9C2DC7 /* OnboardingView.swift in Sources */,
+				664FE52CDAB810602FB12894 /* OpenAIService.swift in Sources */,
+				B3047FC0C27E733341D22A74 /* PlaybackSpeedControlView.swift in Sources */,
+				8F0AAB59C82548C24D1FC3E7 /* PlayerView.swift in Sources */,
+				B09C015067D6E1C0328F044C /* ProfileTierCardView.swift in Sources */,
+				79C009AAFED359040F638A85 /* PromptTemplateLoader.swift in Sources */,
+				57E62879ADEBFA563D51725F /* ReferralManager.swift in Sources */,
+				9524E618BE89DF31974C3302 /* ReferralView.swift in Sources */,
+				E6495B5F4650DFC195C33E4B /* RegisterView.swift in Sources */,
+				589F6F4958AD13C359F7CA87 /* SearchView.swift in Sources */,
+				C7432049ECE24A3528F72AE0 /* SecureStore.swift in Sources */,
+				6E38EA6F8C21289EF2081C0E /* SettingsView.swift in Sources */,
+				0910E9063A0D04A9135098E4 /* SpeechHighlighter.swift in Sources */,
+				B807A4C81324A85A8F22C6A0 /* StealthVaultManager.swift in Sources */,
+				B62D367644591F4B0901CAAC /* TierUpgradeView.swift in Sources */,
+				8F9CB5F76DB24BE931632599 /* UserPreferences.swift in Sources */,
+				4FE5471FFC1A840A58A83213 /* ViralEngine.swift in Sources */,
+				5950103550D4A133B31D07AB /* VoiceAssigner.swift in Sources */,
+				F76BBC4CF867998006647842 /* VoiceCastView.swift in Sources */,
+				B9507F3FBE007AE9200DC61E /* VoiceConfig.swift in Sources */,
+				5F4EB59BA7122524E62A82EF /* VoiceHistory.swift in Sources */,
+				24AC96F11743D6759F47CB56 /* WaveformView.swift in Sources */,
+				184CF49535D8A749D1929064 /* WelcomeSplashView.swift in Sources */,
+				1D7ADADF07E3F32BDC0BD643 /* ACXComplianceChecker.swift in Sources */,
+				5825090C727C413B9B5B2F1D /* AICoPilot.swift in Sources */,
+				2A8C1CBA696FEC79628AC9A7 /* AIEmotionEngine.swift in Sources */,
+				467FB90EEB4B3935CA8EA703 /* AIEngine.swift in Sources */,
+				5B8DF9B333E9E13D694FCCB1 /* AIPlotBooster.swift in Sources */,
+				8BE530D2A1513998D223AF61 /* AIStateTracker.swift in Sources */,
+				A56BD8F460AC360AAEA787D7 /* AIStudioMode.swift in Sources */,
+				21EA60D07072D086FFC4976F /* AISummaryChatService.swift in Sources */,
+				937ADE6B7C2E9314A6108384 /* AITropeDetector.swift in Sources */,
+				CD56AEB77A5EA26521FD47AD /* AIUsageTracker.swift in Sources */,
+				72E8C58E01DFBD260DD1ABB2 /* AIVocalProductionEngine.swift in Sources */,
+				F0B746856AE6B918AC71AF42 /* ARVRPlayback.swift in Sources */,
+				E0F9742B9C3CDF98FA2393E5 /* AccentGenerator.swift in Sources */,
+				BE7139FF90B4AEAECD6D594F /* AccessibilityOutput.swift in Sources */,
+				D2CE452B62C800C4147F2D5D /* AdaptiveDocScanner.swift in Sources */,
+				297A8735EB92C4056E3B9628 /* AdaptiveLearningEngine.swift in Sources */,
+				55661DFECC530BDAA560682F /* AdaptiveMusicGenerator.swift in Sources */,
+				A714B23BAD9DDE32B2273971 /* AdaptiveSceneCompletion.swift in Sources */,
+				B3DDCF9B3A36D21E50F3497D /* AdvancedAudioExport.swift in Sources */,
+				F62CAA8A71C6B527A4209886 /* AdvancedSkipImport.swift in Sources */,
+				37B7137CE7E47E1D58586699 /* AdvancedTimelineEditor.swift in Sources */,
+				C57D0B9A561122B5862C9AD6 /* AgeIDVerifier.swift in Sources */,
+				DF6BDA78E8314623A118ADA4 /* AllAppsDashboard.swift in Sources */,
+				256297D22B2B992FA635421C /* AmbientFXEngine.swift in Sources */,
+				36EACDB98602DD38D08FC85E /* AmbientMixer.swift in Sources */,
+				C16FE41603E632D54CED997D /* AmbientPreviewer.swift in Sources */,
+				BDED3C936287DEC435FDCC87 /* AnalyticsLogger.swift in Sources */,
+				CAB4CC8D9581D9EF90D3312A /* AnimationDashboard.swift in Sources */,
+				E7D1C9A5C07DAB1325960C68 /* AppCatalog.swift in Sources */,
+				9185712159DDB84E4BEF6E36 /* AppFavoriteVoiceService.swift in Sources */,
+				98D517BE7CE95F4752853549 /* AppIdeaGenerator.swift in Sources */,
+				72C886172D6CD04BAD8A2A22 /* AppSettings.swift in Sources */,
+				BFFE5B086B61E601CD7B11FB /* AppStoreIntegration.swift in Sources */,
+				2104EAA6C308DCAF60EC1965 /* AppStoreMetadataConfig.swift in Sources */,
+				98CC0EE09551BC1DAB9026D8 /* AppTheme.swift in Sources */,
+				5A581256B8E4042AA8784200 /* ArchitectureDetector.swift in Sources */,
+				DD8400EA2F82AACC9AA8AEC2 /* AudioCreditManager.swift in Sources */,
+				61A0F830669F332BEFEAD7E3 /* AudioEffectsPipeline.swift in Sources */,
+				E139B4CAD4EED01B626FD9AB /* AudioExportService.swift in Sources */,
+				B5C25DBB6D3C635198F42935 /* AudioExporter.swift in Sources */,
+				958C5C8CFEF31D906938537A /* AudioPlaybackController.swift in Sources */,
+				005D51E2174DF61B9111F94C /* AudioPlaybackEngine.swift in Sources */,
+				83647172614D0C9D959EC174 /* AudioSearchIndex.swift in Sources */,
+				63633D6B236B4031B9DFA58A /* AudiobookCompiler.swift in Sources */,
+				526D64352C8833FD2CA2FC0C /* AudiobookMetadata.swift in Sources */,
+				9F6797794D608306F7B0F867 /* AuditTrail.swift in Sources */,
+				425AF288880971A5573ED12C /* AuthorAudiobookCreator.swift in Sources */,
+				E5C3B60BCBDAA8821CBE4B14 /* AutoBundler.swift in Sources */,
+				37D7FE0EE5A9D000155BC0CB /* AutoCastingEngine.swift in Sources */,
+				41506937E6E61F3E0B8AFE04 /* AutoFormatDialogue.swift in Sources */,
+				527E6BBA80DD1BB811055665 /* AutoRemixMode.swift in Sources */,
+				8E491E82D040B3B095DCAF75 /* AutoTranslateService.swift in Sources */,
+				2DE104251E58E3AD653FAB09 /* AutoUpdater.swift in Sources */,
+				B769A15462431389107B7A2C /* AutoVoiceSelector.swift in Sources */,
+				F3539DC7E3E27120CDCBF67D /* BackendScaffolder.swift in Sources */,
+				075904DECA83CB3517407B25 /* BasicAuthService.swift in Sources */,
+				E5719F3D3454E88D4F6E0DDD /* BatchImportTool.swift in Sources */,
+				39539AB63A32CB68B94D3D1F /* BestsellerStructureEngine.swift in Sources */,
+				7CF884A299F819B6266DB667 /* BlurbGenerator.swift in Sources */,
+				064E591D5E1FFA9E751173D3 /* BookImporter.swift in Sources */,
+				E3CEED1FC08306E439071913 /* BookProcessing.swift in Sources */,
+				859EC4A0D32208CD39B54508 /* BookScanAnalyzer.swift in Sources */,
+				EFC95161AD9B757B2E131E76 /* BrailleOutputService.swift in Sources */,
+				4DC617994735458B2572B076 /* BranchService.swift in Sources */,
+				E3D0306CC4411399D73A7ECF /* BranchingPathsUI.swift in Sources */,
+				DE55987A2AB9FE12B178451D /* BuildBridge.swift in Sources */,
+				3704094814ECD581CD39F03E /* BuildDeploymentEngine.swift in Sources */,
+				6D4264F9B46F3EDA0A77FB02 /* BuildImprovementEngine.swift in Sources */,
+				47877AABAD9ED76E356E708D /* BuildMonetizationManager.swift in Sources */,
+				F95D50886B2EE1172AC19D63 /* BuildPreviewEngine.swift in Sources */,
+				22CEB8648E03FF39A090F507 /* BuildQueueController.swift in Sources */,
+				A9DE2D74DF6C29417AC34C6D /* CMSampleBuffer+PixelBuffer.swift in Sources */,
+				11705C7E44854F3481CE51DC /* CRUDGenerator.swift in Sources */,
+				72B8428ED9A3DF135561716E /* CameraMotionRenderer.swift in Sources */,
+				7BBF8426298903808F7313EF /* CameraStabilizer.swift in Sources */,
+				D752FC3E1B169CC78D430DB4 /* CanonMemoryGraph.swift in Sources */,
+				912335D60E11012BC8D67D95 /* ChapterAnalyticsService.swift in Sources */,
+				968B43B92838CB996CC51C95 /* ChapterDetector.swift in Sources */,
+				35648307004140061CB3B696 /* ChapterManager.swift in Sources */,
+				B652B0850A7CE700CC25F367 /* ChapterSegmenter.swift in Sources */,
+				BCC6441E215D0BA62ECA4EED /* CharacterDetectionEngine.swift in Sources */,
+				9482CD251DE3846DA109873D /* CharacterDossierEngine.swift in Sources */,
+				6321B9451935858BDC9F7188 /* CharacterMemoryEngine.swift in Sources */,
+				E456817B0C101D0AEAE9BFD7 /* CharacterPaletteManager.swift in Sources */,
+				80F9B1BE8344D4BA8D8410BE /* CharacterProfileManager.swift in Sources */,
+				A9092B74C32ACB66AFF89E99 /* CharacterQuirkEngine.swift in Sources */,
+				DF19834B6688177DF7F43ED6 /* CharacterRecognizer.swift in Sources */,
+				467B1F3E41B71BA62F52A4A7 /* CharacterTics.swift in Sources */,
+				4F01B11A5759DC54407DB41C /* CharacterTrackManager.swift in Sources */,
+				BECA139FF3B2831F0FE2CA7A /* CharacterVisualizer.swift in Sources */,
+				501A660BB106D4E7E3375B3A /* CharacterVoiceAging.swift in Sources */,
+				13A5600DA2CE0181509BFE9B /* CharacterVoiceMapper.swift in Sources */,
+				28847D57726AA25DA7F3A905 /* CinematicComposer.swift in Sources */,
+				31123D1CDBF7F53EE9279E9C /* CodeGenerator.swift in Sources */,
+				9F043B122A2AAB70334D35B2 /* ColorGradingEngine.swift in Sources */,
+				328480061620C45CD04FBD54 /* CommentSystem.swift in Sources */,
+				E595D3FE6140DCDCBE30672D /* CommunityFilter.swift in Sources */,
+				AD69189A53D19AC94F7CC8F0 /* CommunityMarketplace.swift in Sources */,
+				CD4F93D52871CABB4FE02BCB /* CommunityReviews.swift in Sources */,
+				973E0B3802AC35FF33866392 /* ComplianceChecker.swift in Sources */,
+				952A39E3F5AF0481E6FF76A8 /* ConsentTracker.swift in Sources */,
+				1AA52E8403AA989F8816CCD0 /* ContentPolicyManager.swift in Sources */,
+				8D4A18350B9F0B7972640A02 /* ContextualMemory.swift in Sources */,
+				6F57878F8DE01FE00BD6E486 /* CoreForgeAudioIntegrator.swift in Sources */,
+				AB2670818A42A464F1697AD2 /* CoreForgeAudio_MissingFeatures.swift in Sources */,
+				876F6A1165736561AAE3AAB4 /* CoreForgeAudio_PlaybackBookmarking.swift in Sources */,
+				F0DBFC416617E2955482C65C /* CoreForgeAudio_PlaybackUIController.swift in Sources */,
+				1F299562C899AC71A2E94D48 /* CoreForgeBloom_MissingFeatures.swift in Sources */,
+				28FAA76CD5E49E796E7E8A42 /* CoreForgeBuild_MissingFeatures.swift in Sources */,
+				62205852EF0BE56791FCA686 /* CoreForgeDNA_MissingFeatures.swift in Sources */,
+				F4D613D190546E8A415690D5 /* CoreForgeLeads_MissingFeatures.swift in Sources */,
+				9494A9BDE1F091910671005F /* CoreForgeLearn_MissingFeatures.swift in Sources */,
+				E83B25FB6427395DEDFE21A4 /* CoreForgeMarket_MissingFeatures.swift in Sources */,
+				12438788C1AE4F304E94E70A /* CoreForgeMind_MissingFeatures.swift in Sources */,
+				6D8C4381E82852BE696E2AC6 /* CoreForgeMusic_MissingFeatures.swift in Sources */,
+				64CD31A24A123D9F4FE5E10A /* CoreForgeQuest_MissingFeatures.swift in Sources */,
+				ACD5C7E0CF1B783DBC9109C8 /* CoreForgeStudio_MissingFeatures.swift in Sources */,
+				2236FDF5BFB1DFA38D9A32C0 /* CoreForgeVisual_MissingFeatures.swift in Sources */,
+				DEFE4FCBC077C593B3CB18A6 /* CoreForgeVoiceLab_MissingFeatures.swift in Sources */,
+				835B16D4ACB3A93337B8D76E /* CoreForgeWriter_MissingFeatures.swift in Sources */,
+				F8104D2538E6E116499A67F3 /* CreatorDashboard.swift in Sources */,
+				BBF3E6AD490FF4BE50CB48D5 /* CreatorPanel.swift in Sources */,
+				23BC5473526F8DFCD7540583 /* CrossAppModuleManager.swift in Sources */,
+				040DA31DE9F1E41322FE83C0 /* CrossBookNarration.swift in Sources */,
+				247353514209079B6CC29D99 /* CrossPlatformVideoGenerator.swift in Sources */,
+				07F16D3F23BE534A90B15CBD /* CrowdSimulator.swift in Sources */,
+				4D5F9D99C88AFFFCB2A8133F /* CustomCodeInjector.swift in Sources */,
+				46B3689308D17C553362DEBE /* CustomVoiceUploads.swift in Sources */,
+				9B62DBD6875C163F325DE3DC /* CyclePredictor.swift in Sources */,
+				311E6CE35A71CC30E1ED6AFF /* DAWSessionExporter.swift in Sources */,
+				9684C9CE2E12CDC90912A05F /* DOBCheck.swift in Sources */,
+				02C9035407F6A7F5755F57EE /* DashboardTabView.swift in Sources */,
+				AC2117E452E8A3B4A0403B6C /* DataEncryptionManager.swift in Sources */,
+				E6E323287CDBD958ABC2FA62 /* DebuggingAssistant.swift in Sources */,
+				908F3438CFF52D23466D1543 /* DecoyScreenManager.swift in Sources */,
+				DBB238E697ABF83E12AB56DD /* DocVideoScanner.swift in Sources */,
+				C2FBC3804F1FE4A82F62D46E /* DocumentParser.swift in Sources */,
+				1D7FF9DA18CF7794727126B1 /* DownloadableAudiobookCreator.swift in Sources */,
+				5084D332A9F8038018BA09D2 /* DramatizedAudiobookProducer.swift in Sources */,
+				570FCBB4B86E3976F27C7547 /* DynamicChapterTransitions.swift in Sources */,
+				1AA681C7991002EBE22B7193 /* EPUBParser.swift in Sources */,
+				49F1AEB974658D286996A3AF /* Ebook2AudiobookBridge.swift in Sources */,
+				DD7CC520C28E734733DBB3E7 /* EbookConverter.swift in Sources */,
+				AF454060362259283D8CB4F0 /* EbookImporter.swift in Sources */,
+				B9FC51F97FCCD8209461C5F1 /* ElevenLabsClient.swift in Sources */,
+				3EC198EEFBDBAA0F72FD376C /* ElevenLabsRenderer.swift in Sources */,
+				A6F7D70158061E5AFA32BAF1 /* EmotionAnalyzer.swift in Sources */,
+				89CBB257C5075B7B8EBDCCEE /* EmotionArcVisualizer.swift in Sources */,
+				475FD751E0D7D3EB23ABA741 /* EmotionDatabase.swift in Sources */,
+				1BA4E1E789BEBE48C112337F /* EmotionGraph.swift in Sources */,
+				983226AC3269E1E980B2DB81 /* EmotionHeatmap.swift in Sources */,
+				3D1064FDEB4C49B1452E657F /* EmotionPacingEditor.swift in Sources */,
+				064D9271B19D714876328E0E /* EmotionShiftTracker.swift in Sources */,
+				88A39C1EFB23B2D768E0D357 /* EmotionalArcTracker.swift in Sources */,
+				36D4F73CDA8D458008694348 /* EnhancedReasoner.swift in Sources */,
+				2132CBAAC68F5F9C282803EC /* EnhancedTTSPlayer.swift in Sources */,
+				C9914A2C3374576717EDD8A8 /* ExperimentalFX.swift in Sources */,
+				BBC3FB8E8BFBD0B52E6EAB1A /* Export360VR.swift in Sources */,
+				412E83DD9E45343C51AB6632 /* ExportManager.swift in Sources */,
+				4D967C143119185E67558A98 /* ExportProduction.swift in Sources */,
+				51CB0978FCBF107D2AF1F553 /* ExportQueueManager.swift in Sources */,
+				D4175B76A01D6EBACA821FA2 /* ExportRenderer.swift in Sources */,
+				5733D7B42A7FECF797DD2DB1 /* ExportService.swift in Sources */,
+				5EC73A546F9E7AEDE057E5D2 /* ExportSystem.swift in Sources */,
+				A48C1D7D9CB1E77E7A332339 /* ExportTools.swift in Sources */,
+				2B97D0BA2FA4FBE35F909FB3 /* FXLibrary.swift in Sources */,
+				82937959DECDA99CA1BEF652 /* FaceTrackerService.swift in Sources */,
+				7020372E06C222EF0B2A683B /* FavoriteVoiceService.swift in Sources */,
+				2DF3955841BBCC8B5F7BFEB4 /* FigmaUIBuilder.swift in Sources */,
+				15DDDDC765A892FA011749B5 /* FileManager+ZipFallback.swift in Sources */,
+				629F859DC58475BA754240E8 /* FilingsDatabase.swift in Sources */,
+				20D2D3743C9345950BAAF5F2 /* FirebaseAudioService.swift in Sources */,
+				431E034C866D60911B3A2A34 /* FormExporter.swift in Sources */,
+				13716A3BFEFDBE7E0E23FC12 /* FormFlowchartRenderer.swift in Sources */,
+				BA6C88A1AB1AE2E42E715788 /* FormGenerator.swift in Sources */,
+				4903CB4DC37626EEB44B716A /* FormTemplate.swift in Sources */,
+				B87A4D0013223C5E297E4681 /* FormTemplateLibrary.swift in Sources */,
+				DA2DC6E7CF07B847E0AC290A /* FormWizard.swift in Sources */,
+				5D0C57F26BCF09CC67C0DC3A /* FrameInterpolationService.swift in Sources */,
+				F1B55EAD8D388FB163774B7D /* FrameRenderer.swift in Sources */,
+				E0C12DD5DB8F68005F6DBF05 /* FreeSampleService.swift in Sources */,
+				94F919D5DAF55BBE6DFA832A /* FusionEngine.swift in Sources */,
+				413E93D574A68F15E6FF4DE9 /* FusionEnginePlugin.swift in Sources */,
+				76C9AAFF840BB9C22008BBDC /* FusionVoiceController.swift in Sources */,
+				EED7686326D2B10218E0580A /* GPTChapterNarrator.swift in Sources */,
+				C182A18E4F08A5A30C1C0437 /* GPUVideoRenderer.swift in Sources */,
+				2E60FC5CB7D7E98DDF1CC41A /* GenesisModeEngine.swift in Sources */,
+				11466E5A50F6767754CB2046 /* GitSync.swift in Sources */,
+				81457D98058B62932F451E64 /* GlobalVoiceLibrary.swift in Sources */,
+				B27822B29A0EB613FE31792F /* HapticDeviceManager.swift in Sources */,
+				5A7B14656B8EA695993D6543 /* HeartRateAdaptiveAudio.swift in Sources */,
+				55E69484754BC863B597221E /* HeatmapAnalytics.swift in Sources */,
+				9D52228C054DAC9838A09607 /* HeroSpotlightBackground.swift in Sources */,
+				D275A78CE305245ECFFF0696 /* HighQualityVoiceLibrary.swift in Sources */,
+				B5F5043AA2633F5A52397B61 /* HistoricalTimePeriodChecker.swift in Sources */,
+				CFCE0B1B837CD137B44E057E /* HybridQuantumTradingEngine.swift in Sources */,
+				E8B6AF0B126C55790449DC63 /* InlineEmotionEngine.swift in Sources */,
+				973D086B8BC577E809F40859 /* InputBindingEngine.swift in Sources */,
+				8CEA8B49AFB228AF0A199180 /* LanguageDetector.swift in Sources */,
+				92D17CC6AEC69593895BC3AD /* LanguageTranslationManager.swift in Sources */,
+				03309982195100DB1BF92880 /* LibrarySync.swift in Sources */,
+				EEF60293F3F86AC85DBAF07C /* LightingConditioner.swift in Sources */,
+				E602DA494477F4167EAE18DC /* LightingRecommender.swift in Sources */,
+				627694E675BC6766FBE373C0 /* LipSyncAdjuster.swift in Sources */,
+				47B41BC4AC3A5DAB3FB4859D /* LiveEnsembleRoom.swift in Sources */,
+				71774170AADACAF32C042827 /* LivePresence.swift in Sources */,
+				0DB8F67BE76D8FDB6314D31D /* LivePreviewPane.swift in Sources */,
+				6B8ABF516E0E565AC75EEC5F /* LoadTester.swift in Sources */,
+				8420E109059CCFC919ACBEB4 /* LocalAIEnginePro.swift in Sources */,
+				5FDC4DE368EEC58975207A23 /* LocalElevenLabsClient.swift in Sources */,
+				9DE37BBC406D7B0AD464149D /* LocalVoiceAI.swift in Sources */,
+				F35DBA9F53FCF6A0C08BD843 /* LoggingPlugin.swift in Sources */,
+				EE417B360490139E749F328F /* LogicBlockLibrary.swift in Sources */,
+				06743902790ADE532127C679 /* LongFormPacingEngine.swift in Sources */,
+				BF893169DF89D32A9B3CD8B0 /* MacroPlugin.swift in Sources */,
+				353C8A7C270259E27F064876 /* MacroWorkflowEngine.swift in Sources */,
+				61BBC4738BDD848FB72FF582 /* MarkdownLayoutParser.swift in Sources */,
+				ADFA07260D0C380397B56485 /* MemoryAnchorService.swift in Sources */,
+				D4676B2BDCBD183D6CA0D1CA /* MemoryEngine.swift in Sources */,
+				60AB8241C5D61DDD55737E1F /* MemoryPinning.swift in Sources */,
+				74FAAD28CAA5A62ABE093D00 /* MemoryTracker.swift in Sources */,
+				65B14E574B3A93ADD7D8479B /* MindNSFWModule.swift in Sources */,
+				E6B8793889BE3039462DD039 /* MockDataGenerator.swift in Sources */,
+				EC67C1AD06C91C6571FBB513 /* MultiCastAudiobookGenerator.swift in Sources */,
+				9B0FDBCF51BFA6F3F26063E3 /* MultiLanguageAccentNarrator.swift in Sources */,
+				C3064E2F5CF9853E93B6D3C3 /* MultiPOVSceneBuilder.swift in Sources */,
+				670183C1D79443BE4A433E9C /* MultiTrackEditor.swift in Sources */,
+				52402D28626D79E8F19E36B3 /* MultiTrackProductionSuite.swift in Sources */,
+				0A14DDBD09CF1A3A8D7AB8B8 /* MultilingualEngine.swift in Sources */,
+				9230F3CA6C198795B20CD218 /* MultilingualVoiceBlend.swift in Sources */,
+				8CBD5DF1312CD02F6B9D54D1 /* MultiverseDirectorToggle.swift in Sources */,
+				4412B8E008024A140DD1C86B /* MultiverseVoiceSystem.swift in Sources */,
+				5BDA0B79CF8C2258F7759EAF /* MultivoiceCharacterMode.swift in Sources */,
+				2A7934F8700FDD9D92C394AB /* NSFWAddonManager.swift in Sources */,
+				D60A6534658E63FB93917648 /* NSFWBlurToggle.swift in Sources */,
+				E7A45BCFB561C6E4322DB0B0 /* NSFWContentManager.swift in Sources */,
+				6E895491308A62B2C87FF59D /* NSFWDatabase.swift in Sources */,
+				68A1AADC824B5662663800A4 /* NSFWEnhancer.swift in Sources */,
+				5A02D8C72BA2EAC75B595C1B /* NSFWGate.swift in Sources */,
+				90F4E4B7FEC73D54BA0661FE /* NSFWHabitBehaviorSimulator.swift in Sources */,
+				D31B0997ABA180E341AE1A7A /* NSFWMode.swift in Sources */,
+				0E33D410CE709C9EA47A2545 /* NSFWMoodHeatmap.swift in Sources */,
+				3CA58600564078D0F40B118B /* NSFWPaywallManager.swift in Sources */,
+				849BC0B5B81E62C69BF28A9B /* NSFWPhase7.swift in Sources */,
+				B4CDAA28B36AAF9BEF3FF384 /* NSFWSFXPackManager.swift in Sources */,
+				C0383323F36AE29E4D4918DE /* NSFWSceneToggle.swift in Sources */,
+				766A5A72FCFA74C2FB7EF3CF /* NSFWService.swift in Sources */,
+				1198214AE85020218C038D22 /* NSFWSoundFXEngine.swift in Sources */,
+				3D18A55946D3EF6F9C6CCB65 /* NSFWToneStyler.swift in Sources */,
+				186C94DFDD52E0C5FD962BF6 /* NSFWToneSyncer.swift in Sources */,
+				DA6C9EA29B3917E43E7C119D /* NSFWVoiceClipManager.swift in Sources */,
+				AA4B0A0D82B1B22E6314A3CD /* NSFWVoiceEngine.swift in Sources */,
+				59E37EFC45EB8E0E3A406759 /* NarrationScheduler.swift in Sources */,
+				22005E24E81A796F1A84BBE5 /* NetworkInfoProvider.swift in Sources */,
+				8570986602FDFBA0C942351E /* NetworkMonitor.swift in Sources */,
+				712ECC59E406E856E85C7C8D /* NeuralOptimizer.swift in Sources */,
+				EE6E15E088D46623C1FC0741 /* NextGenAudioGenerator.swift in Sources */,
+				C3B1CC39D51F10F3BAF19A46 /* NextGenSpeechService.swift in Sources */,
+				8C5740F8D3FE81BA1B446813 /* NotificationSender.swift in Sources */,
+				CABB53BB8469D46F56CEFAB5 /* OCRScanMode.swift in Sources */,
+				FADF3C57FCA359251EEFC063 /* OfflineAudioManager.swift in Sources */,
+				C7EDC2C97A1460CE5E076F1A /* OfflineDownloadQueue.swift in Sources */,
+				9FE1CBAC7DF388DF1A962306 /* OfflineMP3Downloader.swift in Sources */,
+				86F6D63C2BE6DACDE8BA4134 /* OfflineQueue.swift in Sources */,
+				1A6D376754E002C610019DFB /* OfflineTTSCache.swift in Sources */,
+				F1140C6E76117B61FAD86009 /* OfflineVideoManager.swift in Sources */,
+				6D1FBFA5F6E9530F478F086C /* OnboardingManager.swift in Sources */,
+				5B4E2D6D962B2D273F1C3D87 /* OpenAIService.swift in Sources */,
+				A4295BF901A0245501CC24BC /* OutlineGenerator.swift in Sources */,
+				468B1244B5A18F369E24C396 /* ParentReportManager.swift in Sources */,
+				47893FBCED0C448FFBEBDC36 /* ParticleFXLayer.swift in Sources */,
+				57A1D93CF2F848499813B956 /* PerformanceModeSelector.swift in Sources */,
+				DE8AE8ED043E51202294DABC /* PersonalizedGreetingService.swift in Sources */,
+				FAF46C6D0F4B4AE4F7146535 /* PlaybackAnalytics.swift in Sources */,
+				B473CD2896181C102B03F4DF /* PlaybackProgressSync.swift in Sources */,
+				49FD675FF708E635C8228900 /* PluginBuilder.swift in Sources */,
+				34CF03C5874E9D43431DB859 /* PluginDependencyGraph.swift in Sources */,
+				A0EED82AF8570850F3793259 /* PluginLoader.swift in Sources */,
+				0BFE8C2FEF1E7CEC8B1E00D8 /* PluginManifest.swift in Sources */,
+				96641113CE3FB4B69B2919EC /* PluginMarketplace.swift in Sources */,
+				F230890036E90406FACE4D55 /* PluginSandbox.swift in Sources */,
+				41211F13B520C3E3875949F6 /* PreviewKeyManager.swift in Sources */,
+				61675D494DC9BB6E61595E6E /* PreviewSandbox.swift in Sources */,
+				C6AC572D3944E4601B063120 /* ProfanityFilter.swift in Sources */,
+				5BE4BA0BA03C8C7C0563E669 /* ProjectSharing.swift in Sources */,
+				97FED7FD575081ABAAFDC1CB /* PromoCodeManager.swift in Sources */,
+				BCAAB53F8CCF87C37FD49122 /* PromptParser.swift in Sources */,
+				4AC1174B673852DA60AECC00 /* PromptParserEngine.swift in Sources */,
+				A603E89573FDD305DF558BD7 /* PronunciationDictionary.swift in Sources */,
+				1B5B659501CBD28FC2639D29 /* PronunciationEditor.swift in Sources */,
+				DF80B2BED18AE39B1FCE349C /* PropLocalizer.swift in Sources */,
+				E5999F5B9D2A6C8A6EA9E79D /* QuantumAIExtension.swift in Sources */,
+				80512C0CCED929B600D6D1A8 /* QuantumChoicePlottingService.swift in Sources */,
+				F34A6FFEBEB7198EE097571B /* QuantumConnector.swift in Sources */,
+				F4200B0C2CB2057997D9B6E4 /* QuantumEditMode.swift in Sources */,
+				D10B5BB12B47DB3B678F7073 /* QuantumRealitySwitcher.swift in Sources */,
+				729A166A8A9C82D19C1AE86F /* QuantumSceneLogic.swift in Sources */,
+				3CCABB95C845EB7CFCEB93F9 /* RealTimeEmotionAdapter.swift in Sources */,
+				7D32440302B7937768FA9EE4 /* RealTimeFeedManager.swift in Sources */,
+				6D8553F2209B6547FFCC476F /* RealTimeImproviserService.swift in Sources */,
+				0BD4767E7486A4ED942C85EE /* RealisticVoiceoverEngine.swift in Sources */,
+				EDAB8745C7E21E2163E7B639 /* RefactorLogger.swift in Sources */,
+				37D5F29DE309AB6524DDCD6C /* ReferralDashboard.swift in Sources */,
+				B6A1DB6FBEB7313F2D45B531 /* ReferralProgram.swift in Sources */,
+				D72FAEC06AF9F149F2995BA4 /* RenderAnalyticsDashboard.swift in Sources */,
+				8016D22A9C290000522B3A15 /* ReplayAnalytics.swift in Sources */,
+				7334E73341C2A9FE86CCB9FE /* ReplayAnalyticsService.swift in Sources */,
+				5E483AECA40D851DEBFC0562 /* SFXPackManager.swift in Sources */,
+				248986A22963864D51CFFE85 /* SceneAtmosphereBuilder.swift in Sources */,
+				E59E8880597A9FE0146562CF /* SceneBackgroundGenerator.swift in Sources */,
+				EB73CF5395FC3B87F6DE43E7 /* SceneDetector.swift in Sources */,
+				27964C1504EF283FAD01A430 /* SceneDramatization.swift in Sources */,
+				5B634C46C8418ECA0690DE29 /* SceneFXPresets.swift in Sources */,
+				75E06CDA7EA0B4BF761812D2 /* SceneGapFiller.swift in Sources */,
+				658ABA4961DFEAAD4BE83638 /* SceneGenerator.swift in Sources */,
+				027ACED757C341A0BE7F75D5 /* SceneHeatmapManager.swift in Sources */,
+				0E7393C1B40CD4EF040C8376 /* SceneIndexGenerator.swift in Sources */,
+				72093057B365DB57B639A5E0 /* SceneMapper.swift in Sources */,
+				AAD76469C8CE866E4C15B790 /* SceneMemorySimulator.swift in Sources */,
+				D8B35C8FE12475E120B706E6 /* SceneParserEngine.swift in Sources */,
+				F18159810A4A904D84EE773A /* SceneSegmenter.swift in Sources */,
+				7534F2526E44E689ADB0901C /* SceneSoundtrackCoordinator.swift in Sources */,
+				D84BD994A683067AA11D1D5B /* SceneTimeline.swift in Sources */,
+				9C86F46B28C1CF65925997C3 /* SecurityScanner.swift in Sources */,
+				4F2C4056F9014AB67006CD32 /* SegmentEngine.swift in Sources */,
+				EF615E2319C82840F9AC37A2 /* SegmentService.swift in Sources */,
+				BA8350AC1606B6F3199BC42A /* SelfRepairEngine.swift in Sources */,
+				5742C754EEF630B40AFF787E /* SemanticSegmenter.swift in Sources */,
+				63F9706A93248C189085A173 /* SeriesManager.swift in Sources */,
+				6DDAD120E6053C5DCD31AE91 /* SettingsPanel.swift in Sources */,
+				04775D25BB424C102EF3243D /* SettingsSync.swift in Sources */,
+				5C60EAAC6D956CDE011CA0DE /* SignUpView.swift in Sources */,
+				71D0EB2D3D584612C5B3ED67 /* SleepMode.swift in Sources */,
+				09171D31E39D8DEBA9CADC6E /* SleepReadMode.swift in Sources */,
+				FC19D809FB7D75D27C4E6924 /* SmartAmbientMixer.swift in Sources */,
+				7A295C046F0858D51C899A8B /* SocialMediaManager.swift in Sources */,
+				C6D8B2A279CFEF895472335B /* SoundEffectManager.swift in Sources */,
+				3CD77BE409207AB406ECBA30 /* SoundEffectsDatabase.swift in Sources */,
+				CAA99742376AD302B6EF8519 /* SoundLayerEngine.swift in Sources */,
+				A0B853870CB3A24EC9DE6C9A /* SpatialAudioSupport.swift in Sources */,
+				6117E95013AC9F672326A855 /* StealthModeVaultManager.swift in Sources */,
+				B0102067775E47B3C2DF1ABD /* StealthVault.swift in Sources */,
+				EEFDCDE6807345220ACE775D /* StoreKitManager.swift in Sources */,
+				5D2AEF6467A89508D5300FFA /* StoryboardEditor.swift in Sources */,
+				5BA3E9B42906632177D36CC4 /* StoryboardImporter.swift in Sources */,
+				6D510AFB2CBD9118144A960F /* StoryboardPanel.swift in Sources */,
+				7F1CAD7F3C2BFE89C94E3ADE /* StreamAssembler.swift in Sources */,
+				64FB04939F5A34C9C524AEA1 /* StyleEngine.swift in Sources */,
+				6F0A1DA9EF4E1A1794A36619 /* StyleModelTrainer.swift in Sources */,
+				C5B2E8ED9D632FA55DFE807C /* SubscriptionCreditSystem.swift in Sources */,
+				C928671A023EFF3FEBF2423B /* SubscriptionManager.swift in Sources */,
+				395EFB6CABE1B09024A21D5A /* SubtitleGenerator.swift in Sources */,
+				2AC05A6DAE2D0B29C6882F62 /* SupportedLanguages.swift in Sources */,
+				46D865717869C6915D6255E4 /* SyncServiceProtocol.swift in Sources */,
+				07CA134DC788B20337701705 /* AudioImperfectionFilter.swift in Sources */,
+				58CD4E2EF74E261CDD2A2898 /* BreathingLayer.swift in Sources */,
+				94385428478ED4F9A780E9AE /* ConversationalLayer.swift in Sources */,
+				0E8A3BD2150DE0429FA98CC2 /* ProsodyCurveManager.swift in Sources */,
+				A095D86D24671D4E07449FBF /* TTSEngine.swift in Sources */,
+				86A0CBACCAD7B9E9E3535FBC /* TTSHumanizer.swift in Sources */,
+				B3ACB1A9FC1B2D289C1EDF5E /* TTSService.swift in Sources */,
+				BAD27CCE89E630AA7B63C0BE /* TemplateMonetization.swift in Sources */,
+				5918A57843EA49B5C3CECF2F /* ThemeManager.swift in Sources */,
+				37837ADF86216B3DD6B09CA6 /* ThumbnailGenerator.swift in Sources */,
+				E202136668BB3DC5FE0165A1 /* TimelineBranchAdvisor.swift in Sources */,
+				AF40C9D2AA22C91A2B179B85 /* TimelineEditor.swift in Sources */,
+				562D3497768243EFFD9748F7 /* TimelineForkManager.swift in Sources */,
+				EDFA581F16184B594F6F6F9A /* TradingLeaderboard.swift in Sources */,
+				7E2E37F947A0E3401A9456AD /* TraitMemoryPersistence.swift in Sources */,
+				3786BE1A49A9EBC839DBBBAE /* UnifiedAudioEngine.swift in Sources */,
+				1F948802D406681F2D12FC89 /* UnifiedVideoEngine.swift in Sources */,
+				EF6D0BFCE086D89AE87061C1 /* UniversalMediaGenerator.swift in Sources */,
+				5512090500E8ABF3B1AEB746 /* UniversalVideoGenerator.swift in Sources */,
+				43934736DD7B5CCC9AD7D829 /* UnlockableVoiceSkins.swift in Sources */,
+				80C8DF88EEE4D0FA06E556E6 /* UserAnnotations.swift in Sources */,
+				3F3CC5E687BBA675CFDE4215 /* VaultService.swift in Sources */,
+				DD82498321C22A4F52217363 /* VersionHistory.swift in Sources */,
+				989F2C847FA2C6F273EC6517 /* VersionedExports.swift in Sources */,
+				76B0C31726D637421003253C /* VideoEffectsPipeline.swift in Sources */,
+				DFA6D26A82171EAD124B8602 /* VideoExportService.swift in Sources */,
+				EE253A21D1B4CAAE09565D09 /* VideoMetadata.swift in Sources */,
+				0AD175243EBBA5CC2FDC627E /* VideoShareManager.swift in Sources */,
+				86DF8252364C20B55AA0ECA3 /* ViewerNavigationTracker.swift in Sources */,
+				35F02281839F58A5CFA5B746 /* ViralityEngine.swift in Sources */,
+				79CC91EBCF06FD7C468F033A /* VisualContextAdapter.swift in Sources */,
+				40E899E399DDA4908A10CEF8 /* VisualDescriptionExtractor.swift in Sources */,
+				255920D82415805A3F34A04C /* VisualFXEngine.swift in Sources */,
+				44D332CDE81179577D74DDCA /* VisualFeatureEnhancer.swift in Sources */,
+				DDBD718018D730A0A7558DA5 /* VisualMemoryEngine.swift in Sources */,
+				A26B3EA5B79F9EDC8AA8205B /* VisualMultiverseManager.swift in Sources */,
+				6E31890BFB75E237A5560580 /* VoiceAdvisorAI.swift in Sources */,
+				3088EA7E61532F563B18BE1C /* VoiceBookmarkService.swift in Sources */,
+				D2EED75196C43F8EEA728D66 /* VoiceCloneShare.swift in Sources */,
+				81CDBE620969C6AC1E087322 /* VoiceCloneTrainer.swift in Sources */,
+				97E2C0FC49936C059CE2D168 /* VoiceControlService.swift in Sources */,
+				86927019F6A877E45047E100 /* VoiceDNAForge.swift in Sources */,
+				D8294D853B49425AA1CE75FA /* VoiceDNAForker.swift in Sources */,
+				A3CEE9FDC3E2DF6AF2AED6D9 /* VoiceDNAVisualizer.swift in Sources */,
+				CBC0EEFEB7117A648D454E69 /* VoiceFXStackEditor.swift in Sources */,
+				230DB31B8AE1570E75639873 /* VoiceForkManager.swift in Sources */,
+				2042632E5E8D4A8DCE21A04E /* VoiceManager.swift in Sources */,
+				FE9703584FDB6904569C2C51 /* VoiceMappingEngine.swift in Sources */,
+				ECFB84196D7A4DDE89FCD694 /* VoiceMemoryManager.swift in Sources */,
+				CEB603AA505E7A1BA67BEC35 /* VoiceMultiverseLinker.swift in Sources */,
+				EDEF8111B9BC1D53813980CA /* VoiceMultiverseManager.swift in Sources */,
+				F92E58A0AB829468A29884C2 /* VoicePolls.swift in Sources */,
+				44D3FFF891112C95A839871A /* VoiceRatingSystem.swift in Sources */,
+				A22D889340D40BDBA4561A16 /* VoiceReactivity.swift in Sources */,
+				DEFC6B0F1E85797083F17826 /* VoiceReviewSystem.swift in Sources */,
+				5C557C4318AFBE804A030AEE /* VoiceRevisionManager.swift in Sources */,
+				BC5A22C750E7819F10B2B026 /* VoiceSyncController.swift in Sources */,
+				114420EC1862BCA1B8ECCAB5 /* VoiceTimbreModulator.swift in Sources */,
+				1E23825BE372429455672A00 /* VoiceToneMatcher.swift in Sources */,
+				5FEC4877C6944563050AC811 /* VoiceTrainer.swift in Sources */,
+				775AE9ACB7AC05DEB9C4997F /* WatchSyncService.swift in Sources */,
+				D92C40823E7BC5807CE616FC /* WatermarkService.swift in Sources */,
+				C4532D635D0AFB023F14BD2E /* WorldMemoryService.swift in Sources */,
+				7B29E8752CA8957E6B134657 /* Book.swift in Sources */,
+				B0C2AC690DC6C7DEC621B12E /* UsageStats.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0BDBD9C21DB1CC13B69D281F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		476AF4BE0DACF66CCBF2CE98 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				INFOPLIST_FILE = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.creator.coreforge.audio;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6CC2E514249CFA75DD5FE7D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		CB3C05F50FB34C52F1215C9E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				INFOPLIST_FILE = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.creator.coreforge.audio;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.7;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		206F7FDB6839C1E667FA7C27 /* Build configuration list for PBXProject "CoreForgeAudio" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6CC2E514249CFA75DD5FE7D3 /* Debug */,
+				0BDBD9C21DB1CC13B69D281F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AF6BECAF43DCC877C62E12C7 /* Build configuration list for PBXNativeTarget "CoreForgeAudioApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB3C05F50FB34C52F1215C9E /* Release */,
+				476AF4BE0DACF66CCBF2CE98 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4639F30234D6E86D72F43B3C /* Project object */;
+}


### PR DESCRIPTION
## Summary
- generate `CoreForgeAudio.xcodeproj` using the ruby `xcodeproj` gem
- include all Swift source files and resources so iOS builds can be opened in Xcode

## Testing
- `bash scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860800a6f488321b2f9953e82b5f82f