### PR TITLE
Add Auto-Coder workflow

### DIFF
--- a/.github/workflows/auto-coder.yml
+++ b/.github/workflows/auto-coder.yml
@@ -1,0 +1,29 @@
+name: Auto-Coder
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  codex-loop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Codex Orchestrator
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: node scripts/codex-orchestrator.js
+      - name: Push changes
+        if: success()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "actions@github.com"
+          git push
+


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs Codex orchestrator on a schedule

## Testing
- `./scripts/clean_install.sh`
- `cd VoiceLab && npm test`
- `cd ../VisualLab && npm test`
- `swift test` *(fails: Exited with unexpected signal code 4)*
- `pip install -r requirements.txt`
- `pip install tqdm`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6861524a9720832192770dfc7d28a54e