### PR TITLE
Add PhotoPageSorter OCR ordering

### DIFF
--- a/Sources/CreatorCoreForge/PhotoPageSorter.swift
+++ b/Sources/CreatorCoreForge/PhotoPageSorter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Sorts OCR'd page images into logical order based on detected page numbers.
+public final class PhotoPageSorter {
+    private let ocr: OCRScanMode
+    public init(ocr: OCRScanMode = OCRScanMode()) {
+        self.ocr = ocr
+    }
+
+    /// Return texts extracted from images, ordered by detected page numbers.
+    /// If no page number is found, the original index is used.
+    public func orderedTexts(from images: [Data]) -> [String] {
+        let pages: [(order: Int, text: String)] = images.enumerated().map { idx, data in
+            let text = ocr.extractText(from: data)
+            let num = PhotoPageSorter.detectPageNumber(in: text) ?? idx
+            return (num, text)
+        }
+        return pages.sorted { $0.order < $1.order }.map { $0.text }
+    }
+
+    /// Combine pages into a single document string in logical order.
+    public func combinedText(from images: [Data]) -> String {
+        orderedTexts(from: images).joined(separator: "\n")
+    }
+
+    private static func detectPageNumber(in text: String) -> Int? {
+        let pattern = "(?im)^\\s*(?:page\\s*)?(\\d{1,4})\\s*$"
+        for line in text.components(separatedBy: .newlines) {
+            if let match = line.range(of: pattern, options: .regularExpression) {
+                return Int(line[match].trimmingCharacters(in: CharacterSet(charactersIn: "0123456789").inverted))
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PhotoPageSorterTests.swift
+++ b/Tests/CreatorCoreForgeTests/PhotoPageSorterTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class PhotoPageSorterTests: XCTestCase {
+    func testReordersPagesByNumber() {
+        let p1 = "Page 1\nFirst".data(using: .utf8)!
+        let p2 = "Page 2\nSecond".data(using: .utf8)!
+        let p3 = "Page 3\nThird".data(using: .utf8)!
+        let sorter = PhotoPageSorter()
+        let combined = sorter.combinedText(from: [p3, p1, p2])
+        XCTAssertEqual(combined, "Page 1\nFirst\nPage 2\nSecond\nPage 3\nThird")
+    }
+
+    func testMaintainsOrderWithoutNumbers() {
+        let a = "Intro".data(using: .utf8)!
+        let b = "More".data(using: .utf8)!
+        let sorter = PhotoPageSorter()
+        let combined = sorter.combinedText(from: [b, a])
+        XCTAssertEqual(combined, "More\nIntro")
+    }
+}

--- a/docs/PhotoPageSorter.md
+++ b/docs/PhotoPageSorter.md
@@ -1,0 +1,3 @@
+# PhotoPageSorter
+
+This module uses `OCRScanMode` to recognize page numbers in scanned images and reorder them automatically. It ensures that photos of book pages are combined into the correct reading order even if the pictures were taken out of sequence.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Additional guides and phase planning documents for the CreatorCoreForge ecosyste
 - `NextGenSpeech.md` – overview of offline speech synthesis and recognition
 - `AdaptiveDocScanner.md` – overview of the AI document scanner
 - `DocVideoScanner.md` – document and video scanning utilities
+- `PhotoPageSorter.md` – reorder scanned page images using OCR
 - `progress_bot.py` – calculates app progress from `OPEN_TASKS.md` and optionally suggests code using OpenAI.
 - `progress_bot.md` – additional usage notes for the progress bot script
  - `auto_code_bot.py` – generates placeholder code files for missing features. It now includes an offline mode, a `--upgrade-placeholders` option, and writes timestamped snippets to language folders under `output/`.

--- a/features-phase8.json
+++ b/features-phase8.json
@@ -80,6 +80,7 @@
       "BookScanAnalyzer",
       "DocumentParser",
       "OCRScanMode",
+      "PhotoPageSorter",
       "MultiCastAudiobookGenerator",
       "DramatizedAudiobookProducer",
       "BookImporter",


### PR DESCRIPTION
## Summary
- implement `PhotoPageSorter` to order scanned pages using OCR
- add unit tests
- document new module and list in docs README
- register feature `PhotoPageSorter` in Phase 8 features

## Testing
- `npm test`
- `swift test` *(fails: exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68613aa490708321ac2ba0272aeacd3f