### PR TITLE
Add tabbed content view for CoreForge Audio

### DIFF
--- a/apps/CoreForgeAudio/views/MainDashboardView.swift
+++ b/apps/CoreForgeAudio/views/MainDashboardView.swift
@@ -1,0 +1,14 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Wrapper view mapping MainDashboardView to existing HomeDashboardView.
+struct MainDashboardView: View {
+    var body: some View {
+        HomeDashboardView()
+    }
+}
+
+#Preview {
+    MainDashboardView()
+}
+#endif

--- a/apps/CoreForgeAudio/views/TabbedContentView.swift
+++ b/apps/CoreForgeAudio/views/TabbedContentView.swift
@@ -1,0 +1,33 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Simplified entry view showcasing core tabs.
+struct TabbedContentView: View {
+    @Namespace private var ns
+
+    var body: some View {
+        TabView {
+            MainDashboardView()
+                .tabItem {
+                    Label("Home", systemImage: "house.fill")
+                }
+            ImportView()
+                .tabItem {
+                    Label("Import", systemImage: "tray.and.arrow.down")
+                }
+            PlayerView(namespace: ns)
+                .tabItem {
+                    Label("Now Playing", systemImage: "play.circle.fill")
+                }
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape.fill")
+                }
+        }
+    }
+}
+
+#Preview {
+    TabbedContentView()
+}
+#endif


### PR DESCRIPTION
## Summary
- add `MainDashboardView` bridging to `HomeDashboardView`
- add `TabbedContentView` providing a simple tabbed interface
- keep existing features untouched

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860841be2688321ae0ab1a93b1b0393