### PR TITLE
Add cinematic clip stitching scaffolds

### DIFF
--- a/Sources/CreatorCoreForge/CinematicCompiler.swift
+++ b/Sources/CreatorCoreForge/CinematicCompiler.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Compiles a list of rendered clips into a final video structure.
+public final class CinematicCompiler {
+    private let effects = VideoEffectsPipeline()
+    public init() {}
+
+    /// Stitch clips together with simple fade transitions.
+    public func stitch(clips: [RenderedClip]) -> FinalVideo {
+        var frames: [String] = []
+        for (idx, clip) in clips.enumerated() {
+            frames.append(contentsOf: clip.frames)
+            if idx < clips.count - 1 {
+                frames.append("fade")
+            }
+        }
+        let processed = effects.applyTransitions(to: frames, style: "fade")
+        return FinalVideo(frames: processed)
+    }
+}

--- a/Sources/CreatorCoreForge/ClipPreviewPanel.swift
+++ b/Sources/CreatorCoreForge/ClipPreviewPanel.swift
@@ -1,0 +1,54 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Simple preview panel for a scene clip.
+public struct ClipPreviewPanel: View {
+    public var clip: SceneClip
+    public var onRerender: (() -> Void)?
+    public var onAlternate: (() -> Void)?
+
+    public init(clip: SceneClip, onRerender: (() -> Void)? = nil, onAlternate: (() -> Void)? = nil) {
+        self.clip = clip
+        self.onRerender = onRerender
+        self.onAlternate = onAlternate
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            Text(clip.text)
+                .padding()
+            HStack {
+                Button("Play") {}
+                Button("Re-render") { onRerender?() }
+                Button("Alternate") { onAlternate?() }
+            }
+            .buttonStyle(.bordered)
+            HStack {
+                Text(clip.tone).font(.caption2)
+                Spacer()
+                Text(clip.transitionType).font(.caption2)
+            }
+            .padding(.horizontal)
+            ProgressView(value: Double(clip.sceneIndex % 10) / 10.0)
+                .accentColor(.blue)
+                .padding(.horizontal)
+        }
+        .background(RoundedRectangle(cornerRadius: 8).stroke())
+        .padding(4)
+    }
+}
+
+#if DEBUG
+struct ClipPreviewPanel_Previews: PreviewProvider {
+    static var previews: some View {
+        ClipPreviewPanel(clip: SceneClip(clipID: "1", text: "Hello world", sceneIndex: 0, startLine: 0, endLine: 0, tone: "neutral", transitionType: "fade"))
+    }
+}
+#endif
+
+#else
+/// Placeholder view when SwiftUI is unavailable.
+public struct ClipPreviewPanel {
+    public init(clip: SceneClip, onRerender: (() -> Void)? = nil, onAlternate: (() -> Void)? = nil) {}
+}
+#endif

--- a/Sources/CreatorCoreForge/ClipRenderer.swift
+++ b/Sources/CreatorCoreForge/ClipRenderer.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Renders a SceneClip into a RenderedClip with basic retry logic.
+public final class ClipRenderer {
+    private let effects = VideoEffectsPipeline()
+    public init() {}
+
+    /// Render the given scene clip using the provided voice mapping.
+    public func render(sceneClip: SceneClip, voiceMap: VoiceMap) -> RenderedClip {
+        var attempt = 0
+        let maxAttempts = 2
+        while attempt < maxAttempts {
+            do {
+                let voice = voiceMap[sceneClip.clipID] ?? "Narrator"
+                let frames = [sceneClip.text, "voice:\(voice)", "tone:\(sceneClip.tone)"]
+                let processed = effects.applyTransitions(to: frames, style: sceneClip.transitionType)
+                return RenderedClip(frames: processed)
+            } catch {
+                attempt += 1
+                print("ClipRenderer retry \(attempt) for \(sceneClip.clipID)")
+            }
+        }
+        // Fallback empty clip on repeated failure
+        return RenderedClip(frames: [])
+    }
+}

--- a/Sources/CreatorCoreForge/SceneSegmenter.swift
+++ b/Sources/CreatorCoreForge/SceneSegmenter.swift
@@ -8,4 +8,31 @@ public final class SceneSegmenter {
     public func segments(from scene: String) -> [String] {
         scene.split(separator: ".").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
     }
+
+    /// Segment chapters into scene clips with basic emotion tagging.
+    public func segment(chapters: [Chapter]) -> [SceneClip] {
+        var result: [SceneClip] = []
+        let analyzer = EmotionAnalyzer()
+        var index = 0
+        for chapter in chapters {
+            let lines = chapter.text.components(separatedBy: .newlines)
+            for (lineIndex, line) in lines.enumerated() {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else { continue }
+                let tone = analyzer.classify(sentence: trimmed)
+                let clip = SceneClip(
+                    clipID: "\(chapter.order)-\(lineIndex)",
+                    text: trimmed,
+                    sceneIndex: index,
+                    startLine: lineIndex,
+                    endLine: lineIndex,
+                    tone: tone,
+                    transitionType: "cut"
+                )
+                result.append(clip)
+                index += 1
+            }
+        }
+        return result
+    }
 }

--- a/Sources/CreatorCoreForge/VideoClipModels.swift
+++ b/Sources/CreatorCoreForge/VideoClipModels.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Metadata for a small scene clip extracted from the book.
+public struct SceneClip {
+    public let clipID: String
+    public let text: String
+    public let sceneIndex: Int
+    public let startLine: Int
+    public let endLine: Int
+    public let tone: String
+    public let transitionType: String
+
+    public init(clipID: String,
+                text: String,
+                sceneIndex: Int,
+                startLine: Int,
+                endLine: Int,
+                tone: String,
+                transitionType: String) {
+        self.clipID = clipID
+        self.text = text
+        self.sceneIndex = sceneIndex
+        self.startLine = startLine
+        self.endLine = endLine
+        self.tone = tone
+        self.transitionType = transitionType
+    }
+}
+
+/// Simple mapping from character name to assigned voice label.
+public typealias VoiceMap = [String: String]
+
+/// Represents the final stitched video.
+public struct FinalVideo {
+    public let frames: [String]
+    public init(frames: [String]) { self.frames = frames }
+}

--- a/apps/CoreForgeVisual/AGENTS.md
+++ b/apps/CoreForgeVisual/AGENTS.md
@@ -578,3 +578,25 @@ Ensure that CoreForge Audio, Visual, and Build are 100% functionally complete, s
 - [x] GitHub repo tagged as production ready
 - [x] App uploaded to App Store Connect + Play Store internal testing
 - [x] Announce launch with press kit + onboarding video
+
+### Phase 9 – Cinematic Clip Stitching Mode
+- [ ] `SceneSegmenter.segment(chapters:) -> [SceneClip]`
+- [ ] Tag clips with `sceneIndex`, `startLine`, `endLine`, `tone`, `transitionType`
+- [ ] `ClipRenderer.render(sceneClip:voiceMap:) -> RenderedClip`
+- [ ] Support emotion injection, voice lipsync, ambient FX
+- [ ] Add retry logic for failed clip renders with `clipID` logging
+- [ ] Build `ClipPreviewPanel.swift` with play button, re-render option, alternate scene button
+- [ ] Overlay emotion arc and visual tags per clip
+- [ ] `CinematicCompiler.stitch(clips:) -> FinalVideo`
+- [ ] Auto-insert transitions between clips (`fade`, `zoom`, `cut`, etc.)
+- [ ] Normalize voice tone and music across segments
+- [ ] Add watermark/creator tag if applicable
+- [ ] Add new mode `ExportMode.stitchClips`
+- [ ] If enabled: call `SceneSegmenter`, queue clip renders, stitch on completion
+- [ ] Track per-clip render status and allow cancel/retry
+- [ ] Show progress bar for total export with preview of final video
+- [ ] Add toggle: `useClipStitching = true` (default ON)
+- [ ] Add settings for `minClipDuration`, `maxClipDuration` (30–90 sec)
+- [ ] AI pacing advisor to suggest scene breakpoints
+- [ ] Optional recap clip generator between long time jumps
+- [ ] Save all clips as reusable social exports (titles, hashtags, thumbnails auto-generated)

--- a/open_tasks_registry.json
+++ b/open_tasks_registry.json
@@ -9,6 +9,26 @@
     "Add git pre-commit hooks for lint, formatting & basic tests",
     "Configure Danger.js / Danger-Swift to enforce PR rules (tests, docs, coverage)",
     "On any lint/test failure, auto-create a GitHub Issue with logs",
-    "Integrate ChatOps to post build/test status & alerts into Slack"
+    "Integrate ChatOps to post build/test status & alerts into Slack",
+    "SceneSegmenter.segment(chapters:) -> [SceneClip]",
+    "Tag clips with sceneIndex, startLine, endLine, tone, transitionType",
+    "ClipRenderer.render(sceneClip:voiceMap:) -> RenderedClip",
+    "Support emotion injection, voice lipsync, ambient FX",
+    "Add retry logic for failed clip renders with clipID logging",
+    "Build ClipPreviewPanel UI with play, re-render, alternate scene",
+    "Overlay emotion arc and visual tags on each clip",
+    "CinematicCompiler.stitch(clips:) -> FinalVideo",
+    "Auto-insert transitions between clips (fade, zoom, cut, etc.)",
+    "Normalize voice tone and music across segments",
+    "Add watermark/creator tag if applicable",
+    "Add ExportMode.stitchClips to ExportSystem",
+    "Enable stitchClips mode: segment, queue renders, stitch",
+    "ExportQueueManager tracks clip status and cancel/retry",
+    "Show progress bar and preview final video during export",
+    "UserSettings.useClipStitching toggle (default ON)",
+    "Settings for minClipDuration and maxClipDuration (30-90 sec)",
+    "AI pacing advisor for scene breakpoints",
+    "Optional recap clip generator",
+    "Save clips as reusable social exports with hashtags"
   ]
 }


### PR DESCRIPTION
## Summary
- add open tasks for clip stitching mode
- define `SceneClip`, `VoiceMap`, and `FinalVideo` models
- implement scene segmentation to produce `SceneClip`s
- add `ClipRenderer` with retry logic
- build SwiftUI `ClipPreviewPanel`
- implement simple `CinematicCompiler`

## Testing
- `npm test --silent` in VoiceLab
- `npm test --silent` in VisualLab
- `swift test --enable-test-discovery` *(fails: NarrationSchedulerTests.testScheduleExecutes)*

------
https://chatgpt.com/codex/tasks/task_e_68617c93b50483219352936e5adb8ee1