### PR TITLE
Add CoreForge Audio export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,3 +434,15 @@ Use `./scripts/fetch_audiobookshelf.sh` to clone or update the [audiobookshelf](
 
 After fetching the repository, you can leverage VoiceLab's `runN8nAssistant` helper to experiment with n8n-inspired AI workflows locally.
 
+## Exporting CoreForge Audio
+
+To create a standalone repository containing only the CoreForge Audio app and
+shared Swift sources, run:
+
+```bash
+./scripts/export_coreforge_audio_repo.sh /path/to/CoreForgeAudio
+```
+
+This copies `apps/CoreForgeAudio`, the `Sources` directory and `Package.swift`
+into the specified folder and initializes a fresh git repository.
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,3 +12,6 @@ Utility shell and Python scripts used for building projects and auditing feature
   can be run without errors. `pull_plugins.py` will try both `master` and `main`
   branches when downloading.
 
+- `export_coreforge_audio_repo.sh` – copy the CoreForge Audio app and shared
+  Swift sources into a standalone directory, optionally initializing a new git
+  repository.

--- a/scripts/export_coreforge_audio_repo.sh
+++ b/scripts/export_coreforge_audio_repo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export CoreForge Audio app into a standalone repo directory.
+# Usage: ./scripts/export_coreforge_audio_repo.sh /path/to/output
+
+DEST=${1:-../CoreForgeAudio}
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ -e "$DEST" ]; then
+  echo "Destination $DEST already exists. Remove it or choose another path." >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+
+# Copy only the CoreForge Audio app and necessary shared sources.
+cp -R "$REPO_ROOT/apps/CoreForgeAudio" "$DEST/"
+cp -R "$REPO_ROOT/Sources" "$DEST/"
+cp "$REPO_ROOT/Package.swift" "$DEST/"
+
+# Initialize a new git repository if git is available.
+if command -v git >/dev/null 2>&1; then
+  git -C "$DEST" init >/dev/null
+  git -C "$DEST" add .
+  git -C "$DEST" commit -m "Initial import of CoreForge Audio" >/dev/null
+fi
+
+echo "CoreForge Audio exported to $DEST"


### PR DESCRIPTION
## Summary
- add script to export CoreForge Audio to its own repo
- document new script in scripts README
- document export instructions in main README

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test`
- `pytest tests/python`

------
https://chatgpt.com/codex/tasks/task_e_68611648177483218d46373b35f82f45