### PR TITLE
Enhance auto code bot and workflow

### DIFF
--- a/.github/workflows/auto-coder.yml
+++ b/.github/workflows/auto-coder.yml
@@ -2,7 +2,7 @@ name: Auto-Coder
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/2 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -16,10 +16,10 @@ jobs:
           node-version: '18'
       - name: Install dependencies
         run: npm ci
-      - name: Run Codex Orchestrator
+      - name: Run Auto Code Bot
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: node scripts/codex-orchestrator.js
+        run: python scripts/auto_code_bot.py --upgrade-placeholders --complete-todos --complete-stubs
       - name: Push changes
         if: success()
         run: |

--- a/docs/auto_code_bot.md
+++ b/docs/auto_code_bot.md
@@ -28,3 +28,8 @@ Generated filenames now match the detected language. For example, a Swift featur
   for CLI scripts, simple Flask APIs, or contact registries when OpenAI is not
   available.
 In addition to the `generated/` folder, each run now writes a copy of the snippet into language specific folders under `output/`. The filename is suffixed with a timestamp for easy version tracking, e.g. `output/python/login_handler_20240101123000.py`.
+
+### Additional Options
+
+- `--complete-todos` – scan source files for `TODO` comments and replace them with generated code snippets.
+- `--complete-stubs` – detect simple stubs such as `return nil` or empty functions and insert auto-generated implementations.


### PR DESCRIPTION
## Summary
- expand `auto_code_bot.py` to replace TODO comments and stub code with generated snippets
- document new options in `docs/auto_code_bot.md`
- run auto-coder workflow every two minutes and invoke the Python bot

## Testing
- `scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68615459d4b88321a9c6da31f9fc3135