### PR TITLE
Add basic scene-based writing modules

### DIFF
--- a/Sources/CreatorCoreForge/SceneWriter/ChapterComposer.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/ChapterComposer.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Compiles scenes into a chapter preview and supports basic exporting.
+public final class ChapterComposer {
+    public init() {}
+
+    /// Combine the text of active scenes into a single chapter string.
+    public func compile(scenes: [SceneDraft]) -> String {
+        scenes.map { $0.text }.joined(separator: "\n\n")
+    }
+
+    /// Export the chapter string to disk in the desired format.
+    @discardableResult
+    public func export(chapter: String, to url: URL) throws -> URL {
+        try chapter.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}

--- a/Sources/CreatorCoreForge/SceneWriter/EmotionArcTracker.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/EmotionArcTracker.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Tracks emotional flow across multiple scenes.
+public final class EmotionArcTracker {
+    private var order: [UUID] = []
+    private var emotions: [UUID: String] = [:]
+    private let arc: [String] = ["calm", "rising tension", "climax", "resolution"]
+
+    public init() {}
+
+    /// Tag a scene with its primary emotion.
+    public func tag(sceneID: UUID, emotion: String) {
+        if emotions[sceneID] == nil {
+            order.append(sceneID)
+        }
+        emotions[sceneID] = emotion
+    }
+
+    /// Return the emotional sequence of tagged scenes in order of insertion.
+    public func emotionalFlow() -> [String] {
+        order.compactMap { emotions[$0] }
+    }
+
+    /// Recommend the next emotional beat based on a simple arc cycle.
+    public func recommendNextEmotion() -> String {
+        let current = order.last.flatMap { emotions[$0] } ?? "calm"
+        if let index = arc.firstIndex(of: current), index + 1 < arc.count {
+            return arc[index + 1]
+        }
+        return arc.first ?? "calm"
+    }
+}

--- a/Sources/CreatorCoreForge/SceneWriter/SceneManager.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/SceneManager.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Manages a collection of scenes with basic editing utilities.
+public final class SceneManager {
+    public private(set) var scenes: [SceneDraft]
+    private var active: Set<UUID> = []
+    private var alternates: [UUID: [SceneDraft]] = [:]
+    public private(set) var pinnedSceneID: UUID?
+
+    public init(scenes: [SceneDraft] = []) {
+        self.scenes = scenes
+        self.active = Set(scenes.map { $0.id })
+    }
+
+    /// Reorder a scene to a new index.
+    public func reorder(sceneID: UUID, to index: Int) {
+        guard let currentIndex = scenes.firstIndex(where: { $0.id == sceneID }),
+              scenes.indices.contains(index) else { return }
+        let scene = scenes.remove(at: currentIndex)
+        scenes.insert(scene, at: index)
+    }
+
+    /// Toggle whether a scene is active.
+    public func toggleActive(sceneID: UUID) {
+        if active.contains(sceneID) {
+            active.remove(sceneID)
+        } else {
+            active.insert(sceneID)
+        }
+    }
+
+    /// Add an alternate version of a scene.
+    public func addAlternateScene(for sceneID: UUID, draft: SceneDraft) {
+        alternates[sceneID, default: []].append(draft)
+    }
+
+    /// Pin a scene as an anchor point.
+    public func pinScene(id: UUID) {
+        pinnedSceneID = id
+    }
+}

--- a/Sources/CreatorCoreForge/SceneWriter/SceneWriterEngine.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/SceneWriterEngine.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Represents a single scene draft with basic metadata.
+public struct SceneDraft: Codable, Identifiable {
+    public let id: UUID
+    public let chapterID: UUID
+    public var text: String
+    public var tone: String
+    public var pov: String
+    public var emotion: String
+
+    public init(id: UUID = UUID(),
+                chapterID: UUID,
+                text: String,
+                tone: String = "neutral",
+                pov: String = "third",
+                emotion: String = "neutral") {
+        self.id = id
+        self.chapterID = chapterID
+        self.text = text
+        self.tone = tone
+        self.pov = pov
+        self.emotion = emotion
+    }
+}
+
+/// Minimal memory state to provide recent scene context.
+public struct MemoryState {
+    public var recentScenes: [SceneDraft]
+    public init(recentScenes: [SceneDraft] = []) {
+        self.recentScenes = recentScenes
+    }
+}
+
+/// Generates scene drafts with simple continuity support.
+public final class SceneWriterEngine {
+    public init() {}
+
+    /// Generate a new scene draft using the provided prompt and memory.
+    /// The text is returned as-is while metadata defaults are applied.
+    public func generateScene(prompt: String, memory: MemoryState) -> SceneDraft {
+        let chapterID = memory.recentScenes.last?.chapterID ?? UUID()
+        return SceneDraft(chapterID: chapterID, text: prompt)
+    }
+}

--- a/Sources/CreatorCoreForge/SceneWriter/StoryMemory.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/StoryMemory.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Persists character facts and relationships per scene.
+public final class StoryMemory {
+    public struct SceneFacts: Codable {
+        public var characters: [String]
+        public var relationships: [String]
+        public var tone: String
+    }
+
+    private var store: [UUID: SceneFacts] = [:]
+
+    public init() {}
+
+    /// Save facts for a scene.
+    public func saveFacts(for sceneID: UUID, facts: SceneFacts) {
+        store[sceneID] = facts
+    }
+
+    /// Retrieve facts for a scene.
+    public func facts(for sceneID: UUID) -> SceneFacts? {
+        store[sceneID]
+    }
+}

--- a/Sources/CreatorCoreForge/SceneWriter/WritingSessionTracker.swift
+++ b/Sources/CreatorCoreForge/SceneWriter/WritingSessionTracker.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Logs writing activity per scene and suggests stale scenes.
+public final class WritingSessionTracker {
+    private var timeLog: [UUID: TimeInterval] = [:]
+    private var edits: [UUID: Int] = [:]
+    private var lastActive: [UUID: Date] = [:]
+
+    public init() {}
+
+    /// Record time spent editing a scene.
+    public func log(sceneID: UUID, seconds: TimeInterval) {
+        timeLog[sceneID, default: 0] += seconds
+        lastActive[sceneID] = Date()
+    }
+
+    /// Increment edit count for a scene.
+    public func markEdit(sceneID: UUID) {
+        edits[sceneID, default: 0] += 1
+        lastActive[sceneID] = Date()
+    }
+
+    /// Return scenes sorted by most recently active.
+    public func heatmap() -> [UUID] {
+        lastActive.sorted { $0.value > $1.value }.map { $0.key }
+    }
+
+    /// Suggest scenes not modified recently.
+    public func staleScenes(threshold: TimeInterval = 60 * 60 * 24) -> [UUID] {
+        let cutoff = Date().addingTimeInterval(-threshold)
+        return lastActive.filter { $0.value < cutoff }.map { $0.key }
+    }
+}

--- a/Tests/CreatorCoreForgeTests/EmotionArcTrackerNextTests.swift
+++ b/Tests/CreatorCoreForgeTests/EmotionArcTrackerNextTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class EmotionArcTrackerNextTests: XCTestCase {
+    func testRecommendNextEmotion() {
+        let tracker = EmotionArcTracker()
+        tracker.tag(sceneID: UUID(), emotion: "calm")
+        XCTAssertEqual(tracker.recommendNextEmotion(), "rising tension")
+    }
+}

--- a/Tests/CreatorCoreForgeTests/SceneWriterEngineTests.swift
+++ b/Tests/CreatorCoreForgeTests/SceneWriterEngineTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import CreatorCoreForge
+
+final class SceneWriterEngineTests: XCTestCase {
+    func testGenerateSceneCreatesDraft() {
+        let engine = SceneWriterEngine()
+        let scene = engine.generateScene(prompt: "Test scene", memory: MemoryState())
+        XCTAssertEqual(scene.text, "Test scene")
+        XCTAssertFalse(scene.id.uuidString.isEmpty)
+        XCTAssertFalse(scene.chapterID.uuidString.isEmpty)
+    }
+}

--- a/apps/CoreForgeWriter/AGENTS.md
+++ b/apps/CoreForgeWriter/AGENTS.md
@@ -109,3 +109,44 @@ Key points from `README.md`:
 - [x] Multilingual, NSFW gating, offline writing, community/marketplace
 - [x] Import/export PDF, ePub, TXT, Docx
 
+
+### Modular Scene-Based Writing Mode (Phase 9)
+
+## \U0001F4C2 `SceneWriterEngine.swift`
+- [ ] Implement `generateScene(prompt: String, memory: MemoryState) -> SceneDraft`
+- [ ] Support tone, POV, and emotion metadata for each scene
+- [ ] Store scenes as modular blocks with identifiers (SceneID, ChapterID)
+
+## \U0001F4C2 `EmotionArcTracker.swift`
+- [ ] Visualize emotional flow across scenes (calm \u2192 rising tension \u2192 climax \u2192 resolution)
+- [ ] Allow manual tagging of scenes (e.g., betrayal, romance, twist)
+- [ ] AI recommendation for next emotional beat
+
+## \U0001F4C2 `SceneManager.swift`
+- [ ] Enable nonlinear writing: reorder scenes, drag/drop, toggle active/inactive
+- [ ] Add “Alternate Scene” versions under same SceneID
+- [ ] Support “Pin this Scene” as core anchor point
+
+## \U0001F4C2 `ChapterComposer.swift`
+- [ ] Compile selected scenes into a chapter preview
+- [ ] Apply pacing checks, transitions, and AI summaries
+- [ ] Allow exporting chapter in `.txt`, `.epub`, `.json`, or storyboard format
+
+## \U0001F4C2 `WritingSessionTracker.swift`
+- [ ] Log writing time per scene, word count, edit cycles
+- [ ] Generate heatmap of most active scenes
+- [ ] Suggest “stale” or untouched scenes for revisit
+
+## \U0001F4C2 `StoryMemory.swift`
+- [ ] Persist character facts, arcs, tone, relationships per scene
+- [ ] Integrate with multiverse memory model (link to CoreForge Visual)
+
+## \U0001F9E0 AI Enhancement Features
+- [ ] Smart prompt: “Write Scene 5 where Character X finds out the secret”
+- [ ] AI pacing reviewer: recommends which scenes are dragging
+- [ ] Alternate endings tool: propose 3 paths per scene
+
+## \U0001F501 Export + Cross-Platform Integration
+- [ ] One-click “Export to CoreForge Visual”
+- [ ] Export story as scene queue JSON for cinematic rendering
+- [ ] Allow download of individual or full scene set with metadata


### PR DESCRIPTION
## Summary
- add new SceneWriter modules for CoreForge Writer
- update Writer AGENTS with modular scene-based writing checklist
- test minimal scene generator and emotion tracker

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_68617d71787083218d4ff55f7dc0ac31