### PR TITLE
Update HomeDashboardView with new layout

### DIFF
--- a/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel+NewImport.swift
+++ b/apps/CoreForgeAudio/VocalVerseFull/VocalVerse/LibraryModel+NewImport.swift
@@ -1,0 +1,11 @@
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+extension LibraryModel {
+    /// Placeholder action for starting a new import flow from the dashboard.
+    /// Real import logic should present an ImportView or similar UI.
+    func startNewImport() {
+        // TODO: integrate with actual import flow
+    }
+}


### PR DESCRIPTION
## Summary
- modernize `HomeDashboardView` with layout selector and themed backgrounds
- add placeholder `startNewImport()` in library model for new book action

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(failed: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_686113a2b8d08321b2e52d0febfdaf4c