### PR TITLE
Add Codex issue workflow

### DIFF
--- a/.github/workflows/codex-github-models.yml
+++ b/.github/workflows/codex-github-models.yml
@@ -1,0 +1,26 @@
+name: Codex on GitHub Models
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  codex:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run Codex agent
+        uses: sgoedecke/codex-github-models@main
+        with:
+          # no secrets needed—uses GitHub Models
+          issue-number: ${{ github.event.issue.number }}
+
+      - name: Comment with results
+        run: echo "✅ Codex has processed this issue and proposed changes." \
+          | gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ available.
 
 
 ## CI/CD
-The repository uses GitHub Actions workflows for building, testing, and releasing the apps across platforms. See the files in [.github/workflows](./.github/workflows) for details.
+The repository uses GitHub Actions workflows for building, testing, and releasing the apps across platforms. See the files in [.github/workflows](./.github/workflows) for details. An **Issues** workflow automatically runs the Codex agent on new issues using GitHub Models.
 For iOS builds in Xcode Cloud, see [docs/XcodeCloud.md](docs/XcodeCloud.md) and the workflow template under `.xcodecloud/workflows`.
 
 


### PR DESCRIPTION
## Summary
- add a workflow to run the Codex GitHub Models agent when new issues open
- document the new Issues workflow in the CI/CD section of the README

## Testing
- `bash scripts/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68615082b0088321a0d374529ddb6b18