### PR TITLE
Implement coverage gating for Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,10 @@ jobs:
           python-version: '3.11'
       - name: Install Python deps
         run: pip install -r requirements.txt
-      - name: Run Python Tests
-        run: pytest tests/python tests/fuzz
+      - name: Run Python Coverage
+        run: |
+          coverage run -m pytest tests/python tests/fuzz
+          coverage report --fail-under=90
       - name: Setup Swift
         uses: swift-actions/setup-swift@v1
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 pydub==0.25.1
 torch==2.2.2+cpu
 hypothesis==6.98.1
+coverage==7.5.0


### PR DESCRIPTION
## Summary
- add `coverage` to requirements
- fail CI when Python coverage < 90%

## Testing
- `coverage run -m pytest tests/python tests/fuzz` *(fails: ModuleNotFoundError: tqdm)*
- `coverage report --fail-under=90` *(fails: coverage 46% < 90%)*
- `npm run lint` *(fails: plugin conflict)*
- `npm test` *(fails: coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68616d1ec1f08321af8fd527945199f6