### PR TITLE
Add PhotoPageSorter OCR ordering

### DIFF
--- a/CoreForgeAudio.xcodeproj/project.pbxproj
+++ b/CoreForgeAudio.xcodeproj/project.pbxproj
@@ -387,7 +387,8 @@
 		C9914A2C3374576717EDD8A8 /* ExperimentalFX.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7417EBD61C3C8D8BBE5DA1CC /* ExperimentalFX.swift */; };
 		CAA99742376AD302B6EF8519 /* SoundLayerEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB8397BB4A0AD48935317E7 /* SoundLayerEngine.swift */; };
 		CAB4CC8D9581D9EF90D3312A /* AnimationDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F30C35756E870A3AEBCD593 /* AnimationDashboard.swift */; };
-		CABB53BB8469D46F56CEFAB5 /* OCRScanMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6418A4324EDFAD12529EC847 /* OCRScanMode.swift */; };
+               CABB53BB8469D46F56CEFAB5 /* OCRScanMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6418A4324EDFAD12529EC847 /* OCRScanMode.swift */; };
+               736A8AD5609D34AC42EC7D36 /* PhotoPageSorter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DCF3C685DFCA6C40A5DCB /* PhotoPageSorter.swift */; };
                CB1B9773262EB025BA79FCAA /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E239EC118899F28C0A22D2A2 /* DashboardView.swift */; };
                DC20416E17CC4787B9E323AF /* HomeDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CC1DF2EA8BA4A67A7E4D155 /* HomeDashboardView.swift */; };
                9D5B764C2D6D4F7492FC82A7 /* MainDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF755BE847684FB6BA0BE265 /* MainDashboardView.swift */; };
@@ -695,8 +696,9 @@
 		62BA2B64DB508D632FB96114 /* PluginLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PluginLoader.swift; path = Sources/CreatorCoreForge/PluginLoader.swift; sourceTree = "<group>"; };
 		6324FA4CA2BF4C4F43B85DCE /* prompts.json */ = {isa = PBXFileReference; includeInIndex = 1; name = prompts.json; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/prompts.json; sourceTree = "<group>"; };
 		640CE93D2F0ED1998B5F88B6 /* SemanticSegmenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SemanticSegmenter.swift; path = Sources/CreatorCoreForge/SemanticSegmenter.swift; sourceTree = "<group>"; };
-		6418A4324EDFAD12529EC847 /* OCRScanMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OCRScanMode.swift; path = Sources/CreatorCoreForge/OCRScanMode.swift; sourceTree = "<group>"; };
-		64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorldMemoryService.swift; path = Sources/CreatorCoreForge/WorldMemoryService.swift; sourceTree = "<group>"; };
+                6418A4324EDFAD12529EC847 /* OCRScanMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OCRScanMode.swift; path = Sources/CreatorCoreForge/OCRScanMode.swift; sourceTree = "<group>"; };
+                651DCF3C685DFCA6C40A5DCB /* PhotoPageSorter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PhotoPageSorter.swift; path = Sources/CreatorCoreForge/PhotoPageSorter.swift; sourceTree = "<group>"; };
+                64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorldMemoryService.swift; path = Sources/CreatorCoreForge/WorldMemoryService.swift; sourceTree = "<group>"; };
 		64D8465318B2DB2FA3F0A365 /* VoiceReactivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VoiceReactivity.swift; path = Sources/CreatorCoreForge/VoiceReactivity.swift; sourceTree = "<group>"; };
 		6504DE864796A7669332A703 /* PronunciationDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PronunciationDictionary.swift; path = Sources/CreatorCoreForge/PronunciationDictionary.swift; sourceTree = "<group>"; };
 		654E8C9E07A92A5C533F7B53 /* Assets.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = apps/CoreForgeAudio/VocalVerseFull/VocalVerse/Assets.xcassets; sourceTree = "<group>"; };
@@ -1480,8 +1482,9 @@
 				A07EF8BE89459197D50EB1C6 /* VoiceTrainer.swift */,
 				D85114D6FD55C1EBD6CCD888 /* WatchSyncService.swift */,
 				E750817C5D453940CFE0FBC8 /* WatermarkService.swift */,
-				64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */,
-				F95C843A8084D05B4FB215CE /* Book.swift */,
+                               64695E4714A6EA5A989A39DA /* WorldMemoryService.swift */,
+                               651DCF3C685DFCA6C40A5DCB /* PhotoPageSorter.swift */,
+                               F95C843A8084D05B4FB215CE /* Book.swift */,
 				AA328AEA3C24F926CA0F0671 /* UsageStats.swift */,
 			);
 			sourceTree = "<group>";
@@ -1910,8 +1913,9 @@
 				468B1244B5A18F369E24C396 /* ParentReportManager.swift in Sources */,
 				47893FBCED0C448FFBEBDC36 /* ParticleFXLayer.swift in Sources */,
 				57A1D93CF2F848499813B956 /* PerformanceModeSelector.swift in Sources */,
-				DE8AE8ED043E51202294DABC /* PersonalizedGreetingService.swift in Sources */,
-				FAF46C6D0F4B4AE4F7146535 /* PlaybackAnalytics.swift in Sources */,
+                               DE8AE8ED043E51202294DABC /* PersonalizedGreetingService.swift in Sources */,
+                               736A8AD5609D34AC42EC7D36 /* PhotoPageSorter.swift in Sources */,
+                               FAF46C6D0F4B4AE4F7146535 /* PlaybackAnalytics.swift in Sources */,
 				B473CD2896181C102B03F4DF /* PlaybackProgressSync.swift in Sources */,
 				49FD675FF708E635C8228900 /* PluginBuilder.swift in Sources */,
 				34CF03C5874E9D43431DB859 /* PluginDependencyGraph.swift in Sources */,

--- a/Sources/CreatorCoreForge/PhotoPageSorter.swift
+++ b/Sources/CreatorCoreForge/PhotoPageSorter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Sorts OCR'd page images into logical order based on detected page numbers.
+public final class PhotoPageSorter {
+    private let ocr: OCRScanMode
+    public init(ocr: OCRScanMode = OCRScanMode()) {
+        self.ocr = ocr
+    }
+
+    /// Return texts extracted from images, ordered by detected page numbers.
+    /// If no page number is found, the original index is used.
+    public func orderedTexts(from images: [Data]) -> [String] {
+        let pages: [(order: Int, text: String)] = images.enumerated().map { idx, data in
+            let text = ocr.extractText(from: data)
+            let num = PhotoPageSorter.detectPageNumber(in: text) ?? idx
+            return (num, text)
+        }
+        return pages.sorted { $0.order < $1.order }.map { $0.text }
+    }
+
+    /// Combine pages into a single document string in logical order.
+    public func combinedText(from images: [Data]) -> String {
+        orderedTexts(from: images).joined(separator: "\n")
+    }
+
+    private static func detectPageNumber(in text: String) -> Int? {
+        let pattern = "(?im)^\\s*(?:page\\s*)?(\\d{1,4})\\s*$"
+        for line in text.components(separatedBy: .newlines) {
+            if let match = line.range(of: pattern, options: .regularExpression) {
+                return Int(line[match].trimmingCharacters(in: CharacterSet(charactersIn: "0123456789").inverted))
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/CreatorCoreForgeTests/PhotoPageSorterTests.swift
+++ b/Tests/CreatorCoreForgeTests/PhotoPageSorterTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class PhotoPageSorterTests: XCTestCase {
+    func testReordersPagesByNumber() {
+        let p1 = "Page 1\nFirst".data(using: .utf8)!
+        let p2 = "Page 2\nSecond".data(using: .utf8)!
+        let p3 = "Page 3\nThird".data(using: .utf8)!
+        let sorter = PhotoPageSorter()
+        let combined = sorter.combinedText(from: [p3, p1, p2])
+        XCTAssertEqual(combined, "Page 1\nFirst\nPage 2\nSecond\nPage 3\nThird")
+    }
+
+    func testMaintainsOrderWithoutNumbers() {
+        let a = "Intro".data(using: .utf8)!
+        let b = "More".data(using: .utf8)!
+        let sorter = PhotoPageSorter()
+        let combined = sorter.combinedText(from: [b, a])
+        XCTAssertEqual(combined, "More\nIntro")
+    }
+}

--- a/docs/PhotoPageSorter.md
+++ b/docs/PhotoPageSorter.md
@@ -1,0 +1,3 @@
+# PhotoPageSorter
+
+This module uses `OCRScanMode` to recognize page numbers in scanned images and reorder them automatically. It ensures that photos of book pages are combined into the correct reading order even if the pictures were taken out of sequence.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Additional guides and phase planning documents for the CreatorCoreForge ecosyste
 - `NextGenSpeech.md` – overview of offline speech synthesis and recognition
 - `AdaptiveDocScanner.md` – overview of the AI document scanner
 - `DocVideoScanner.md` – document and video scanning utilities
+- `PhotoPageSorter.md` – reorder scanned page images using OCR
 - `progress_bot.py` – calculates app progress from `OPEN_TASKS.md` and optionally suggests code using OpenAI.
 - `progress_bot.md` – additional usage notes for the progress bot script
  - `auto_code_bot.py` – generates placeholder code files for missing features. It now includes an offline mode, a `--upgrade-placeholders` option, and writes timestamped snippets to language folders under `output/`.

--- a/features-phase8.json
+++ b/features-phase8.json
@@ -80,6 +80,7 @@
       "BookScanAnalyzer",
       "DocumentParser",
       "OCRScanMode",
+      "PhotoPageSorter",
       "MultiCastAudiobookGenerator",
       "DramatizedAudiobookProducer",
       "BookImporter",


### PR DESCRIPTION
## Summary
- implement `PhotoPageSorter` to order scanned pages using OCR
- add unit tests
- document new module and list in docs README
- register feature `PhotoPageSorter` in Phase 8 features
- reference new file in the CoreForgeAudio Xcode project

## Testing
- `npm test`
- `swift test` *(fails: exited with signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_68613aa490708321ac2ba0272aeacd3f